### PR TITLE
Refactor upgrade repeatability logic

### DIFF
--- a/autoloads/upgrade_manager.gd
+++ b/autoloads/upgrade_manager.gd
@@ -176,13 +176,10 @@ func max_level(id: String) -> int:
 	return int(m)
 
 func is_repeatable(id: String) -> bool:
-	var upgrade := get_upgrade(id)
-	if upgrade == null:
-		return false
-	return upgrade.get("repeatable", true)
-
-func is_one_time(id: String) -> bool:
-	return not is_repeatable(id)
+        var upgrade := get_upgrade(id)
+        if upgrade == null:
+                return false
+        return upgrade.get("repeatable", true)
 
 func get_cost_for_next_level(id: String) -> Dictionary:
 	var upgrade := get_upgrade(id)

--- a/components/upgrade_scenes/upgrade_tooltip.gd
+++ b/components/upgrade_scenes/upgrade_tooltip.gd
@@ -43,10 +43,10 @@ func _update_display() -> void:
 		effect_list.add_child(effect_label)
 	
 		# Evaluate upgrade state
-		var can_purchase = UpgradeManager.can_purchase(id)
-		var level = StatManager.get_upgrade_level(id)
-		var purchased_once = UpgradeManager.is_one_time(id) and level >= 1
-		var maxed = not purchased_once and UpgradeManager.max_level(id) != -1 and level >= UpgradeManager.max_level(id)
+                var can_purchase = UpgradeManager.can_purchase(id)
+                var level = StatManager.get_upgrade_level(id)
+                var purchased_once = not UpgradeManager.is_repeatable(id) and level >= 1
+                var maxed = not purchased_once and UpgradeManager.max_level(id) != -1 and level >= UpgradeManager.max_level(id)
 
 		buy_button.disabled = not can_purchase or purchased_once or maxed
 		if purchased_once:
@@ -97,11 +97,11 @@ func get_status_text(upgrade: Dictionary) -> String:
 	if id == "":
 		return ""
 	
-		var level = StatManager.get_upgrade_level(id)
-		if UpgradeManager.is_one_time(id) and level >= 1:
-				return "Purchased"
-		if UpgradeManager.max_level(id) != -1 and level >= UpgradeManager.max_level(id):
-				return "Maxed Out"
+                var level = StatManager.get_upgrade_level(id)
+                if not UpgradeManager.is_repeatable(id) and level >= 1:
+                                return "Purchased"
+                if UpgradeManager.max_level(id) != -1 and level >= UpgradeManager.max_level(id):
+                                return "Maxed Out"
 	
 	if UpgradeManager.is_locked(id):
 		return "Locked"


### PR DESCRIPTION
## Summary
- remove redundant `is_one_time` helper from upgrade manager
- rely on `is_repeatable` in upgrade tooltip to detect one-off upgrades

## Testing
- `./Godot_v4.2.1-stable_linux.x86_64 --headless --path . --run-tests` *(fails: resources not imported, project not opened in editor)*

------
https://chatgpt.com/codex/tasks/task_e_68a13e81f918832585f178064506714e