### PR TITLE
Add EarlyBird worm yield upgrade and manual flap toggle

### DIFF
--- a/components/apps/early_bird/early_bird.gd
+++ b/components/apps/early_bird/early_bird.gd
@@ -13,6 +13,7 @@ class_name EarlyBird
 @export var max_speed: float = 2400.0  # 1600 tested as safe
 @onready var autopilot: Node = %EarlyBirdAutopilot
 @onready var autopilot_button: Button = %AutopilotButton
+@onready var disable_flaps_checkbox: CheckBox = %DisableManualFlaps
 
 @export var base_width: float = 440.0
 @export var max_width: float = 1920.0
@@ -37,6 +38,7 @@ var game_active: bool = false
 var cash_per_score: float = 0.01
 var winnings: float = 0.00
 var autopilot_cost: float = 1.0
+var manual_flaps_disabled: bool = false
 
 func _ready() -> void:
 	window_frame = find_parent_window_frame()
@@ -47,13 +49,16 @@ func _ready() -> void:
 	player.died.connect(_on_player_died)
 	player.scored_point.connect(_on_player_scored)
 	hud.restart_pressed.connect(_on_restart_pressed)
-	hud.quit_pressed.connect(_on_quit_pressed)
+        hud.quit_pressed.connect(_on_quit_pressed)
+
+        disable_flaps_checkbox.toggled.connect(_on_disable_flaps_toggled)
 
 	StatManager.connect_to_stat("cash_per_score", self, "_on_cash_per_score_changed")
 	autopilot_cost = StatManager.get_stat("autopilot_cost", 1.0)
 	UpgradeManager.upgrade_purchased.connect(_on_upgrade_purchased)
-	_update_autopilot_button_text()
-	start_game()
+        _update_autopilot_button_text()
+        _update_disable_flaps_visibility()
+        start_game()
 
 func find_parent_window_frame() -> WindowFrame:
 	var parent = get_parent()
@@ -98,17 +103,20 @@ func _adjust_window_size() -> void:
 	window_frame.size = new_size
 
 func start_game() -> void:
-	_update_cash_per_score()
-	game_active = true
-	player.reset()
-	pipe_manager.reset()
-	round_manager.start_round_cycle()
-	winnings = 0.0
-	hud.reset(cash_per_score)
-	window_frame.size = Vector2(base_width, fixed_height)
-	reset_speed()
-	%Worm.show()
-	_update_autopilot_button_text()
+        _update_cash_per_score()
+        game_active = true
+        player.reset()
+        pipe_manager.reset()
+        round_manager.start_round_cycle()
+        winnings = 0.0
+        hud.reset(cash_per_score)
+        window_frame.size = Vector2(base_width, fixed_height)
+        reset_speed()
+        %Worm.show()
+        _update_autopilot_button_text()
+        disable_flaps_checkbox.button_pressed = false
+        manual_flaps_disabled = false
+        _update_disable_flaps_visibility()
 
 func reset_speed():
 	speed_timer = 0.0
@@ -116,13 +124,13 @@ func reset_speed():
 	pipe_manager.set_move_speed(current_speed)
 
 func _input(event: InputEvent) -> void:
-	if not game_active:
-		return
-	if (
-		(event is InputEventMouseButton and event.pressed)
-		or (event is InputEventKey and event.pressed and event.keycode == KEY_SPACE)
-	):
-		player.flap()
+        if not game_active:
+                return
+        if (
+                (event is InputEventMouseButton and event.pressed)
+                or (event is InputEventKey and event.pressed and event.keycode == KEY_SPACE)
+        ) and not manual_flaps_disabled:
+                player.flap()
 
 func _on_round_started(round_type: String) -> void:
 	if round_type == "pipe":
@@ -186,12 +194,24 @@ func _update_autopilot_button_text() -> void:
 				autopilot_button.text = "Autopilot"
 
 func _on_upgrade_purchased(id: String, _level: int) -> void:
-		if id == "earlybird_autopilot_free":
-				_update_autopilot_button_text()
+                if id == "earlybird_autopilot_free":
+                                _update_autopilot_button_text()
+                elif id == "earlybird_disable_manual_flaps":
+                                _update_disable_flaps_visibility()
 
 func _update_cash_per_score() -> void:
 	cash_per_score = StatManager.get_stat("cash_per_score", 0.01)
 
 func _on_cash_per_score_changed(value: float) -> void:
-	cash_per_score = value
-	hud.update_cash_per_score(cash_per_score)
+        cash_per_score = value
+        hud.update_cash_per_score(cash_per_score)
+
+func _on_disable_flaps_toggled(pressed: bool) -> void:
+        manual_flaps_disabled = pressed
+
+func _update_disable_flaps_visibility() -> void:
+        var visible := UpgradeManager.get_level("earlybird_disable_manual_flaps") > 0
+        disable_flaps_checkbox.visible = visible
+        if not visible:
+                disable_flaps_checkbox.button_pressed = false
+                manual_flaps_disabled = false

--- a/components/apps/early_bird/early_bird.tscn
+++ b/components/apps/early_bird/early_bird.tscn
@@ -327,6 +327,23 @@ focus_mode = 0
 toggle_mode = true
 text = "Autopilot"
 
+[node name="DisableManualFlaps" type="CheckBox" parent="HUD"]
+unique_name_in_owner = true
+layout_mode = 1
+anchors_preset = 3
+anchor_left = 1.0
+anchor_top = 1.0
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_left = -260.0
+offset_right = -120.0
+offset_top = -4.0
+grow_horizontal = 0
+grow_vertical = 0
+focus_mode = 0
+text = "Disable Manual Flaps"
+visible = false
+
 [node name="Worm" type="Area2D" parent="."]
 unique_name_in_owner = true
 position = Vector2(1709, 238)

--- a/components/apps/early_bird/worm.gd
+++ b/components/apps/early_bird/worm.gd
@@ -37,12 +37,14 @@ func _start_pulsing() -> void:
 	pulse_tween.tween_property(sprite, "scale", Vector2(1.0, 1.0), pulse_animation_interval / 2).set_trans(Tween.TRANS_SINE).set_ease(Tween.EASE_IN_OUT)
 
 func _on_input_event(viewport: Node, event: InputEvent, shape_idx: int) -> void:
-	print("worm clicked")
-	if event is InputEventMouseButton and event.pressed and event.button_index == MOUSE_BUTTON_LEFT:
-		PortfolioManager.add_cash(1.0)
-		if StatpopManager:
-			print("worm statpop")
-			StatpopManager.spawn("+$1", global_position, "click", Color.GREEN)
+        print("worm clicked")
+        if event is InputEventMouseButton and event.pressed and event.button_index == MOUSE_BUTTON_LEFT:
+                var value := StatManager.get_stat("worm_yield", 1.0)
+                PortfolioManager.add_cash(value)
+                if StatpopManager:
+                        print("worm statpop")
+                        var amount := NumberFormatter.format_commas(value, 2, true)
+                        StatpopManager.spawn("+$" + amount, global_position, "click", Color.GREEN)
 
 
 func _on_worm_texture_mouse_entered() -> void:
@@ -58,12 +60,14 @@ func _on_worm_texture_mouse_exited() -> void:
 
 
 func _on_worm_texture_gui_input(event: InputEvent) -> void:
-	print("worm clicked")
-	if event is InputEventMouseButton and event.pressed and event.button_index == MOUSE_BUTTON_LEFT:
-		PortfolioManager.add_cash(1)
-		if StatpopManager:
-			print("worm statpop")
-			StatpopManager.spawn("+$1", global_position, "click")
+        print("worm clicked")
+        if event is InputEventMouseButton and event.pressed and event.button_index == MOUSE_BUTTON_LEFT:
+                var value := StatManager.get_stat("worm_yield", 1.0)
+                PortfolioManager.add_cash(value)
+                if StatpopManager:
+                        print("worm statpop")
+                        var amount := NumberFormatter.format_commas(value, 2, true)
+                        StatpopManager.spawn("+$" + amount, global_position, "click")
 
 
 func _on_timer_timeout() -> void:

--- a/data/stats/base_stats.json
+++ b/data/stats/base_stats.json
@@ -6,5 +6,6 @@
   "gpu_power": 1.0,
   "power_per_click": 1.0,
   "cash_per_score": 0.01,
-  "autopilot_cost": 1.0
+  "autopilot_cost": 1.0,
+  "worm_yield": 1.0
 }

--- a/data/upgrades/disable_manual_flaps.json
+++ b/data/upgrades/disable_manual_flaps.json
@@ -1,0 +1,14 @@
+{
+  "id": "earlybird_disable_manual_flaps",
+  "name": "Wing Restraints",
+  "description": "Unlocks a checkbox to disable manual flaps.",
+  "effects": [],
+  "systems": [
+    "earlybird"
+  ],
+  "dependencies": [],
+  "cost_per_level": {
+    "cash": 100
+  },
+  "max_level": 1
+}

--- a/data/upgrades/worm_yield.json
+++ b/data/upgrades/worm_yield.json
@@ -1,0 +1,23 @@
+{
+  "id": "earlybird_worm_yield",
+  "name": "Protein Packed",
+  "description": "Each level increases worm yield by $1.",
+  "effects": [
+    {
+      "target": "worm_yield",
+      "operation": "add",
+      "value": 1.0
+    }
+  ],
+  "systems": [
+    "earlybird"
+  ],
+  "dependencies": [],
+  "cost_per_level": {
+    "cash": 100
+  },
+  "scale_by_formula": true,
+  "cost_formula": {
+    "cash": "base_cost[\"cash\"] * pow(1.2, level-1)"
+  }
+}


### PR DESCRIPTION
## Summary
- add `worm_yield` stat and upgrade to boost worm cash rewards
- add upgrade gating a new **Disable Manual Flaps** checkbox and logic
- wire worms to read `worm_yield` stat for payouts

## Testing
- `godot3 --headless --path . --quit` *(fails: project requires newer config version)*

------
https://chatgpt.com/codex/tasks/task_e_68a12fff686083258d1cbbb7ef2c017d