### PR TITLE
Add toggleable debug console overlay

### DIFF
--- a/autoload/debug_console_manager.gd
+++ b/autoload/debug_console_manager.gd
@@ -1,0 +1,46 @@
+extends Node
+class_name DebugConsoleManager
+
+var console_scene: PackedScene
+var console: DebugConsole
+
+const TOGGLE_ACTION := "toggle_debug_console"
+
+func _ready() -> void:
+    # Ensure input action exists for toggling
+    _ensure_toggle_action()
+
+    console_scene = load("res://components/debug/debug_console.tscn")
+    console = console_scene.instantiate() as DebugConsole
+    get_tree().root.add_child(console)
+    console.hide()
+
+func _input(event: InputEvent) -> void:
+    if event.is_action_pressed(TOGGLE_ACTION):
+        if is_instance_valid(console):
+            console.toggle()
+            get_viewport().set_input_as_handled()
+
+func open() -> void:
+    if is_instance_valid(console):
+        console.open()
+
+func close() -> void:
+    if is_instance_valid(console):
+        console.close()
+
+func toggle() -> void:
+    if is_instance_valid(console):
+        console.toggle()
+
+func _ensure_toggle_action() -> void:
+    if not InputMap.has_action(TOGGLE_ACTION):
+        InputMap.add_action(TOGGLE_ACTION)
+    # Bind the backquote key if no events are assigned
+    var events := InputMap.action_get_events(TOGGLE_ACTION)
+    if events.size() == 0:
+        var ev := InputEventKey.new()
+        # Backquote / tilde key (US layout)
+        ev.physical_keycode = KEY_GRAVE
+        ev.pressed = false
+        InputMap.action_add_event(TOGGLE_ACTION, ev)

--- a/components/debug/debug_console.gd
+++ b/components/debug/debug_console.gd
@@ -1,0 +1,133 @@
+extends PanelContainer
+class_name DebugConsole
+
+@onready var command_line: LineEdit = %CommandLine
+@onready var enter_button: Button = %EnterButton
+@onready var feedback_label: Label = %FeedbackLabel
+
+func _ready() -> void:
+    # Fullscreen anchors (defensive in case scene settings change)
+    anchors_preset = Control.PRESET_FULL_RECT
+    anchor_right = 1.0
+    anchor_bottom = 1.0
+    visible = false
+
+    # Simple appearance tweak so it reads as an overlay
+    self_modulate = Color(1, 1, 1, 0.95)
+
+    enter_button.pressed.connect(_on_enter_pressed)
+    command_line.text_submitted.connect(_on_text_submitted)
+
+func open() -> void:
+    visible = true
+    show()
+    await get_tree().process_frame
+    if is_instance_valid(command_line):
+        command_line.grab_focus()
+        command_line.caret_column = command_line.text.length()
+
+func close() -> void:
+    hide()
+    visible = false
+
+func toggle() -> void:
+    if visible:
+        close()
+    else:
+        open()
+
+func _unhandled_input(event: InputEvent) -> void:
+    if not visible:
+        return
+
+    # Submit on Enter anywhere
+    if event.is_action_pressed("ui_accept"):
+        _submit_command()
+        get_viewport().set_input_as_handled()
+
+    # Close on ESC
+    if event.is_action_pressed("ui_cancel"):
+        close()
+        get_viewport().set_input_as_handled()
+
+func _on_enter_pressed() -> void:
+    _submit_command()
+
+func _on_text_submitted(_text: String) -> void:
+    _submit_command()
+
+func _submit_command() -> void:
+    var cmd := command_line.text.strip_edges()
+    if cmd == "":
+        _set_feedback("No command entered.", false)
+        return
+
+    var ok := process_command(cmd)
+    if ok:
+        _set_feedback("OK: " + cmd, true)
+    else:
+        if feedback_label.text == "" or feedback_label.text.begins_with("OK"):
+            _set_feedback("Unknown or invalid command.", false)
+
+    command_line.text = ""
+    command_line.grab_focus()
+
+func _set_feedback(msg: String, success: bool) -> void:
+    if success:
+        feedback_label.modulate = Color(0.6, 1.0, 0.6, 1.0)
+    else:
+        feedback_label.modulate = Color(1.0, 0.6, 0.6, 1.0)
+    feedback_label.text = msg
+
+func process_command(command: String) -> bool:
+    var parts := command.split(" ", false)
+    if parts.size() == 0:
+        return false
+
+    var cmd := parts[0].to_lower()
+
+    if cmd == "add_cash":
+        if parts.size() < 2:
+            _set_feedback("Usage: add_cash <amount>", false)
+            return false
+        var amount_str := parts[1]
+        var amount := _parse_number(amount_str)
+        if amount == null:
+            _set_feedback("Invalid amount: " + amount_str, false)
+            return false
+        if not _has_portfolio_manager():
+            _set_feedback("PortfolioManager not found.", false)
+            return false
+        # Prefer a dedicated API; fall back to set/get if needed.
+        if "add_cash" in PortfolioManager:
+            PortfolioManager.add_cash(amount)
+        else:
+            if not PortfolioManager.has_method("get_cash") or not PortfolioManager.has_method("set_cash"):
+                _set_feedback("PortfolioManager lacks add_cash and get/set APIs.", false)
+                return false
+            var current_cash = PortfolioManager.get_cash()
+            PortfolioManager.set_cash(current_cash + amount)
+        return true
+
+    return false
+
+func _parse_number(s: String):
+    # Accept int or float
+    if s.find(".") != -1:
+        var f := s.to_float()
+        if str(f) == "nan":
+            return null
+        return f
+    else:
+        var i := s.to_int()
+        # to_int always returns 0 on failure; detect non-numeric explicitly
+        if s != "0" and i == 0 and not s.strip_edges().begins_with("0"):
+            # check if it truly is non-numeric
+            var tmp := s.to_float()
+            if str(tmp) == "nan":
+                return null
+            return tmp
+        return i
+
+func _has_portfolio_manager() -> bool:
+    return Engine.has_singleton("PortfolioManager") or typeof(PortfolioManager) != TYPE_NIL

--- a/components/debug/debug_console.tscn
+++ b/components/debug/debug_console.tscn
@@ -1,0 +1,24 @@
+[gd_scene load_steps=3]
+
+[ext_resource type="Script" path="res://components/debug/debug_console.gd" id="1_ekq6y"]
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_0xw1n"]
+bg_color = Color(0, 0, 0, 0.7)
+
+[node name="DebugConsole" type="PanelContainer"]
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+theme_override_styles/panel = SubResource("StyleBoxFlat_0xw1n")
+script = ExtResource("1_ekq6y")
+
+[node name="MarginContainer" type="MarginContainer" parent="."]
+[node name="VBoxContainer" type="VBoxContainer" parent="MarginContainer"]
+[node name="TitleLabel" type="Label" parent="MarginContainer/VBoxContainer"]
+text = "SigmaSim Debug Console"
+[node name="HBoxContainer" type="HBoxContainer" parent="MarginContainer/VBoxContainer"]
+[node name="CommandLine" type="LineEdit" parent="MarginContainer/VBoxContainer/HBoxContainer"]
+[node name="EnterButton" type="Button" parent="MarginContainer/VBoxContainer/HBoxContainer"]
+text = "Enter"
+[node name="FeedbackLabel" type="Label" parent="MarginContainer/VBoxContainer"]
+text = ""

--- a/project.godot
+++ b/project.godot
@@ -46,6 +46,7 @@ FumbleManager="*res://autoloads/fumble_manager.gd"
 MarkupParser="*res://autoloads/markup_parser.gd"
 StatManager="*res://autoloads/stat_manager.gd"
 Events="*res://autoloads/events.gd"
+DebugConsoleManager="*res://autoload/debug_console_manager.gd"
 
 [display]
 


### PR DESCRIPTION
## Summary
- Add full-screen DebugConsole scene with command input and feedback
- Implement DebugConsole script to handle add_cash and toggle visibility
- Provide DebugConsoleManager autoload to instantiate and toggle console
- Register DebugConsoleManager autoload in project.godot

## Testing
- `godot --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a0bbb23d048325b153058dfd9b0b67