### PR TITLE
Fix fumble attractiveness upgrades

### DIFF
--- a/data/upgrades/fumble_personal_trainer.json
+++ b/data/upgrades/fumble_personal_trainer.json
@@ -3,11 +3,11 @@
   "name": "Personal Trainer",
   "description": "Hire a personal trainer. Increases dime status by up to 0.1, scaling down to +0.01 as dime approaches 9.",
   "effects": [
-	{
-	  "target": "dime_status",
-	  "operation": "add_formula",
-	  "value_formula": "max(0.01, 0.1 - clamp((current_dime_status - 8) * 0.09, 0, 0.09))"
-	}
+        {
+          "target": "attractiveness",
+          "operation": "add_formula",
+          "value_formula": "10 * max(0.01, 0.1 - clamp((current_dime_status - 8) * 0.09, 0, 0.09))"
+        }
   ],
   "systems": [
 	"fumble"

--- a/data/upgrades/fumble_turkish_hair_surgery.json
+++ b/data/upgrades/fumble_turkish_hair_surgery.json
@@ -3,11 +3,11 @@
   "name": "Turkish Hair Surgery",
   "description": "Undergo Turkish hair surgery. Increases dime status by 0.6.",
   "effects": [
-	{
-	  "target": "dime_status",
-	  "operation": "add",
-	  "value": 0.6
-	}
+        {
+          "target": "attractiveness",
+          "operation": "add",
+          "value": 6.0
+        }
   ],
   "systems": [
 	"fumble"


### PR DESCRIPTION
## Summary
- support `add_formula` upgrade operation
- retarget personal trainer and hair surgery upgrades to modify attractiveness

## Testing
- `godot3-server --version`
- `gdlint autoloads/stat_manager.gd` *(fails: Trailing whitespace(s); Definition out of order in global scope)*
- `/tmp/godot4/Godot_v4.2.2-stable_linux.x86_64 --headless --path . --quit` *(fails: Failed loading resource: res://.godot/imported/greenbutton.png-...)*

------
https://chatgpt.com/codex/tasks/task_e_68a16f33a43083258571d470295da3fb