### PR TITLE
Add deterministic portrait system

### DIFF
--- a/components/portraits/character_creator.gd
+++ b/components/portraits/character_creator.gd
@@ -1,0 +1,118 @@
+extends Control
+class_name CharacterCreator
+
+signal applied(config: PortraitConfig)
+
+var index_selectors: Dictionary = {}
+var color_selectors: Dictionary = {}
+var color_options: Dictionary = {}
+
+@onready var name_edit: LineEdit = $VBox/NameRow/LineEdit
+@onready var preview: PortraitView = $VBox/PortraitView
+@onready var layer_container: VBoxContainer = $VBox/LayerControls
+@onready var randomize_button: Button = $VBox/ButtonRow/Randomize
+@onready var seed_button: Button = $VBox/ButtonRow/SeedFromName
+@onready var save_button: Button = $VBox/ButtonRow/Save
+@onready var apply_button: Button = $VBox/ButtonRow/Apply
+
+func _ready():
+    _build_controls()
+    randomize_button.pressed.connect(randomize)
+    seed_button.pressed.connect(func(): seed_from_name(name_edit.text))
+    save_button.pressed.connect(func(): save_png("user://portraits/%s.png" % name_edit.text))
+    apply_button.pressed.connect(apply_and_emit)
+
+func _build_controls() -> void:
+    for layer in PortraitFactory.get_layers_order():
+        var h := HBoxContainer.new()
+        layer_container.add_child(h)
+        var label := Label.new()
+        label.text = layer
+        h.add_child(label)
+
+        var idx_opt := OptionButton.new()
+        var info := PortraitFactory.get_layer_info(layer)
+        var count: int = info.get("count", 1)
+        for i in count:
+            idx_opt.add_item(str(i + 1), i + 1)
+        idx_opt.item_selected.connect(_on_index_changed.bind(layer))
+        h.add_child(idx_opt)
+        index_selectors[layer] = idx_opt
+
+        var color_opt := OptionButton.new()
+        var palette_name: String = info.get("palette", "")
+        var colors: Array = PortraitFactory.PALETTES.get(palette_name, [])
+        color_options[layer] = colors
+        for i in colors.size():
+            color_opt.add_item(str(i + 1), i)
+        color_opt.item_selected.connect(_on_color_changed.bind(layer))
+        h.add_child(color_opt)
+        color_selectors[layer] = color_opt
+
+func _on_index_changed(index: int, layer: String) -> void:
+    _update_layer(layer)
+
+func _on_color_changed(index: int, layer: String) -> void:
+    _update_layer(layer)
+
+func _update_layer(layer: String) -> void:
+    var idx: int = index_selectors[layer].get_selected_id()
+    var tex := PortraitFactory.get_texture_for(layer, idx)
+    preview.set_layer_texture(layer, tex)
+    var color_idx: int = color_selectors[layer].get_selected_id()
+    var cols: Array = color_options[layer]
+    if cols.size() > color_idx:
+        preview.set_layer_color(layer, cols[color_idx])
+
+func seed_from_name(name: String) -> void:
+    var cfg := PortraitFactory.generate_config_for_name(name)
+    load_from_config(cfg)
+
+func randomize() -> void:
+    var rng := PortraitFactory.rng_from_seed(Time.get_unix_time_from_system())
+    var indices: Dictionary = {}
+    var colors: Dictionary = {}
+    for layer in PortraitFactory.get_layers_order():
+        indices[layer] = PortraitFactory.pick_index(layer, rng)
+        colors[layer] = PortraitFactory.random_palette_color(layer, rng)
+    var cfg := PortraitConfig.new()
+    cfg.name = name_edit.text
+    cfg.indices = indices
+    cfg.colors = colors
+    cfg.seed = rng.seed
+    load_from_config(cfg)
+
+func apply_and_emit() -> void:
+    var cfg := gather_config()
+    emit_signal("applied", cfg)
+
+func save_png(path: String) -> void:
+    var cfg := gather_config()
+    PortraitFactory.apply_config_to_view(cfg, preview)
+    PortraitFactory.export_view_to_png(preview, path)
+
+func load_from_config(cfg: PortraitConfig) -> void:
+    name_edit.text = cfg.name
+    for layer in PortraitFactory.get_layers_order():
+        var idx: int = cfg.indices.get(layer, 1)
+        index_selectors[layer].select(idx - 1)
+        var cols: Array = color_options[layer]
+        var col: Color = cfg.colors.get(layer, Color.WHITE)
+        var c_index := cols.find(col)
+        if c_index == -1:
+            c_index = 0
+        color_selectors[layer].select(c_index)
+    PortraitFactory.apply_config_to_view(cfg, preview)
+
+func gather_config() -> PortraitConfig:
+    var cfg := PortraitConfig.new()
+    cfg.name = name_edit.text
+    cfg.indices = {}
+    cfg.colors = {}
+    cfg.seed = PortraitFactory.djb2(cfg.name)
+    for layer in PortraitFactory.get_layers_order():
+        cfg.indices[layer] = index_selectors[layer].get_selected_id()
+        var cols: Array = color_options[layer]
+        var col_idx: int = color_selectors[layer].get_selected_id()
+        cfg.colors[layer] = cols[col_idx]
+    return cfg

--- a/components/portraits/character_creator.tscn
+++ b/components/portraits/character_creator.tscn
@@ -1,0 +1,37 @@
+[gd_scene format=4]
+
+[ext_resource path="res://components/portraits/character_creator.gd" type="Script" id=1]
+[ext_resource path="res://components/portraits/portrait_view.tscn" type="PackedScene" id=2]
+
+[node name="CharacterCreator" type="Control"]
+script = ExtResource(1)
+
+[node name="VBox" type="VBoxContainer" parent="."]
+anchor_right = 1.0
+anchor_bottom = 1.0
+
+[node name="NameRow" type="HBoxContainer" parent="VBox"]
+
+[node name="Label" type="Label" parent="VBox/NameRow"]
+text = "Name"
+
+[node name="LineEdit" type="LineEdit" parent="VBox/NameRow"]
+size_flags_horizontal = 3
+
+[node name="PortraitView" parent="VBox" instance=ExtResource(2)]
+
+[node name="LayerControls" type="VBoxContainer" parent="VBox"]
+
+[node name="ButtonRow" type="HBoxContainer" parent="VBox"]
+
+[node name="Randomize" type="Button" parent="VBox/ButtonRow"]
+text = "Randomize"
+
+[node name="SeedFromName" type="Button" parent="VBox/ButtonRow"]
+text = "Seed From Name"
+
+[node name="Save" type="Button" parent="VBox/ButtonRow"]
+text = "Save / Export"
+
+[node name="Apply" type="Button" parent="VBox/ButtonRow"]
+text = "Apply"

--- a/components/portraits/manifest.json
+++ b/components/portraits/manifest.json
@@ -1,0 +1,12 @@
+{
+  "order": ["HairBack", "Face", "Eyes", "Nose", "Mouth", "Hair", "Shirt"],
+  "layers": {
+    "HairBack": {"path": "res://art/portraits/HairBack/", "prefix": "HairBack", "count": 4, "palette": "Hair"},
+    "Face": {"path": "res://art/portraits/Face/", "prefix": "face", "count": 4, "palette": "Skin"},
+    "Eyes": {"path": "res://art/portraits/Eyes/", "prefix": "eyes", "count": 4, "palette": "Eyes"},
+    "Nose": {"path": "res://art/portraits/Nose/", "prefix": "Nose", "count": 4, "palette": "Skin"},
+    "Mouth": {"path": "res://art/portraits/Mouth/", "prefix": "Mouth", "count": 4, "palette": "Skin"},
+    "Hair": {"path": "res://art/portraits/Hair/", "prefix": "hair", "count": 4, "palette": "Hair"},
+    "Shirt": {"path": "res://art/portraits/Shirt/", "prefix": "Shirt", "count": 4, "palette": "Shirt"}
+  }
+}

--- a/components/portraits/portrait_config.gd
+++ b/components/portraits/portrait_config.gd
@@ -1,0 +1,29 @@
+extends Resource
+class_name PortraitConfig
+
+@export var name: String = ""
+@export var indices: Dictionary = {}
+@export var colors: Dictionary = {}
+@export var seed: int = 0
+
+func to_dict() -> Dictionary:
+    var data: Dictionary = {
+        "name": name,
+        "indices": indices,
+        "colors": {},
+        "seed": seed
+    }
+    for k in colors.keys():
+        data["colors"][k] = colors[k].to_html()
+    return data
+
+static func from_dict(d: Dictionary) -> PortraitConfig:
+    var cfg := PortraitConfig.new()
+    cfg.name = d.get("name", "")
+    cfg.indices = d.get("indices", {})
+    var cols: Dictionary = {}
+    for k in d.get("colors", {}).keys():
+        cols[k] = Color(d["colors"][k])
+    cfg.colors = cols
+    cfg.seed = d.get("seed", 0)
+    return cfg

--- a/components/portraits/portrait_factory.gd
+++ b/components/portraits/portrait_factory.gd
@@ -1,0 +1,125 @@
+extends Node
+class_name PortraitFactory
+
+static var _manifest: Dictionary = {}
+
+static var PALETTES := {
+    "Skin": [
+        Color("3a2f1b"),
+        Color("4c342a"),
+        Color("6b4f33"),
+        Color("8d6b5a"),
+        Color("a6785b"),
+        Color("c09786")
+    ],
+    "Hair": [
+        Color("1b1b1b"),
+        Color("2e1e16"),
+        Color("4a2a1f"),
+        Color("5b3b2e"),
+        Color("673b2f"),
+        Color("7c4b3a")
+    ],
+    "Eyes": [
+        Color("3b2f23"),
+        Color("4a3f2d"),
+        Color("596552"),
+        Color("46533a"),
+        Color("3e403b"),
+        Color("2e312d")
+    ],
+    "Shirt": [
+        Color("556b2f"),
+        Color("2f4f4f"),
+        Color("333333"),
+        Color("1f2a44"),
+        Color("5c4033"),
+        Color("4b5320")
+    ]
+}
+
+static func djb2(s: String) -> int:
+    var hash: int = 5381
+    for i in s.length():
+        hash = ((hash << 5) + hash) + int(s.unicode_at(i))
+    return abs(hash)
+
+static func rng_from_seed(seed: int) -> RandomNumberGenerator:
+    var rng := RandomNumberGenerator.new()
+    rng.seed = seed
+    return rng
+
+static func load_manifest() -> Dictionary:
+    if _manifest.is_empty():
+        var text := FileAccess.get_file_as_string("res://components/portraits/manifest.json")
+        var data = JSON.parse_string(text)
+        if typeof(data) == TYPE_DICTIONARY:
+            _manifest = data
+        else:
+            _manifest = {}
+    return _manifest
+
+static func get_layers_order() -> Array[String]:
+    var manifest := load_manifest()
+    return manifest.get("order", [])
+
+static func get_layer_info(layer: String) -> Dictionary:
+    var manifest := load_manifest()
+    var layers: Dictionary = manifest.get("layers", {})
+    return layers.get(layer, {})
+
+static func get_texture_for(layer: String, index: int) -> Texture2D:
+    var info := get_layer_info(layer)
+    var path: String = info.get("path", "")
+    var prefix: String = info.get("prefix", "")
+    var tex_path := path + prefix + str(index) + ".png"
+    return load(tex_path)
+
+static func random_palette_color(layer: String, rng: RandomNumberGenerator) -> Color:
+    var info := get_layer_info(layer)
+    var palette_name: String = info.get("palette", "")
+    var colors: Array = PALETTES.get(palette_name, [])
+    if colors.is_empty():
+        return Color.WHITE
+    var idx := rng.randi_range(0, colors.size() - 1)
+    return colors[idx]
+
+static func pick_index(layer: String, rng: RandomNumberGenerator) -> int:
+    var info := get_layer_info(layer)
+    var count: int = int(info.get("count", 1))
+    return rng.randi_range(1, count)
+
+static func generate_config_for_name(name: String) -> PortraitConfig:
+    var seed := djb2(name)
+    var rng := rng_from_seed(seed)
+    var indices: Dictionary = {}
+    var colors: Dictionary = {}
+    for layer in get_layers_order():
+        var idx := pick_index(layer, rng)
+        indices[layer] = idx
+        colors[layer] = random_palette_color(layer, rng)
+    var cfg := PortraitConfig.new()
+    cfg.name = name
+    cfg.indices = indices
+    cfg.colors = colors
+    cfg.seed = seed
+    return cfg
+
+static func apply_config_to_view(config: PortraitConfig, view: PortraitView) -> void:
+    for layer in get_layers_order():
+        var idx: int = config.indices.get(layer, 1)
+        var tex := get_texture_for(layer, idx)
+        view.set_layer_texture(layer, tex)
+        var col: Color = config.colors.get(layer, Color.WHITE)
+        view.set_layer_color(layer, col)
+
+static func export_view_to_png(view: PortraitView, out_path: String) -> bool:
+    var viewport := Viewport.new()
+    viewport.disable_3d = true
+    viewport.render_target_clear_mode = Viewport.CLEAR_MODE_ALWAYS
+    viewport.size = view.size
+    var inst := view.duplicate()
+    viewport.add_child(inst)
+    viewport.render_target_update_mode = Viewport.UPDATE_ONCE
+    var img := viewport.get_texture().get_image()
+    return img.save_png(out_path) == OK

--- a/components/portraits/portrait_view.gd
+++ b/components/portraits/portrait_view.gd
@@ -1,0 +1,15 @@
+extends Control
+class_name PortraitView
+
+func get_order() -> Array[String]:
+    return PortraitFactory.get_layers_order()
+
+func set_layer_texture(layer: String, tex: Texture2D) -> void:
+    var node: TextureRect = get_node_or_null(layer)
+    if node:
+        node.texture = tex
+
+func set_layer_color(layer: String, color: Color) -> void:
+    var node: TextureRect = get_node_or_null(layer)
+    if node:
+        node.modulate = color

--- a/components/portraits/portrait_view.tscn
+++ b/components/portraits/portrait_view.tscn
@@ -1,0 +1,49 @@
+[gd_scene format=4]
+
+[ext_resource path="res://components/portraits/portrait_view.gd" type="Script" id=1]
+
+[node name="PortraitView" type="Control"]
+custom_minimum_size = Vector2(512, 512)
+script = ExtResource(1)
+
+[node name="HairBack" type="TextureRect" parent="."]
+anchor_right = 1.0
+anchor_bottom = 1.0
+expand_mode = 1
+stretch_mode = 0
+
+[node name="Face" type="TextureRect" parent="."]
+anchor_right = 1.0
+anchor_bottom = 1.0
+expand_mode = 1
+stretch_mode = 0
+
+[node name="Eyes" type="TextureRect" parent="."]
+anchor_right = 1.0
+anchor_bottom = 1.0
+expand_mode = 1
+stretch_mode = 0
+
+[node name="Nose" type="TextureRect" parent="."]
+anchor_right = 1.0
+anchor_bottom = 1.0
+expand_mode = 1
+stretch_mode = 0
+
+[node name="Mouth" type="TextureRect" parent="."]
+anchor_right = 1.0
+anchor_bottom = 1.0
+expand_mode = 1
+stretch_mode = 0
+
+[node name="Hair" type="TextureRect" parent="."]
+anchor_right = 1.0
+anchor_bottom = 1.0
+expand_mode = 1
+stretch_mode = 0
+
+[node name="Shirt" type="TextureRect" parent="."]
+anchor_right = 1.0
+anchor_bottom = 1.0
+expand_mode = 1
+stretch_mode = 0


### PR DESCRIPTION
## Summary
- add PortraitConfig resource and factory with palettes, manifest-based loading, deterministic djb2 seeding
- add PortraitView and CharacterCreator scenes for layered portrait preview and editing
- include manifest for runtime-safe asset lookup

## Testing
- `gdformat --version` *(fails: command not found)*
- `godot --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a18749a7a4832585d161ec45456e7b