### PR TITLE
feat: add deterministic NPC portraits

### DIFF
--- a/autoloads/db_manager.gd
+++ b/autoloads/db_manager.gd
@@ -44,8 +44,9 @@ const SCHEMA := {
 		"neuroticism": {"data_type": "real"},
 		"mbti": {"data_type": "text"},
 		"zodiac": {"data_type": "text"},
-		"wall_posts": {"data_type": "text"}
-	},
+		"wall_posts": {"data_type": "text"},
+		"portrait_config": {"data_type": "text"}
+},
 	"fumble_relationships": {
 		"npc_id": {"data_type": "int", "primary_key": true},
 		"slot_id": {"data_type": "int", "primary_key": true},
@@ -117,6 +118,8 @@ func save_npc(idx: int, npc: NPC, slot_id: int = SaveManager.current_slot_id):
 	dict["player_pet_names"] = to_json(dict.get("player_pet_names", []))
 	dict["ocean"] = to_json(dict.get("ocean", {}))
 	dict["wall_posts"] = to_json(dict.get("wall_posts", []))
+		var pc = dict.get("portrait_config", null)
+		dict["portrait_config"] = to_json(pc) if pc != null else ""
 	# Profile pic is not natively serializable; see below
 
 	var update_data = dict.duplicate()
@@ -142,6 +145,7 @@ func load_npc(idx: int, slot_id: int = SaveManager.current_slot_id) -> NPC:
 	row["player_pet_names"] = _safe_from_json(row.get("player_pet_names", null), "[]")
 	row["ocean"] = _safe_from_json(row.get("ocean", null), "{}")
 	row["wall_posts"] = _safe_from_json(row.get("wall_posts", null), "[]")
+		row["portrait_config"] = _safe_from_json(row.get("portrait_config", null), "{}")
 	return NPC.from_dict(row)
 
 func get_all_npcs_for_slot(slot_id: int = SaveManager.current_slot_id) -> Array:
@@ -155,6 +159,7 @@ func get_all_npcs_for_slot(slot_id: int = SaveManager.current_slot_id) -> Array:
 		row["player_pet_names"] = _safe_from_json(row.get("player_pet_names", null), "[]")
 		row["ocean"] = _safe_from_json(row.get("ocean", null), "{}")
 		row["wall_posts"] = _safe_from_json(row.get("wall_posts", null), "[]")
+		row["portrait_config"] = _safe_from_json(row.get("portrait_config", null), "{}")
 		out.append(NPC.from_dict(row))
 	return out
 

--- a/autoloads/portrait_cache.gd
+++ b/autoloads/portrait_cache.gd
@@ -28,13 +28,16 @@ func layer_info(layer: String) -> Dictionary:
 	return manifest.get(layer, {})
 
 func get_texture(layer: String, index: int) -> Texture2D:
+	if index <= 0:
+		return null
 	var layer_cache = _texture_cache.get(layer, {})
 	if layer_cache.has(index):
 		return layer_cache[index]
 	var info := layer_info(layer)
 	var textures: Array = info.get("textures", [])
-	if index >= 0 and index < textures.size():
-		var path: String = textures[index]
+	var arr_idx := index - 1
+	if arr_idx >= 0 and arr_idx < textures.size():
+		var path: String = textures[arr_idx]
 		var tex: Texture2D = load(path)
 		if tex != null:
 			if not _texture_cache.has(layer):

--- a/components/npc/npc.gd
+++ b/components/npc/npc.gd
@@ -11,6 +11,7 @@ extends Resource
 
 @export var username: String
 @export var profile_pic: Texture2D
+@export var portrait_config: PortraitConfig
 @export var occupation: String = "Funemployed"
 @export var relationship_status: String = "Single"
 
@@ -147,7 +148,8 @@ func to_dict() -> Dictionary:
 		"mbti": mbti,
 		"zodiac": zodiac,
 		"wall_posts": wall_posts.duplicate(),
-	}
+		"portrait_config": portrait_config.to_dict() if portrait_config != null else null,
+}
 
 static func from_dict(data: Dictionary) -> NPC:
 	var npc = NPC.new()
@@ -194,6 +196,11 @@ static func from_dict(data: Dictionary) -> NPC:
 	npc.neuroticism       = _safe_float(data.get("neuroticism"))
 	npc.mbti              = _safe_string(data.get("mbti"))
 	npc.zodiac            = _safe_string(data.get("zodiac"))
+	var pc_src = data.get("portrait_config")
+	if typeof(pc_src) == TYPE_DICTIONARY and pc_src.size() > 0:
+		npc.portrait_config = PortraitConfig.from_dict(pc_src)
+	else:
+		npc.portrait_config = null
 	_assign_string_array(npc.wall_posts, data.get("wall_posts"), ["hello world"])
 	return npc
 

--- a/components/npc/npc_manager.gd
+++ b/components/npc/npc_manager.gd
@@ -32,6 +32,10 @@ func get_npc_by_index(idx: int) -> NPC:
 	for key in data.keys():
 		npc.set(key, data[key])
 
+	if npc.portrait_config == null:
+		npc.portrait_config = PortraitFactory.ensure_config_for_npc(idx, npc.full_name)
+
+
 	npcs[idx] = npc
 	return npc
 

--- a/resources/portraits/portrait_config.gd
+++ b/resources/portraits/portrait_config.gd
@@ -6,36 +6,32 @@ class_name PortraitConfig
 @export var indices: Dictionary = {}
 @export var colors: Dictionary = {}
 
-func _init() -> void:
-	pass
-
 func to_dict() -> Dictionary:
-	var data: Dictionary = {}
-	data["name"] = name
-	data["seed"] = seed
-	data["indices"] = indices.duplicate(true)
-	var color_copy: Dictionary = {}
-	for key in colors.keys():
-		var value = colors[key]
-		if value is Color:
-			color_copy[key] = value.to_html()
-		else:
-			color_copy[key] = value
-	data["colors"] = color_copy
-	return data
+	var d := {}
+	d["name"] = name
+	d["seed"] = seed
+	d["indices"] = indices.duplicate(true)
+	var cols := {}
+	for k in colors.keys():
+		var c: Color = colors[k]
+		cols[k] = [c.r, c.g, c.b, c.a]
+	d["colors"] = cols
+	return d
 
-static func from_dict(d: Dictionary) -> PortraitConfig:
+static func from_dict(src: Dictionary) -> PortraitConfig:
 	var cfg := PortraitConfig.new()
-	cfg.name = d.get("name", "")
-	cfg.seed = d.get("seed", 0)
-	cfg.indices = d.get("indices", {}).duplicate(true)
-	var color_dict: Dictionary = {}
-	var src_colors: Dictionary = d.get("colors", {})
-	for key in src_colors.keys():
-		var val = src_colors[key]
-		if typeof(val) == TYPE_STRING:
-			color_dict[key] = Color(val)
-		else:
-			color_dict[key] = val
-	cfg.colors = color_dict
+	cfg.name = src.get("name", "")
+	cfg.seed = int(src.get("seed", 0))
+	cfg.indices = src.get("indices", {}).duplicate(true)
+	var col_in: Dictionary = src.get("colors", {})
+	var out := {}
+	for k in col_in.keys():
+		var arr: Array = col_in[k]
+		if typeof(arr) == TYPE_ARRAY and arr.size() >= 3:
+			var a = 1.0
+			if arr.size() >= 4:
+				a = float(arr[3])
+			out[k] = Color(float(arr[0]), float(arr[1]), float(arr[2]), a)
+	cfg.colors = out
 	return cfg
+

--- a/resources/portraits/portrait_factory.gd
+++ b/resources/portraits/portrait_factory.gd
@@ -1,0 +1,58 @@
+class_name PortraitFactory
+
+static func djb2(name: String) -> int:
+	var hash := 5381
+	for i in name.length():
+		hash = ((hash << 5) + hash) + name.unicode_at(i)
+		hash &= 0xFFFFFFFF
+	return hash
+
+static func rng_from_seed(seed: int) -> RandomNumberGenerator:
+	var rng := RandomNumberGenerator.new()
+	rng.seed = seed
+	return rng
+
+static func generate_config_for_name(full_name: String) -> PortraitConfig:
+	var seed = djb2(full_name)
+	var rng = rng_from_seed(seed)
+	var cfg := PortraitConfig.new()
+	cfg.name = full_name
+	cfg.seed = seed
+	for layer in PortraitCache.layers_order():
+		var info := PortraitCache.layer_info(layer)
+		var count := (info.get("textures", []) as Array).size()
+		var idx := 0
+		match layer:
+		"face":
+			if count > 0:
+				idx = rng.randi_range(1, count)
+		"hair_back":
+			if rng.randf() < 0.4 and count > 0:
+				idx = rng.randi_range(1, count)
+		"hair":
+			if rng.randf() < 0.95 and count > 0:
+				idx = rng.randi_range(1, count)
+		_:
+			if rng.randf() >= 0.001 and count > 0:
+				idx = rng.randi_range(1, count)
+		cfg.indices[layer] = idx
+		if idx > 0:
+			cfg.colors[layer] = Color(rng.randf(), rng.randf(), rng.randf(), 1.0)
+	return cfg
+
+static func ensure_config_for_npc(idx: int, full_name: String) -> PortraitConfig:
+	var slot_id = SaveManager.current_slot_id
+	var rows = DBManager.db.select_rows("npc", "id = %d AND slot_id = %d" % [idx, slot_id], ["portrait_config"])
+	if rows.size() > 0:
+		var raw = rows[0].get("portrait_config", null)
+		var parsed = raw if typeof(raw) == TYPE_DICTIONARY else DBManager.from_json(str(raw))
+		if typeof(parsed) == TYPE_DICTIONARY and parsed.size() > 0:
+			return PortraitConfig.from_dict(parsed)
+		var cfg := generate_config_for_name(full_name)
+		DBManager.db.update_rows("npc", "id = %d AND slot_id = %d" % [idx, slot_id], {"portrait_config": to_json(cfg.to_dict())})
+		return cfg
+	else:
+		var cfg := generate_config_for_name(full_name)
+		DBManager.db.insert_row("npc", {"id": idx, "slot_id": slot_id, "full_name": full_name, "portrait_config": to_json(cfg.to_dict())})
+		return cfg
+


### PR DESCRIPTION
## Summary
- add PortraitConfig resource and factory for seeded portrait generation
- persist portrait_config JSON in NPC table and load on demand
- ensure portrait indices allow blank layer and are cached deterministically

## Testing
- `godot --headless --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a197dbd1a48325b4fc82434ef162e9