### PR TITLE
Fix chat battle persistence

### DIFF
--- a/components/apps/fumble/chats_tab.gd
+++ b/components/apps/fumble/chats_tab.gd
@@ -59,10 +59,10 @@ func refresh_battles():
 	var battles = FumbleManager.get_active_battles()
 	for b in battles:
 		var npc = NPCManager.get_npc_by_index(b.npc_idx)
-		var btn = battle_button_scene.instantiate()
-		chat_battles_container.add_child(btn)
-		btn.set_battle(npc, b.battle_id, b.npc_idx)
-		btn.pressed.connect(func(): _on_battle_button_pressed(b.battle_id, npc))
+               var btn = battle_button_scene.instantiate()
+               chat_battles_container.add_child(btn)
+               btn.set_battle(npc, b.battle_id, b.npc_idx)
+               btn.pressed.connect(func(): _on_battle_button_pressed(b.battle_id, npc, b.npc_idx))
 		
 
 func _on_match_button_pressed(npc, idx):
@@ -70,23 +70,23 @@ func _on_match_button_pressed(npc, idx):
 	#get_tree().root.
 	add_child(match_profile)
 	match_profile.set_profile(npc, idx)
-	match_profile.start_battle_requested.connect(_on_start_battle_requested)
+       match_profile.start_battle_requested.connect(_on_start_battle_requested)
 	
 
-func _on_start_battle_requested(battle_id, npc):
-	open_battle(battle_id, npc)
-	refresh_battles()
-	refresh_matches()
+func _on_start_battle_requested(battle_id, npc, idx):
+       open_battle(battle_id, npc, idx)
+       refresh_battles()
+       refresh_matches()
 
-func _on_battle_button_pressed(battle_id, npc):
-	open_battle(battle_id, npc)
+func _on_battle_button_pressed(battle_id, npc, idx):
+       open_battle(battle_id, npc, idx)
 
-func open_battle(battle_id, npc):
-	print("opening battle!")
-	var scene = battle_scene.instantiate()
-	#get_tree().root.
-	add_child(scene)
-	scene.load_battle(battle_id, npc)
-	
-	request_resize_x_to.emit(860)
+func open_battle(battle_id, npc, idx):
+        print("opening battle!")
+        var scene = battle_scene.instantiate()
+        #get_tree().root.
+        add_child(scene)
+        scene.load_battle(battle_id, npc, [], {}, idx)
+
+        request_resize_x_to.emit(860)
 	

--- a/components/apps/fumble/fumble_match_profile.gd
+++ b/components/apps/fumble/fumble_match_profile.gd
@@ -1,7 +1,7 @@
 extends Control
 class_name FumbleMatchProfile
 
-signal start_battle_requested(battle_id, npc)
+signal start_battle_requested(battle_id, npc, npc_idx)
 
 
 @onready var fumble_profile: FumbleProfileUI = %FumbleProfile
@@ -25,8 +25,8 @@ func _ready():
 
 func _on_chat_button_pressed():
 	if not FumbleManager.has_active_battle(npc_idx):
-		var battle_id = FumbleManager.start_battle(npc_idx)
-		start_battle_requested.emit(battle_id, npc)
+               var battle_id = FumbleManager.start_battle(npc_idx)
+               start_battle_requested.emit(battle_id, npc, npc_idx)
 		queue_free()  # Close the profile popup
 	else:
 		print("Already in a battle with this NPC.")


### PR DESCRIPTION
## Summary
- track `npc_idx` when loading battles so NPC data can be updated
- update progress stats in DB after every turn
- write final stats to NPC data when a battle ends

## Testing
- `godot --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688a42a3d9f883259e1bcd50d89fbea2