### PR TITLE
Track fumble match timestamps and sort by recency

### DIFF
--- a/autoloads/fumble_manager.gd
+++ b/autoloads/fumble_manager.gd
@@ -43,6 +43,9 @@ func _ready():
 func get_matches() -> Array:
 	return NPCManager.get_fumble_matches()
 
+static func get_matches_with_times() -> Array:
+	return NPCManager.get_fumble_matches_with_times()
+
 func get_active_battles() -> Array:
 	# Returns all battles for the current slot, including finished ones.
 	return DBManager.get_active_fumble_battles(SaveManager.current_slot_id)

--- a/components/npc/npc_manager.gd
+++ b/components/npc/npc_manager.gd
@@ -164,14 +164,27 @@ func set_relationship_status(idx: int, app_name: String, status: FumbleManager.F
 
 # Returns all NPC indices the player has "liked" in Fumble
 func get_fumble_matches() -> Array:
-	var matches = []
-	var rels = DBManager.get_all_fumble_relationships()
-	for idx in rels.keys():
-		var status_enum: FumbleManager.FumbleStatus = rels[idx]
-		# Show only if currently "liked" or "matched"
-		if status_enum == FumbleManager.FumbleStatus.LIKED or status_enum == FumbleManager.FumbleStatus.MATCHED:
-			matches.append(int(idx))
-	return matches
+        var matches = []
+        var rels = DBManager.get_all_fumble_relationships()
+        for idx in rels.keys():
+                var status_enum: FumbleManager.FumbleStatus = rels[idx]
+                # Show only if currently "liked" or "matched"
+                if status_enum == FumbleManager.FumbleStatus.LIKED or status_enum == FumbleManager.FumbleStatus.MATCHED:
+                        matches.append(int(idx))
+        return matches
+
+func get_fumble_matches_with_times() -> Array:
+        var out: Array = []
+        var rows = DBManager.get_all_fumble_relationship_rows()
+        for r in rows:
+                var status_enum: FumbleManager.FumbleStatus = FumbleManager.FUMBLE_STATUS_LOOKUP.get(r.status, FumbleManager.FumbleStatus.LIKED)
+                if status_enum == FumbleManager.FumbleStatus.LIKED or status_enum == FumbleManager.FumbleStatus.MATCHED:
+                        out.append({
+                                "npc_id": int(r.npc_id),
+                                "created_at": int(r.created_at),
+                                "updated_at": int(r.updated_at)
+                        })
+        return out
 
 
 


### PR DESCRIPTION
## Summary
- record created_at/updated_at for fumble relationships and expose helper to read them
- provide NPC and Fumble manager helpers returning matches with timestamps
- default Chats tab sorting to most recent and add recency aware refresh logic

## Testing
- `gdformat --check autoloads/db_manager.gd components/npc/npc_manager.gd autoloads/fumble_manager.gd components/apps/fumble/chats_tab.gd`

------
https://chatgpt.com/codex/tasks/task_e_68a165832d1c8325b2505d1ae13b2102