### PR TITLE
Add EarlyBird autopilot cost and free upgrade

### DIFF
--- a/data/stats/base_stats.json
+++ b/data/stats/base_stats.json
@@ -5,5 +5,6 @@
   "worker_productivity_per_tick": 1.0,
   "gpu_power": 1.0,
   "power_per_click": 1.0,
-  "cash_per_score": 0.01
+  "cash_per_score": 0.01,
+  "autopilot_cost": 1.0
 }

--- a/data/upgrades/autopilot_free.json
+++ b/data/upgrades/autopilot_free.json
@@ -1,0 +1,14 @@
+{
+  "id": "earlybird_autopilot_free",
+  "name": "Autopilot Forever",
+  "description": "Autopilot is free forever.",
+  "effects": [],
+  "systems": [
+    "earlybird"
+  ],
+  "dependencies": [],
+  "cost_per_level": {
+    "cash": 100
+  },
+  "max_level": 1
+}


### PR DESCRIPTION
## Summary
- Charge $1 for enabling EarlyBird autopilot, increasing cost by $0.01 per use
- Display current autopilot cost on the button and make it free with a $100 upgrade
- Track autopilot cost persistently via new stat

## Testing
- `godot --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a12b54a8108325bd88035a548564fd