### PR TITLE
Refactor upgrade repeatability with one-time unlock support

### DIFF
--- a/components/upgrade_scenes/upgrade_tooltip.gd
+++ b/components/upgrade_scenes/upgrade_tooltip.gd
@@ -42,12 +42,17 @@ func _update_display() -> void:
 		effect_label.text = describe_effect(effect)
 		effect_list.add_child(effect_label)
 	
-	# Evaluate upgrade state
-	var can_purchase = UpgradeManager.can_purchase(id)
-	var maxed = UpgradeManager.max_level(id) != -1 and StatManager.get_upgrade_level(id) >= UpgradeManager.max_level(id)
+        # Evaluate upgrade state
+        var can_purchase = UpgradeManager.can_purchase(id)
+        var level = StatManager.get_upgrade_level(id)
+        var purchased_once = UpgradeManager.is_one_time(id) and level >= 1
+        var maxed = not purchased_once and UpgradeManager.max_level(id) != -1 and level >= UpgradeManager.max_level(id)
 
-	buy_button.disabled = not can_purchase or maxed
-	buy_button.text = "Maxed Out" if maxed else "Buy"
+        buy_button.disabled = not can_purchase or purchased_once or maxed
+        if purchased_once:
+                buy_button.text = "Purchased"
+        else:
+                buy_button.text = "Maxed Out" if maxed else "Buy"
 
 	var status = get_status_text(current_upgrade)
 	status_label.text = status
@@ -92,8 +97,11 @@ func get_status_text(upgrade: Dictionary) -> String:
 	if id == "":
 		return ""
 	
-	if UpgradeManager.max_level(id) != -1 and StatManager.get_upgrade_level(id) >= UpgradeManager.max_level(id):
-		return "Maxed Out"
+        var level = StatManager.get_upgrade_level(id)
+        if UpgradeManager.is_one_time(id) and level >= 1:
+                return "Purchased"
+        if UpgradeManager.max_level(id) != -1 and level >= UpgradeManager.max_level(id):
+                return "Maxed Out"
 	
 	if UpgradeManager.is_locked(id):
 		return "Locked"

--- a/data/upgrades/autopilot_free.json
+++ b/data/upgrades/autopilot_free.json
@@ -8,7 +8,8 @@
   ],
   "dependencies": [],
   "cost_per_level": {
-	"cash": 100
+        "cash": 100
   },
-  "max_level": 1
+  "max_level": 1,
+  "repeatable": false
 }

--- a/data/upgrades/cash_per_score.json
+++ b/data/upgrades/cash_per_score.json
@@ -17,7 +17,8 @@
 	  "cash": 1
 	},
 	"scale_by_formula": true,
-	"cost_formula": {
-	  "cash": "base_cost[\"cash\"] * pow(1.2, level-1)"
-	}
+        "cost_formula": {
+          "cash": "base_cost[\"cash\"] * pow(1.2, level-1)"
+        },
+        "repeatable": true
   }

--- a/data/upgrades/disable_manual_flaps.json
+++ b/data/upgrades/disable_manual_flaps.json
@@ -8,7 +8,8 @@
   ],
   "dependencies": [],
   "cost_per_level": {
-	"cash": 1000
+        "cash": 1000
   },
-  "max_level": 1
+  "max_level": 1,
+  "repeatable": false
 }

--- a/data/upgrades/fumble_personal_trainer.json
+++ b/data/upgrades/fumble_personal_trainer.json
@@ -1,7 +1,7 @@
 {
   "id": "fumble_personal_trainer",
   "name": "Personal Trainer",
-  "description": "Hire a personal trainer. Repeatable every week. Soft limit 10. Increases dime status by up to 0.1, scaling down to +0.01 as dime approaches 9.",
+  "description": "Hire a personal trainer. Increases dime status by up to 0.1, scaling down to +0.01 as dime approaches 9.",
   "effects": [
 	{
 	  "target": "dime_status",
@@ -14,10 +14,9 @@
   ],
   "dependencies": [],
   "cost_per_level": {
-	"cash": 1500
+        "cash": 1500
   },
-  "max_level": 9999,
-  "soft_limit": 10,
-  "repeatable_cooldown_days": 7,
+  "max_level": 1,
+  "repeatable": false,
   "scale_by_formula": false
 }

--- a/data/upgrades/fumble_turkish_hair_surgery.json
+++ b/data/upgrades/fumble_turkish_hair_surgery.json
@@ -14,8 +14,9 @@
   ],
   "dependencies": [],
   "cost_per_level": {
-	"cash": 25000
+        "cash": 25000
   },
   "max_level": 1,
+  "repeatable": false,
   "scale_by_formula": false
 }

--- a/data/upgrades/upgrade_ui.gd
+++ b/data/upgrades/upgrade_ui.gd
@@ -34,7 +34,12 @@ func set_locked(locked: bool) -> void:
 			self.modulate = Color(1, 1, 1, 1)
 
 func set_level(level: int) -> void:
-	level_label.text = "Level: %d" % level
+        var repeatable = upgrade_data.get("repeatable", true)
+        if repeatable:
+                level_label.text = "Level: %d" % level
+        else:
+                level_label.text = "PURCHASED" if level > 0 else ""
+        buy_button.disabled = is_locked or not UpgradeManager.can_purchase(upgrade_data.get("id", ""))
 
 func _refresh_cost() -> void:
 	var cost = UpgradeManager.get_cost_for_next_level(upgrade_data["id"])

--- a/data/upgrades/upgrade_ui.tscn
+++ b/data/upgrades/upgrade_ui.tscn
@@ -45,7 +45,7 @@ unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 3
 size_flags_stretch_ratio = 0.25
-text = "Level: 0"
+text = ""
 
 [node name="HBoxContainer2" type="HBoxContainer" parent="MarginContainer/VBoxContainer"]
 layout_mode = 2

--- a/data/upgrades/worm_yield.json
+++ b/data/upgrades/worm_yield.json
@@ -19,5 +19,6 @@
   "scale_by_formula": true,
   "cost_formula": {
     "cash": "base_cost[\"cash\"] * pow(1.2, level-1)"
-  }
+  },
+  "repeatable": true
 }


### PR DESCRIPTION
## Summary
- add `repeatable` flag to all upgrade JSON definitions
- treat `repeatable: false` as one-time purchases in `UpgradeManager` and UI
- show "PURCHASED" for non-repeatable upgrades instead of levels

## Testing
- `godot3 --headless --check autoloads/upgrade_manager.gd` *(fails: Can't open project, expected Godot 4)*

------
https://chatgpt.com/codex/tasks/task_e_68a1365f66588325808843b6dc549b68