### PR TITLE
Implement SQLite persistence for Fumble

### DIFF
--- a/autoloads/db_manager.gd
+++ b/autoloads/db_manager.gd
@@ -33,7 +33,23 @@ func _create_tables():
 		"likes": { "data_type": "text" }, # comma-separated
 		"fumble_bio": { "data_type": "text" }
 	}
-	db.create_table("npc", npc_table)
+        db.create_table("npc", npc_table)
+
+       # -- Fumble Tables --
+       var relationships_table := {
+               "npc_id": { "data_type": "int", "primary_key": true },
+               "status": { "data_type": "text" }
+       }
+       db.create_table("fumble_relationships", relationships_table)
+
+       var battles_table := {
+               "battle_id": { "data_type": "text", "primary_key": true },
+               "npc_id": { "data_type": "int" },
+               "chatlog": { "data_type": "text" },
+               "stats": { "data_type": "text" },
+               "outcome": { "data_type": "text" }
+       }
+       db.create_table("fumble_battles", battles_table)
 
 
 func save_npc(idx: int, npc: NPC):
@@ -66,8 +82,50 @@ func load_npc(idx: int) -> Dictionary:
 	return result[0] if result.size() > 0 else null
 
 func has_npc(idx: int) -> bool:
-	var rows = db.select_rows("npc", "id = %d" % idx, ["id"])
-	return rows.size() > 0
+        var rows = db.select_rows("npc", "id = %d" % idx, ["id"])
+        return rows.size() > 0
+
+func save_fumble_relationship(npc_id: int, status: String) -> void:
+       db.insert_row("fumble_relationships", {
+               "npc_id": npc_id,
+               "status": status
+       })
+
+func get_fumble_relationship(npc_id: int) -> String:
+       var rows = db.select_rows("fumble_relationships", "npc_id = %d" % npc_id, ["status"])
+       return rows[0].status if rows.size() > 0 else ""
+
+func get_all_fumble_relationships() -> Dictionary:
+       var rows = db.select_rows("fumble_relationships", "", ["npc_id", "status"])
+       var out := {}
+       for r in rows:
+               out[r.npc_id] = r.status
+       return out
+
+func save_fumble_battle(battle_id: String, npc_id: int, chatlog: Array, stats: Dictionary, outcome: String) -> void:
+       db.insert_row("fumble_battles", {
+               "battle_id": battle_id,
+               "npc_id": npc_id,
+               "chatlog": to_json(chatlog),
+               "stats": to_json(stats),
+               "outcome": outcome
+       })
+
+func load_fumble_battle(battle_id: String) -> Dictionary:
+       var rows = db.select_rows("fumble_battles", "battle_id = '%s'" % battle_id, ["*"])
+       return rows[0] if rows.size() > 0 else {}
+
+func get_active_fumble_battles() -> Array:
+       var rows = db.select_rows("fumble_battles", "outcome = 'active'", ["battle_id", "npc_id", "chatlog", "stats"])
+       var out := []
+       for r in rows:
+               out.append({
+                       "battle_id": r.battle_id,
+                       "npc_idx": int(r.npc_id),
+                       "chatlog": from_json(r.chatlog),
+                       "stats": from_json(r.stats)
+               })
+       return out
 
 func to_json(value: Variant) -> String:
 	match typeof(value):

--- a/autoloads/fumble_manager.gd
+++ b/autoloads/fumble_manager.gd
@@ -3,6 +3,9 @@ extends Node
 
 var active_battles: Array = [] # {npc_idx, battle_id}
 
+func _ready():
+       active_battles = DBManager.get_active_fumble_battles()
+
 
 func get_matches() -> Array:
 	return NPCManager.get_fumble_matches()
@@ -11,11 +14,37 @@ func has_active_battle(npc_idx: int) -> bool:
 	return active_battles.any(func(b): b.npc_idx == npc_idx)
 
 func start_battle(npc_idx: int) -> String:
-	if not has_active_battle(npc_idx):
-		var battle_id = "%s_%d" % [str(Time.get_unix_time_from_system()), randi() % 1000000]
-		active_battles.append({ "npc_idx": npc_idx, "battle_id": battle_id })
-		return battle_id
-	return active_battles.filter(func(b): b.npc_idx == npc_idx)[0].battle_id
+       if not has_active_battle(npc_idx):
+               var battle_id = "%s_%d" % [str(Time.get_unix_time_from_system()), randi() % 1000000]
+               var entry = { "npc_idx": npc_idx, "battle_id": battle_id, "chatlog": [], "stats": {}, "outcome": "active" }
+               active_battles.append(entry)
+               DBManager.save_fumble_battle(battle_id, npc_idx, [], {}, "active")
+               NPCManager.promote_to_persistent(npc_idx)
+               return battle_id
+        return active_battles.filter(func(b): b.npc_idx == npc_idx)[0].battle_id
 
 func get_active_battles():
-	return active_battles
+       return active_battles
+
+func save_battle_state(battle_id: String, chatlog: Array, stats: Dictionary, outcome: String) -> void:
+       var npc_idx := -1
+       for b in active_battles:
+               if b.battle_id == battle_id:
+                       npc_idx = b.npc_idx
+                       b.chatlog = chatlog.duplicate()
+                       b.stats = stats.duplicate()
+                       b.outcome = outcome
+                       break
+       if npc_idx != -1:
+               DBManager.save_fumble_battle(battle_id, npc_idx, chatlog, stats, outcome)
+
+func load_battle_state(battle_id: String) -> Dictionary:
+       var data = DBManager.load_fumble_battle(battle_id)
+       if data.size() == 0:
+               return {}
+       return {
+               "npc_idx": int(data.npc_id),
+               "chatlog": DBManager.from_json(data.chatlog),
+               "stats": DBManager.from_json(data.stats),
+               "outcome": data.outcome
+       }

--- a/components/apps/fumble/fumble.gd
+++ b/components/apps/fumble/fumble.gd
@@ -82,8 +82,9 @@ func _on_card_swiped_left(npc_idx):
 	# Add further logic if desired
 
 func _on_card_swiped_right(npc_idx):
-	NPCManager.set_relationship_status(npc_idx, "fumble", "liked")
-	PlayerManager.adjust_stat("confidence", 1)
+       NPCManager.set_relationship_status(npc_idx, "fumble", "liked")
+       NPCManager.promote_to_persistent(npc_idx)
+       PlayerManager.adjust_stat("confidence", 1)
 
 
 func highlight_active(button: Button):

--- a/components/apps/fumble/fumble_battle/battle_ui.gd
+++ b/components/apps/fumble/fumble_battle/battle_ui.gd
@@ -101,9 +101,14 @@ func _ready():
 	
 
 func load_battle(new_battle_id: String, new_npc: NPC, chatlog_in: Array = [], stats_in: Dictionary = {}):
-	battle_id = new_battle_id
-	npc = new_npc
-	chatlog = chatlog_in.duplicate() if chatlog_in.size() > 0 else []
+       battle_id = new_battle_id
+       npc = new_npc
+       if chatlog_in.size() == 0 and stats_in.size() == 0:
+               var data = FumbleManager.load_battle_state(battle_id)
+               if data.size() > 0:
+                       chatlog = data.chatlog
+                       stats_in = data.stats
+       chatlog = chatlog_in.duplicate() if chatlog_in.size() > 0 else chatlog
 
 	# If stats_in is empty, pull stats from npc resource
 	var battle_stats_to_use: Dictionary = {}
@@ -242,12 +247,13 @@ func _on_catch_button_pressed():
 	await do_move("catch")
 
 func _on_ghost_button_pressed():
-	if is_animating:
-		return
-	var chat = add_chat_line("*ghosts*", true)
-	await animate_chat_text(chat, "*ghosts*")
-	await get_tree().create_timer(0.69).timeout
-	queue_free()
+       if is_animating:
+               return
+       var chat = add_chat_line("*ghosts*", true)
+       await animate_chat_text(chat, "*ghosts*")
+       await get_tree().create_timer(0.69).timeout
+       FumbleManager.save_battle_state(battle_id, chatlog, battle_stats, "ghosted")
+       queue_free()
 
 
 func swap_move(slot_index: int, new_move: String):
@@ -278,11 +284,13 @@ func add_chat_line(text: String, is_player: bool, is_victory_number := false) ->
 		hbox.add_child(spacer)
 		hbox.add_child(chat)
 
-	chat_container.add_child(hbox)
-	chat.text_label.text = text
-	chat.text_label.visible_ratio = 0.0
-	scroll_to_newest_chat()
-	return chat
+       chat_container.add_child(hbox)
+       chat.text_label.text = text
+       chat.text_label.visible_ratio = 0.0
+       scroll_to_newest_chat()
+       chatlog.append({"text": text, "is_player": is_player})
+       FumbleManager.save_battle_state(battle_id, chatlog, battle_stats, "active")
+       return chat
 
 
 
@@ -445,13 +453,14 @@ func _on_victory_number_clicked() -> void:
 var ex_award: float
 
 func show_victory_screen():
-	ex_award = npc.attractiveness/1000.0
-	
-	victory_ex_label.text = "You earned " + str(ex_award) + " Ex"
-	
-	
-	end_battle_screen_container.show() #animate
-	end_battle(victorious, npc)
+       ex_award = npc.attractiveness/1000.0
+
+       victory_ex_label.text = "You earned " + str(ex_award) + " Ex"
+
+
+       end_battle_screen_container.show() #animate
+       end_battle(victorious, npc)
+       FumbleManager.save_battle_state(battle_id, chatlog, battle_stats, "victory")
 
 func end_battle(success: bool, npc: NPC) -> void:
 	# Lock out further player interaction
@@ -620,5 +629,6 @@ func animate_chat_text(chat_box: Control, text: String) -> void:
 
 
 func _on_close_chat_button_pressed() -> void:
-	#set chat state as either Victory! or BLOCKED!
-	queue_free()
+       #set chat state as either Victory! or BLOCKED!
+       FumbleManager.save_battle_state(battle_id, chatlog, battle_stats, "active")
+       queue_free()

--- a/components/npc/npc_manager.gd
+++ b/components/npc/npc_manager.gd
@@ -182,21 +182,22 @@ func mark_npc_inactive_in_app(idx: int, app_name: String) -> void:
 		active_npcs_by_app[app_name].erase(idx)
 
 func set_relationship_status(idx: int, app_name: String, status: String) -> void:
-	if not relationship_status.has(idx):
-		relationship_status[idx] = {}
-	relationship_status[idx][app_name] = status
+        if not relationship_status.has(idx):
+                relationship_status[idx] = {}
+        relationship_status[idx][app_name] = status
+
+       if app_name == "fumble":
+               DBManager.save_fumble_relationship(idx, status)
 
 
 # Returns all NPC indices the player has "liked" in Fumble
 func get_fumble_matches() -> Array:
-	var matches = []
-	#print("Checking encountered NPCs for fumble:", encountered_npcs_by_app.get("fumble", []))
-	for idx in encountered_npcs_by_app.get("fumble", []):
-		var status = relationship_status.get(idx, {}).get("fumble", "")
-		#print("NPC", idx, "status:", status)
-		if status == "liked":
-			matches.append(idx)
-	return matches
+        var matches = []
+       var rels = DBManager.get_all_fumble_relationships()
+       for idx in rels.keys():
+               if rels[idx] == "liked":
+                       matches.append(int(idx))
+       return matches
 
 # Returns true if a battle is active with this NPC (FumbleManager sets this flag)
 func is_fumble_battle_active(npc_idx: int) -> bool:


### PR DESCRIPTION
## Summary
- create new tables `fumble_relationships` and `fumble_battles`
- expose helpers in `DBManager` for reading and writing Fumble data
- persist matches and battles through `FumbleManager`
- store chat logs and outcomes from `BattleUI`
- mark liked NPCs persistent

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688a37a5f71c83259d8e5333fe566bed