### PR TITLE
Add autopay toggle to bill popup

### DIFF
--- a/components/popups/bill_popup_ui.gd
+++ b/components/popups/bill_popup_ui.gd
@@ -10,6 +10,7 @@ var popup_type := "BillPopupUI"
 
 @onready var bill_label: Label = %BillLabel
 @onready var interest_label: Label = %InterestLabel
+@onready var autopay_checkbox: CheckBox = %AutopayCheckBox
 
 func _ready() -> void:
 	user_movable = true
@@ -18,6 +19,7 @@ func _ready() -> void:
 	#window_can_minimize = false
 	# If the popup was restored after data load, manually refresh UI
 	_update_display()
+	autopay_checkbox.button_pressed = BillManager.autopay_enabled
 
 func init(name: String) -> void:
 	bill_name = name
@@ -54,6 +56,10 @@ func _on_pay_by_credit_button_pressed() -> void:
 	else:
 		print("❌ Not enough credit")
 	WindowManager.launch_app_by_name("OwerView")
+
+func _on_autopay_check_box_toggled(toggled_on: bool) -> void:
+	BillManager.autopay_enabled = toggled_on
+
 
 # --- SAVE SUPPORT ---
 

--- a/components/popups/bill_popup_ui.tscn
+++ b/components/popups/bill_popup_ui.tscn
@@ -110,5 +110,14 @@ text = "*Paying by credit imposes a 30% fee"
 horizontal_alignment = 1
 autowrap_mode = 3
 
+[node name="AutopayCheckBox" type="CheckBox" parent="MarginContainer/VBoxContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 4
+focus_mode = 0
+theme_override_font_sizes/font_size = 24
+text = "Autopay Bills"
+
 [connection signal="pressed" from="MarginContainer/VBoxContainer/HBoxContainer/PayNowButton" to="." method="_on_pay_now_button_pressed"]
 [connection signal="pressed" from="MarginContainer/VBoxContainer/HBoxContainer/PayByCreditButton" to="." method="_on_pay_by_credit_button_pressed"]
+[connection signal="toggled" from="MarginContainer/VBoxContainer/AutopayCheckBox" to="." method="_on_autopay_check_box_toggled"]


### PR DESCRIPTION
## Summary
- add an autopay checkbox to each bill popup and hook it to BillManager

## Testing
- `godot --headless --quit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a1535b7f308325a30c58eb06b550a8