### PR TITLE
Sync autopay UI across calendar and bill popups

### DIFF
--- a/autoloads/bill_manager.gd
+++ b/autoloads/bill_manager.gd
@@ -2,9 +2,18 @@ extends Node
 # Autoload: BillManager
 
 signal lifestyle_updated
+signal autopay_changed(enabled: bool)
 
-var autopay_enabled: bool = false
-var active_bills: Dictionary = {} 
+var _autopay_enabled: bool = false
+var autopay_enabled: bool:
+        get:
+                return _autopay_enabled
+        set(value):
+                if _autopay_enabled == value:
+                        return
+                _autopay_enabled = value
+                autopay_changed.emit(value)
+var active_bills: Dictionary = {}
 
 var lifestyle_categories := {}  # category_name: Dictionary
 

--- a/components/popups/bill_popup_ui.gd
+++ b/components/popups/bill_popup_ui.gd
@@ -13,13 +13,14 @@ var popup_type := "BillPopupUI"
 @onready var autopay_checkbox: CheckBox = %AutopayCheckBox
 
 func _ready() -> void:
-	user_movable = true
-	window_title = "Bill: " + str(bill_name)
-	#window_can_close = false
-	#window_can_minimize = false
-	# If the popup was restored after data load, manually refresh UI
-	_update_display()
-	autopay_checkbox.button_pressed = BillManager.autopay_enabled
+        user_movable = true
+        window_title = "Bill: " + str(bill_name)
+        #window_can_close = false
+        #window_can_minimize = false
+        # If the popup was restored after data load, manually refresh UI
+        _update_display()
+        autopay_checkbox.set_pressed_no_signal(BillManager.autopay_enabled)
+        BillManager.autopay_changed.connect(_on_autopay_changed)
 
 func init(name: String) -> void:
 	bill_name = name
@@ -58,7 +59,10 @@ func _on_pay_by_credit_button_pressed() -> void:
 	WindowManager.launch_app_by_name("OwerView")
 
 func _on_autopay_check_box_toggled(toggled_on: bool) -> void:
-	BillManager.autopay_enabled = toggled_on
+        BillManager.autopay_enabled = toggled_on
+
+func _on_autopay_changed(enabled: bool) -> void:
+        autopay_checkbox.set_pressed_no_signal(enabled)
 
 
 # --- SAVE SUPPORT ---

--- a/components/popups/calendar_popup_ui.gd
+++ b/components/popups/calendar_popup_ui.gd
@@ -8,13 +8,13 @@ extends Pane
 @onready var month_year_label: Label = %MonthYearLabel
 
 func _ready():
-	hide()
-	autopay_checkbox.button_pressed = BillManager.autopay_enabled
-	autopay_checkbox.toggled.connect(_on_autopay_toggled)
-	TimeManager.day_passed.connect(_on_day_passed)
-	populate_calendar(TimeManager.current_month, TimeManager.current_year)
-	month_year_label.text = str(TimeManager.month_names[TimeManager.current_month-1]) + " " + str(TimeManager.current_year)
-	call_deferred("move_to_front")
+        hide()
+        autopay_checkbox.set_pressed_no_signal(BillManager.autopay_enabled)
+        BillManager.autopay_changed.connect(_on_autopay_changed)
+        TimeManager.day_passed.connect(_on_day_passed)
+        populate_calendar(TimeManager.current_month, TimeManager.current_year)
+        month_year_label.text = str(TimeManager.month_names[TimeManager.current_month-1]) + " " + str(TimeManager.current_year)
+        call_deferred("move_to_front")
 
 func add_click_catcher() -> void:
 	click_catcher = preload("res://components/ui/click_catcher.tscn").instantiate()
@@ -39,9 +39,6 @@ func close() -> void:
 
 func _on_day_passed(_day: int, month: int, year: int):
 	populate_calendar(month, year)
-
-func _on_autopay_toggled(pressed: bool) -> void:
-	BillManager.autopay_enabled = pressed
 
 func populate_calendar(month: int, year: int) -> void:
 	var days_in_month := TimeManager.get_days_in_month(month, year)
@@ -92,7 +89,10 @@ func populate_calendar(month: int, year: int) -> void:
 	month_year_label.text = str(TimeManager.month_names[TimeManager.current_month-1]) + " " + str(TimeManager.current_year)
 
 func _on_autopay_check_box_toggled(toggled_on: bool) -> void:
-	BillManager.autopay_enabled = toggled_on
+        BillManager.autopay_enabled = toggled_on
+
+func _on_autopay_changed(enabled: bool) -> void:
+        autopay_checkbox.set_pressed_no_signal(enabled)
 
 func _on_life_stylist_button_pressed() -> void:
 	WindowManager.launch_app_by_name("LifeStylist")


### PR DESCRIPTION
## Summary
- Emit `autopay_changed` signal from BillManager whenever autopay is toggled
- Calendar and Bill popups now listen for autopay changes and update their checkboxes accordingly

## Testing
- `godot --version` *(fails: command not found)*
- `apt-get install -y godot4` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68a157409bf8832595bb3de0ec7732dd