### PR TITLE
Add sorting controls for ChatsTab containers

### DIFF
--- a/components/apps/fumble/chats_tab.gd
+++ b/components/apps/fumble/chats_tab.gd
@@ -1,56 +1,82 @@
-extends Control
 class_name ChatsTab
+extends Control
 
 signal request_resize_x_to(pixels)
 signal request_resize_y_to(pixels)
-
-@onready var matches_label: Label = %MatchesLabel
-@onready var matches_container: HBoxContainer = %MatchesContainer
-@onready var chat_battles_container: VBoxContainer = %ChatBattlesContainer
-
-@onready var average_match_label: Label = %AverageMatchLabel
 
 @export var match_button_scene: PackedScene
 @export var battle_button_scene: PackedScene
 @export var match_profile_scene: PackedScene
 @export var battle_scene: PackedScene
 
+@onready var matches_label: Label = %MatchesLabel
+@onready var matches_container: HBoxContainer = %MatchesContainer
+@onready var matches_sort: OptionButton = %MatchesSort
+@onready var chat_battles_container: VBoxContainer = %ChatBattlesContainer
+@onready var chat_battles_sort: OptionButton = %ChatBattlesSort
+
+@onready var average_match_label: Label = %AverageMatchLabel
+
+
 func _ready():
+	matches_sort.add_item("🔥 Asc")
+	matches_sort.add_item("🔥 Desc")
+	matches_sort.add_item("Name")
+	matches_sort.add_item("Type")
+	matches_sort.item_selected.connect(_on_matches_sort_selected)
+
+	chat_battles_sort.add_item("🔥 Asc")
+	chat_battles_sort.add_item("🔥 Desc")
+	chat_battles_sort.add_item("Name")
+	chat_battles_sort.add_item("Type")
+	chat_battles_sort.add_item("Status")
+	chat_battles_sort.item_selected.connect(_on_chat_battles_sort_selected)
+
 	refresh_ui()
+
 
 func refresh_ui():
 	refresh_matches()
 	refresh_battles()
 
+
 func refresh_matches():
-	# Always clear
 	for child in matches_container.get_children():
 		child.queue_free()
-
-# Gather all "liked" or "matched" NPCs, but not currently in a chat battle
 	var matches: Array = FumbleManager.get_matches()
 	var battles: Array = FumbleManager.get_active_battles()
 	var battle_npc_indices := battles.map(func(b): return b.npc_idx)
 
 	var total_attractiveness := 0
 	var filtered_count := 0
+	var data := []
 
 	for idx in matches:
 		if battle_npc_indices.has(idx):
-			continue # Already chatting, show only in battles section
+			continue
 		var npc = NPCManager.get_npc_by_index(idx)
 		total_attractiveness += npc.attractiveness
 		filtered_count += 1
+		data.append({"npc": npc, "idx": idx})
+	match matches_sort.selected:
+		0:
+			data.sort_custom(func(a, b): return a.npc.attractiveness < b.npc.attractiveness)
+		1:
+			data.sort_custom(func(a, b): return a.npc.attractiveness > b.npc.attractiveness)
+		2:
+			data.sort_custom(func(a, b): return a.npc.full_name < b.npc.full_name)
+		3:
+			data.sort_custom(
+				func(a, b): return str(a.npc.chat_battle_type) < str(b.npc.chat_battle_type)
+			)
+	for d in data:
 		var btn = match_button_scene.instantiate()
 		matches_container.add_child(btn)
-		btn.set_profile(npc, idx)
+		btn.set_profile(d.npc, d.idx)
 		btn.match_pressed.connect(_on_match_button_pressed)
-
-	# Include NPCs currently in battles in the totals
 	for b in battles:
 		var npc = NPCManager.get_npc_by_index(b.npc_idx)
 		total_attractiveness += npc.attractiveness
-
 	var total_count := filtered_count + battles.size()
 	matches_label.text = "Matches: %d" % total_count
 
@@ -59,17 +85,43 @@ func refresh_matches():
 		avg_att = float(total_attractiveness) / total_count
 	average_match_label.text = "Avg: 🔥 %.1f/10" % (avg_att / 10.0)
 
+
 func refresh_battles():
 	for child in chat_battles_container.get_children():
 		child.queue_free()
-
 	var battles: Array = FumbleManager.get_active_battles()
+	var data := []
 	for b in battles:
 		var npc = NPCManager.get_npc_by_index(b.npc_idx)
+		data.append({"npc": npc, "battle": b})
+	match chat_battles_sort.selected:
+		0:
+			data.sort_custom(func(a, b): return a.npc.attractiveness < b.npc.attractiveness)
+		1:
+			data.sort_custom(func(a, b): return a.npc.attractiveness > b.npc.attractiveness)
+		2:
+			data.sort_custom(func(a, b): return a.npc.full_name < b.npc.full_name)
+		3:
+			data.sort_custom(
+				func(a, b): return str(a.npc.chat_battle_type) < str(b.npc.chat_battle_type)
+			)
+		4:
+			var order = {"blocked": 0, "victory": 1, "active": 2}
+			data.sort_custom(
+				func(a, b):
+					return (
+						order.get(a.battle.get("outcome", "active"), 2)
+						< order.get(b.battle.get("outcome", "active"), 2)
+					)
+			)
+	for d in data:
+		var npc = d.npc
+		var b = d.battle
 		var btn = battle_button_scene.instantiate()
 		btn.set_battle(npc, b.battle_id, b.npc_idx, b.get("outcome", "active"))
 		btn.pressed.connect(func(): _on_battle_button_pressed(b.battle_id, npc, b.npc_idx))
 		chat_battles_container.add_child(btn)
+
 
 func _on_match_button_pressed(npc, idx):
 	var match_profile = match_profile_scene.instantiate()
@@ -77,24 +129,30 @@ func _on_match_button_pressed(npc, idx):
 	match_profile.set_profile(npc, idx)
 	match_profile.start_battle_requested.connect(_on_start_battle_requested)
 
+
 func _on_start_battle_requested(battle_id, npc, idx):
 	open_battle(battle_id, npc, idx)
 	refresh_ui()
 
+
 func _on_battle_button_pressed(battle_id, npc, idx):
 	open_battle(battle_id, npc, idx)
+
 
 func open_battle(battle_id, npc, idx):
 	var battle_data = FumbleManager.load_battle_state(battle_id)
 	var scene = battle_scene.instantiate()
 	add_child(scene)
-	scene.load_battle(
-		battle_id,
-		npc,
-		battle_data.chatlog,
-		battle_data.stats,
-		idx,
-		battle_data.get("outcome", "active"),
+	(
+		scene
+		. load_battle(
+			battle_id,
+			npc,
+			battle_data.chatlog,
+			battle_data.stats,
+			idx,
+			battle_data.get("outcome", "active"),
+		)
 	)
 	scene.chat_closed.connect(_on_chat_closed)
 	request_resize_x_to.emit(911)
@@ -105,6 +163,7 @@ func _on_chat_closed() -> void:
 	print("chat closed")
 	refresh_ui()
 
+
 # Optional: If you want to always re-sync when the chats tab is shown from parent UI
 func on_tab_selected():
 	refresh_ui()
@@ -114,3 +173,11 @@ func sort_containers_by_recency() -> void:
 	pass
 	#sort matches_container with the most recent additions on the left
 	#sort chat_battles_container with the most recently interacted on top
+
+
+func _on_matches_sort_selected(_idx):
+	refresh_matches()
+
+
+func _on_chat_battles_sort_selected(_idx):
+	refresh_battles()

--- a/components/apps/fumble/chats_tab.tscn
+++ b/components/apps/fumble/chats_tab.tscn
@@ -61,13 +61,22 @@ custom_minimum_size = Vector2(0, 156)
 layout_mode = 2
 size_flags_stretch_ratio = 0.5
 
-[node name="MatchesContainer" type="HBoxContainer" parent="MarginContainer/PanelContainer/MarginContainer/VBoxContainer/MarginContainer/ScrollContainer"]
+[node name="MatchesHBox" type="HBoxContainer" parent="MarginContainer/PanelContainer/MarginContainer/VBoxContainer/MarginContainer/ScrollContainer"]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+
+[node name="MatchesSort" type="OptionButton" parent="MarginContainer/PanelContainer/MarginContainer/VBoxContainer/MarginContainer/ScrollContainer/MatchesHBox"]
+unique_name_in_owner = true
+layout_mode = 2
+
+[node name="MatchesContainer" type="HBoxContainer" parent="MarginContainer/PanelContainer/MarginContainer/VBoxContainer/MarginContainer/ScrollContainer/MatchesHBox"]
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
 
-[node name="MatchButton" parent="MarginContainer/PanelContainer/MarginContainer/VBoxContainer/MarginContainer/ScrollContainer/MatchesContainer" instance=ExtResource("2_qddv1")]
+[node name="MatchButton" parent="MarginContainer/PanelContainer/MarginContainer/VBoxContainer/MarginContainer/ScrollContainer/MatchesHBox/MatchesContainer" instance=ExtResource("2_qddv1")]
 custom_minimum_size = Vector2(128, 96)
 layout_mode = 2
 size_flags_vertical = 4
@@ -87,9 +96,18 @@ text = "Average Match: 0"
 layout_mode = 2
 size_flags_vertical = 3
 
-[node name="ChatBattlesContainer" type="VBoxContainer" parent="MarginContainer/PanelContainer/MarginContainer/VBoxContainer/ScrollContainer2"]
+[node name="ChatBattlesVBox" type="VBoxContainer" parent="MarginContainer/PanelContainer/MarginContainer/VBoxContainer/ScrollContainer2"]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+
+[node name="ChatBattlesSort" type="OptionButton" parent="MarginContainer/PanelContainer/MarginContainer/VBoxContainer/ScrollContainer2/ChatBattlesVBox"]
 unique_name_in_owner = true
 layout_mode = 2
 
-[node name="ChatBattleButton" parent="MarginContainer/PanelContainer/MarginContainer/VBoxContainer/ScrollContainer2/ChatBattlesContainer" instance=ExtResource("3_3cmco")]
+[node name="ChatBattlesContainer" type="VBoxContainer" parent="MarginContainer/PanelContainer/MarginContainer/VBoxContainer/ScrollContainer2/ChatBattlesVBox"]
+unique_name_in_owner = true
+layout_mode = 2
+
+[node name="ChatBattleButton" parent="MarginContainer/PanelContainer/MarginContainer/VBoxContainer/ScrollContainer2/ChatBattlesVBox/ChatBattlesContainer" instance=ExtResource("3_3cmco")]
 layout_mode = 2


### PR DESCRIPTION
## Summary
- add sort dropdowns for matches and chat battles in ChatsTab
- allow sorting by attractiveness, name, battle type, and status
- implement sorting logic for both matches and battles

## Testing
- `gdformat components/apps/fumble/chats_tab.gd`
- `gdlint components/apps/fumble/chats_tab.gd`


------
https://chatgpt.com/codex/tasks/task_e_68a15429317483259b6dbb8c5c732159