### PR TITLE
Add autopay toggle to bill popup

### DIFF
--- a/autoloads/bill_manager.gd
+++ b/autoloads/bill_manager.gd
@@ -2,9 +2,10 @@ extends Node
 # Autoload: BillManager
 
 signal lifestyle_updated
+signal autopay_changed(enabled: bool)
 
-var autopay_enabled: bool = false
-var active_bills: Dictionary = {} 
+var autopay_enabled: bool = false setget set_autopay_enabled
+var active_bills: Dictionary = {}
 
 var lifestyle_categories := {}  # category_name: Dictionary
 
@@ -20,9 +21,15 @@ var weekly_bill_cycle := [
 var static_bill_amounts := {}
 
 
+func set_autopay_enabled(value: bool) -> void:
+        if autopay_enabled == value:
+                return
+        autopay_enabled = value
+        autopay_changed.emit(value)
+
 func _ready() -> void:
-	TimeManager.day_passed.connect(_on_day_passed)
-	#TimeManager.hour_passed.connect(_on_hour_passed)
+        TimeManager.day_passed.connect(_on_day_passed)
+        #TimeManager.hour_passed.connect(_on_hour_passed)
 	PortfolioManager.credit_updated.connect(_on_credit_updated)
 	if lifestyle_categories.is_empty():
 		for category in lifestyle_options.keys():
@@ -257,10 +264,10 @@ func get_save_data() -> Dictionary:
 	}
 
 func load_from_data(data: Dictionary) -> void:
-	autopay_enabled = data.get("autopay_enabled", false)
-	lifestyle_categories = data.get("lifestyle_categories", {}).duplicate()
-	lifestyle_indices = data.get("lifestyle_indices", {}).duplicate()
-	active_bills.clear()
+       set_autopay_enabled(data.get("autopay_enabled", false))
+       lifestyle_categories = data.get("lifestyle_categories", {}).duplicate()
+       lifestyle_indices = data.get("lifestyle_indices", {}).duplicate()
+       active_bills.clear()
 	emit_signal("lifestyle_updated")
 
 	if data.has("pane_data"):

--- a/components/popups/bill_popup_ui.gd
+++ b/components/popups/bill_popup_ui.gd
@@ -10,14 +10,17 @@ var popup_type := "BillPopupUI"
 
 @onready var bill_label: Label = %BillLabel
 @onready var interest_label: Label = %InterestLabel
+@onready var autopay_checkbox: CheckBox = %AutopayCheckBox
 
 func _ready() -> void:
-	user_movable = true
-	window_title = "Bill: " + str(bill_name)
-	#window_can_close = false
-	#window_can_minimize = false
-	# If the popup was restored after data load, manually refresh UI
-	_update_display()
+        user_movable = true
+        window_title = "Bill: " + str(bill_name)
+        #window_can_close = false
+        #window_can_minimize = false
+        # If the popup was restored after data load, manually refresh UI
+       _update_display()
+       autopay_checkbox.set_pressed_no_signal(BillManager.autopay_enabled)
+       BillManager.autopay_changed.connect(_on_autopay_changed)
 
 func init(name: String) -> void:
 	bill_name = name
@@ -54,6 +57,13 @@ func _on_pay_by_credit_button_pressed() -> void:
 	else:
 		print("❌ Not enough credit")
 	WindowManager.launch_app_by_name("OwerView")
+
+func _on_autopay_check_box_toggled(toggled_on: bool) -> void:
+       BillManager.set_autopay_enabled(toggled_on)
+
+func _on_autopay_changed(enabled: bool) -> void:
+       autopay_checkbox.set_pressed_no_signal(enabled)
+
 
 # --- SAVE SUPPORT ---
 

--- a/components/popups/bill_popup_ui.tscn
+++ b/components/popups/bill_popup_ui.tscn
@@ -110,5 +110,14 @@ text = "*Paying by credit imposes a 30% fee"
 horizontal_alignment = 1
 autowrap_mode = 3
 
+[node name="AutopayCheckBox" type="CheckBox" parent="MarginContainer/VBoxContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 4
+focus_mode = 0
+theme_override_font_sizes/font_size = 24
+text = "Autopay Bills"
+
 [connection signal="pressed" from="MarginContainer/VBoxContainer/HBoxContainer/PayNowButton" to="." method="_on_pay_now_button_pressed"]
 [connection signal="pressed" from="MarginContainer/VBoxContainer/HBoxContainer/PayByCreditButton" to="." method="_on_pay_by_credit_button_pressed"]
+[connection signal="toggled" from="MarginContainer/VBoxContainer/AutopayCheckBox" to="." method="_on_autopay_check_box_toggled"]

--- a/components/popups/calendar_popup_ui.gd
+++ b/components/popups/calendar_popup_ui.gd
@@ -8,13 +8,13 @@ extends Pane
 @onready var month_year_label: Label = %MonthYearLabel
 
 func _ready():
-	hide()
-	autopay_checkbox.button_pressed = BillManager.autopay_enabled
-	autopay_checkbox.toggled.connect(_on_autopay_toggled)
-	TimeManager.day_passed.connect(_on_day_passed)
-	populate_calendar(TimeManager.current_month, TimeManager.current_year)
-	month_year_label.text = str(TimeManager.month_names[TimeManager.current_month-1]) + " " + str(TimeManager.current_year)
-	call_deferred("move_to_front")
+        hide()
+       autopay_checkbox.set_pressed_no_signal(BillManager.autopay_enabled)
+       BillManager.autopay_changed.connect(_on_autopay_changed)
+        TimeManager.day_passed.connect(_on_day_passed)
+        populate_calendar(TimeManager.current_month, TimeManager.current_year)
+        month_year_label.text = str(TimeManager.month_names[TimeManager.current_month-1]) + " " + str(TimeManager.current_year)
+        call_deferred("move_to_front")
 
 func add_click_catcher() -> void:
 	click_catcher = preload("res://components/ui/click_catcher.tscn").instantiate()
@@ -39,9 +39,6 @@ func close() -> void:
 
 func _on_day_passed(_day: int, month: int, year: int):
 	populate_calendar(month, year)
-
-func _on_autopay_toggled(pressed: bool) -> void:
-	BillManager.autopay_enabled = pressed
 
 func populate_calendar(month: int, year: int) -> void:
 	var days_in_month := TimeManager.get_days_in_month(month, year)
@@ -92,7 +89,10 @@ func populate_calendar(month: int, year: int) -> void:
 	month_year_label.text = str(TimeManager.month_names[TimeManager.current_month-1]) + " " + str(TimeManager.current_year)
 
 func _on_autopay_check_box_toggled(toggled_on: bool) -> void:
-	BillManager.autopay_enabled = toggled_on
+       BillManager.set_autopay_enabled(toggled_on)
+
+func _on_autopay_changed(enabled: bool) -> void:
+       autopay_checkbox.set_pressed_no_signal(enabled)
 
 func _on_life_stylist_button_pressed() -> void:
 	WindowManager.launch_app_by_name("LifeStylist")


### PR DESCRIPTION
## Summary
- add an autopay checkbox to each bill popup and hook it to BillManager
- keep calendar and bill popups in sync via BillManager `autopay_changed`

## Testing
- `godot --headless --quit` *(fails: command not found)*
- `godot3 --headless --quit` *(fails: project uses newer config version)*

------
https://chatgpt.com/codex/tasks/task_e_68a1535b7f308325a30c58eb06b550a8