### PR TITLE
Reduce lag when swiping right in Fumble

### DIFF
--- a/components/apps/fumble/chats_tab.gd
+++ b/components/apps/fumble/chats_tab.gd
@@ -36,54 +36,65 @@ func _ready():
 
 
 func refresh_ui():
-	refresh_matches()
-	refresh_battles()
+        refresh_matches()
+        refresh_battles()
 
 
-func refresh_matches():
-	for child in matches_container.get_children():
-		child.queue_free()
-	var matches: Array = FumbleManager.get_matches()
-	var battles: Array = FumbleManager.get_active_battles()
-	var battle_npc_indices := battles.map(func(b): return b.npc_idx)
+func refresh_matches(time_budget_msec := 8) -> void:
+        for child in matches_container.get_children():
+                child.queue_free()
+        var matches: Array = FumbleManager.get_matches()
+        var battles: Array = FumbleManager.get_active_battles()
+        var battle_npc_indices := battles.map(func(b): return b.npc_idx)
 
-	var total_attractiveness := 0
-	var filtered_count := 0
-	var data := []
+        var total_attractiveness := 0
+        var filtered_count := 0
+        var data := []
 
-	for idx in matches:
-		if battle_npc_indices.has(idx):
-			continue
-		var npc = NPCManager.get_npc_by_index(idx)
-		total_attractiveness += npc.attractiveness
-		filtered_count += 1
-		data.append({"npc": npc, "idx": idx})
-	match matches_sort.selected:
-		0:
-			data.sort_custom(func(a, b): return a.npc.attractiveness < b.npc.attractiveness)
-		1:
-			data.sort_custom(func(a, b): return a.npc.attractiveness > b.npc.attractiveness)
-		2:
-			data.sort_custom(func(a, b): return a.npc.full_name < b.npc.full_name)
-		3:
-			data.sort_custom(
-				func(a, b): return str(a.npc.chat_battle_type) < str(b.npc.chat_battle_type)
-			)
-	for d in data:
-		var btn = match_button_scene.instantiate()
-		matches_container.add_child(btn)
-		btn.set_profile(d.npc, d.idx)
-		btn.match_pressed.connect(_on_match_button_pressed)
-	for b in battles:
-		var npc = NPCManager.get_npc_by_index(b.npc_idx)
-		total_attractiveness += npc.attractiveness
-	var total_count := filtered_count + battles.size()
-	matches_label.text = "Matches: %d" % total_count
+        var start_time = Time.get_ticks_msec()
 
-	var avg_att := 0.0
-	if total_count > 0:
-		avg_att = float(total_attractiveness) / total_count
-	average_match_label.text = "Avg: 🔥 %.1f/10" % (avg_att / 10.0)
+        for idx in matches:
+                if battle_npc_indices.has(idx):
+                        continue
+                var npc = NPCManager.get_npc_by_index(idx)
+                total_attractiveness += npc.attractiveness
+                filtered_count += 1
+                data.append({"npc": npc, "idx": idx})
+                if Time.get_ticks_msec() - start_time > time_budget_msec:
+                        await get_tree().process_frame
+                        start_time = Time.get_ticks_msec()
+        match matches_sort.selected:
+                0:
+                        data.sort_custom(func(a, b): return a.npc.attractiveness < b.npc.attractiveness)
+                1:
+                        data.sort_custom(func(a, b): return a.npc.attractiveness > b.npc.attractiveness)
+                2:
+                        data.sort_custom(func(a, b): return a.npc.full_name < b.npc.full_name)
+                3:
+                        data.sort_custom(
+                                func(a, b): return str(a.npc.chat_battle_type) < str(b.npc.chat_battle_type)
+                        )
+        for d in data:
+                var btn = match_button_scene.instantiate()
+                matches_container.add_child(btn)
+                btn.set_profile(d.npc, d.idx)
+                btn.match_pressed.connect(_on_match_button_pressed)
+                if Time.get_ticks_msec() - start_time > time_budget_msec:
+                        await get_tree().process_frame
+                        start_time = Time.get_ticks_msec()
+        for b in battles:
+                var npc = NPCManager.get_npc_by_index(b.npc_idx)
+                total_attractiveness += npc.attractiveness
+                if Time.get_ticks_msec() - start_time > time_budget_msec:
+                        await get_tree().process_frame
+                        start_time = Time.get_ticks_msec()
+        var total_count := filtered_count + battles.size()
+        matches_label.text = "Matches: %d" % total_count
+
+        var avg_att := 0.0
+        if total_count > 0:
+                avg_att = float(total_attractiveness) / total_count
+        average_match_label.text = "Avg: 🔥 %.1f/10" % (avg_att / 10.0)
 
 
 func refresh_battles():

--- a/components/apps/fumble/fumble.gd
+++ b/components/apps/fumble/fumble.gd
@@ -84,11 +84,11 @@ func _on_card_swiped_left(npc_idx):
 	# Add further logic if needed
 
 func _on_card_swiped_right(npc_idx):
-	NPCManager.promote_to_persistent(npc_idx)
-	NPCManager.set_relationship_status(npc_idx, "fumble", FumbleManager.FumbleStatus.LIKED)
-	var new_confidence = clamp(StatManager.get_stat("confidence") + 1.0, 0.0, 100.0)
-	StatManager.set_base_stat("confidence", new_confidence)
-	chats_tab.refresh_matches()
+        NPCManager.promote_to_persistent(npc_idx)
+        NPCManager.set_relationship_status(npc_idx, "fumble", FumbleManager.FumbleStatus.LIKED)
+        var new_confidence = clamp(StatManager.get_stat("confidence") + 1.0, 0.0, 100.0)
+        StatManager.set_base_stat("confidence", new_confidence)
+        chats_tab.call_deferred("refresh_matches")
 
 func highlight_active(button: Button):
 	self_button.modulate = Color.WHITE


### PR DESCRIPTION
## Summary
- Defer match list refresh after swipe to avoid blocking UI
- Break up `refresh_matches` work over frames with a time budget

## Testing
- `godot3-server --path . --quit` *(fails: project targets a newer Godot config version)*

------
https://chatgpt.com/codex/tasks/task_e_68a15d90a8b48325b6fa7b58390664a8