### PR TITLE
Integrate FumbleManager with SaveManager

### DIFF
--- a/autoloads/fumble_manager.gd
+++ b/autoloads/fumble_manager.gd
@@ -1,10 +1,10 @@
 extends Node
-#Autoload: FumbleManager
+# Autoload: FumbleManager
 
-var active_battles: Array = [] # {npc_idx, battle_id}
+var active_battles: Array = [] # {npc_idx, battle_id, chatlog, stats, outcome}
 
 func _ready():
-	active_battles = DBManager.get_active_fumble_battles()
+        active_battles.clear()
 
 
 func get_matches() -> Array:
@@ -14,29 +14,27 @@ func has_active_battle(npc_idx: int) -> bool:
 	return active_battles.any(func(b): b.npc_idx == npc_idx)
 
 func start_battle(npc_idx: int) -> String:
-	if not has_active_battle(npc_idx):
-		var battle_id = "%s_%d" % [str(Time.get_unix_time_from_system()), randi() % 1000000]
-		var entry = { "npc_idx": npc_idx, "battle_id": battle_id, "chatlog": [], "stats": {}, "outcome": "active" }
-		active_battles.append(entry)
-		DBManager.save_fumble_battle(battle_id, npc_idx, [], {}, "active")
-		NPCManager.promote_to_persistent(npc_idx)
-		return battle_id
-	return active_battles.filter(func(b): b.npc_idx == npc_idx)[0].battle_id
+        if not has_active_battle(npc_idx):
+                var battle_id = "%s_%d" % [str(Time.get_unix_time_from_system()), randi() % 1000000]
+                var entry = { "npc_idx": npc_idx, "battle_id": battle_id, "chatlog": [], "stats": {}, "outcome": "active" }
+                active_battles.append(entry)
+                NPCManager.promote_to_persistent(npc_idx)
+                return battle_id
+        return active_battles.filter(func(b): b.npc_idx == npc_idx)[0].battle_id
 
 func get_active_battles():
 	return active_battles
 
 func save_battle_state(battle_id: String, chatlog: Array, stats: Dictionary, outcome: String) -> void:
-	var npc_idx := -1
-	for b in active_battles:
-			if b.battle_id == battle_id:
-					npc_idx = b.npc_idx
-					b.chatlog = chatlog.duplicate()
-					b.stats = stats.duplicate()
-					b.outcome = outcome
-					break
-	if npc_idx != -1:
-			DBManager.save_fumble_battle(battle_id, npc_idx, chatlog, stats, outcome)
+        var npc_idx := -1
+        for b in active_battles:
+                        if b.battle_id == battle_id:
+                                        npc_idx = b.npc_idx
+                                        b.chatlog = chatlog.duplicate()
+                                        b.stats = stats.duplicate()
+                                        b.outcome = outcome
+                                        break
+        # Persisted via SaveManager when the profile is saved
 
 func load_battle_state(battle_id: String) -> Dictionary:
         # Prefer in-memory data first
@@ -48,19 +46,37 @@ func load_battle_state(battle_id: String) -> Dictionary:
                                 "stats": b.stats.duplicate(),
                                 "outcome": b.outcome
                         }
+        return {}
 
-        var data = DBManager.load_fumble_battle(battle_id)
-        if data.size() == 0:
-                return {}
-        var parsed_chatlog = DBManager.from_json(data.chatlog)
-        if parsed_chatlog == null:
-                parsed_chatlog = []
-        var parsed_stats = DBManager.from_json(data.stats)
-        if parsed_stats == null:
-                parsed_stats = {}
-        return {
-                "npc_idx": int(data.npc_id),
-                "chatlog": parsed_chatlog,
-                "stats": parsed_stats,
-                "outcome": data.outcome
-        }
+
+func get_save_data() -> Dictionary:
+        var battles := []
+        for b in active_battles:
+                battles.append({
+                        "npc_idx": b.npc_idx,
+                        "battle_id": b.battle_id,
+                        "chatlog": b.chatlog.duplicate(),
+                        "stats": b.stats.duplicate(),
+                        "outcome": b.outcome,
+                })
+        return { "active_battles": battles }
+
+
+func load_from_data(data: Dictionary) -> void:
+        reset()
+        var battles = data.get("active_battles", [])
+        if typeof(battles) != TYPE_ARRAY:
+                return
+        for entry in battles:
+                var e = {
+                        "npc_idx": int(entry.get("npc_idx", -1)),
+                        "battle_id": str(entry.get("battle_id", "")),
+                        "chatlog": entry.get("chatlog", []),
+                        "stats": entry.get("stats", {}),
+                        "outcome": entry.get("outcome", "active")
+                }
+                active_battles.append(e)
+
+
+func reset() -> void:
+        active_battles.clear()

--- a/autoloads/save_manager.gd
+++ b/autoloads/save_manager.gd
@@ -77,12 +77,13 @@ func save_to_slot(slot_id: int) -> void:
 		"market": MarketManager.get_save_data(),
 		"tasks": TaskManager.get_save_data(),
 		"player": PlayerManager.get_save_data(),
-		"workers": WorkerManager.get_save_data(),
-		"bills": BillManager.get_save_data(),
-		"gpus": GPUManager.get_save_data(),
-		"upgrades": UpgradeManager.get_save_data(),
-		"windows": WindowManager.get_save_data(),
-	}
+                "workers": WorkerManager.get_save_data(),
+                "bills": BillManager.get_save_data(),
+                "gpus": GPUManager.get_save_data(),
+                "upgrades": UpgradeManager.get_save_data(),
+                "windows": WindowManager.get_save_data(),
+                "fumble": FumbleManager.get_save_data(),
+        }
 
 	var file := FileAccess.open(get_slot_path(slot_id), FileAccess.WRITE)
 	file.store_string(JSON.stringify(data, "\t"))
@@ -140,14 +141,17 @@ func load_from_slot(slot_id: int) -> void:
 	if data.has("workers"):
 		WorkerManager.load_from_data(data["workers"])
 	
-	if data.has("gpus"):
-		GPUManager.load_from_data(data["gpus"])
-	if data.has("bills"):
-		BillManager.load_from_data(data["bills"])
+        if data.has("gpus"):
+                GPUManager.load_from_data(data["gpus"])
+        if data.has("bills"):
+                BillManager.load_from_data(data["bills"])
+
+        if data.has("fumble"):
+                FumbleManager.load_from_data(data["fumble"])
 
 
-	if data.has("windows"): ##Always load windows last (I think)
-		WindowManager.load_from_data(data["windows"])
+        if data.has("windows"): ##Always load windows last (I think)
+                WindowManager.load_from_data(data["windows"])
 
 func reset_game_state() -> void:
 	# Reset all relevant managers to blank state
@@ -157,11 +161,12 @@ func reset_game_state() -> void:
 	TimeManager.reset()
 	TaskManager.reset()
 	EffectManager.reset()
-	WorkerManager.reset()
-	MarketManager.reset()
-	GPUManager.reset()
-	#BillManager.reset()
-	#UpgradeManager.reset()
+        WorkerManager.reset()
+        MarketManager.reset()
+        GPUManager.reset()
+        FumbleManager.reset()
+        #BillManager.reset()
+        #UpgradeManager.reset()
 
 
 
@@ -170,11 +175,12 @@ func reset_managers():
 	PlayerManager.reset()
 	WindowManager.reset()
 	TimeManager.reset()
-	WorkerManager.reset()
-	EffectManager.reset()
-	TaskManager.reset()
-	GPUManager.reset()
-	EffectManager.reset()
+        WorkerManager.reset()
+        EffectManager.reset()
+        TaskManager.reset()
+        GPUManager.reset()
+        EffectManager.reset()
+        FumbleManager.reset()
 
 func delete_save(slot_id: int) -> void:
 	var path := get_slot_path(slot_id)


### PR DESCRIPTION
## Summary
- persist Fumble battle data via SaveManager instead of DBManager
- add save/load/reset logic to `FumbleManager`
- include `FumbleManager` in SaveManager's save/load and reset routines

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688ab8465998832588b79518d3acbe0e