### PR TITLE
Use portrait config for NPC images in Fumble

### DIFF
--- a/components/apps/fumble/fumble_battle/battle_ui.gd
+++ b/components/apps/fumble/fumble_battle/battle_ui.gd
@@ -21,7 +21,7 @@ var block_warning_active: bool = false
 @onready var name_label: Label = %NameLabel
 
 @onready var npc_type_label: Label = %NPCTypeLabel
-@onready var npc_profile_pic: TextureRect = %NPCProfilePic
+@onready var npc_portrait: PortraitView = %NPCProfilePic
 @onready var npc_attractiveness_label: Label = %NPCAttractivenessLabel
 @onready var npc_name_label: Label = %NPCNameLabel
 
@@ -211,7 +211,8 @@ func _update_profiles():
 	name_label.text = PlayerManager.get_var("name", "You")
 	
 	# NPC info
-	npc_profile_pic.texture = npc.profile_pic if npc.profile_pic else preload("res://assets/prof_pics/silhouette.png")
+        if npc.portrait_config != null:
+                npc_portrait.apply_config(npc.portrait_config)
 	npc_attractiveness_label.text = "🔥 %.1f/10" % (float(npc.attractiveness) / 10.0)
 	npc_name_label.text = npc.full_name
 	npc_type_label.text = npc.chat_battle_type

--- a/components/apps/fumble/fumble_battle/battle_ui.tscn
+++ b/components/apps/fumble/fumble_battle/battle_ui.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=37 format=3 uid="uid://cel7rmg2pea12"]
+[gd_scene load_steps=38 format=3 uid="uid://cel7rmg2pea12"]
 
 [ext_resource type="Script" uid="uid://b4cmpyad34a6u" path="res://components/apps/fumble/fumble_battle/battle_ui.gd" id="1_ctqjn"]
 [ext_resource type="Texture2D" uid="uid://pld574giprix" path="res://assets/prof_pics/silhouette.png" id="1_vooct"]
@@ -20,6 +20,7 @@
 [ext_resource type="Texture2D" uid="uid://dnvlxo5xu0ypo" path="res://assets/emojis/smiling_eyes_blush_twemoji_x72_1f60a.png" id="11_7gtst"]
 [ext_resource type="Texture2D" uid="uid://8icgbuxae2a8" path="res://assets/emojis/grimace_twemoji_x72_1f62c.png" id="12_mq0jq"]
 [ext_resource type="FontFile" uid="uid://cb6nxrsvpxlk1" path="res://assets/fonts/LuckiestGuy.ttf" id="20_7gtst"]
+[ext_resource type="PackedScene" uid="uid://portrait_view" path="res://components/portrait/portrait_view.tscn" id="13_pv"]
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_6oduf"]
 border_color = Color(0, 0, 0, 1)
@@ -392,12 +393,11 @@ theme_override_constants/margin_bottom = 10
 layout_mode = 2
 size_flags_vertical = 4
 
-[node name="NPCProfilePic" type="TextureRect" parent="MarginContainer/VBoxContainer/HBoxContainer/NPCMarginContainer/VBoxContainer4/PanelContainer2/MarginContainer/VBoxContainer"]
+[node name="NPCProfilePic" parent="MarginContainer/VBoxContainer/HBoxContainer/NPCMarginContainer/VBoxContainer4/PanelContainer2/MarginContainer/VBoxContainer" instance=ExtResource("13_pv")]
 unique_name_in_owner = true
 custom_minimum_size = Vector2(64, 64)
 layout_mode = 2
 size_flags_horizontal = 4
-texture = ExtResource("1_vooct")
 
 [node name="NPCAttractivenessLabel" type="Label" parent="MarginContainer/VBoxContainer/HBoxContainer/NPCMarginContainer/VBoxContainer4/PanelContainer2/MarginContainer/VBoxContainer/NPCProfilePic"]
 unique_name_in_owner = true

--- a/components/apps/fumble/fumble_profile.gd
+++ b/components/apps/fumble/fumble_profile.gd
@@ -2,7 +2,7 @@ class_name FumbleProfileUI
 extends PanelContainer
 
 
-@onready var profile_pic: TextureRect = %ProfilePic
+@onready var portrait: PortraitView = %ProfilePic
 @onready var attractiveness_label: Label = %AttractivenessLabel
 @onready var name_label: Label = %NameLabel
 
@@ -19,7 +19,8 @@ extends PanelContainer
 
 
 func load_npc(npc: NPC) -> void:
-	# Core info
+       portrait.apply_config(npc.portrait_config)
+       # Core info
 	name_label.text = npc.full_name
 	attractiveness_label.text = "%0.1f/10" % (float(npc.attractiveness) / 10.0)
 	type_label.text = str(npc.chat_battle_type)

--- a/components/apps/fumble/fumble_profile_ui.tscn
+++ b/components/apps/fumble/fumble_profile_ui.tscn
@@ -1,9 +1,9 @@
 [gd_scene load_steps=7 format=3 uid="uid://cwin011rx52n7"]
 
 [ext_resource type="Theme" uid="uid://cesgvqexxaqev" path="res://assets/windows_95_theme.tres" id="1_a0w3w"]
-[ext_resource type="Texture2D" uid="uid://pld574giprix" path="res://assets/prof_pics/silhouette.png" id="1_m5oeo"]
 [ext_resource type="Script" uid="uid://ck1rp36ofvy52" path="res://components/apps/fumble/fumble_profile.gd" id="1_r7irv"]
 [ext_resource type="PackedScene" uid="uid://bo7jj5gh57d4n" path="res://components/greek_stats_ui.tscn" id="4_5ticg"]
+[ext_resource type="PackedScene" uid="uid://portrait_view" path="res://components/portrait/portrait_view.tscn" id="5_pv"]
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_5ticg"]
 bg_color = Color(0.968627, 0.968627, 1, 1)
@@ -56,11 +56,10 @@ size_flags_horizontal = 3
 size_flags_vertical = 3
 theme_override_constants/separation = 8
 
-[node name="ProfilePic" type="TextureRect" parent="ProfileMarginContainer/ScrollContainer/VBoxContainer"]
+[node name="ProfilePic" parent="ProfileMarginContainer/ScrollContainer/VBoxContainer" instance=ExtResource("5_pv")]
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 4
-texture = ExtResource("1_m5oeo")
 
 [node name="AttractivenessLabel" type="Label" parent="ProfileMarginContainer/ScrollContainer/VBoxContainer/ProfilePic"]
 unique_name_in_owner = true

--- a/components/apps/fumble/match_button.gd
+++ b/components/apps/fumble/match_button.gd
@@ -3,7 +3,7 @@ class_name MatchButton
 
 signal match_pressed(npc, npc_idx)
 
-@onready var profile_pic: TextureRect = %ProfilePic
+@onready var portrait: PortraitView = %ProfilePic
 @onready var name_label: Label = %NameLabel
 @onready var attractiveness_label: Label = %AttractivenessLabel
 @onready var type_label: Label = %TypeLabel
@@ -17,11 +17,9 @@ var npc_idx: int
 func set_profile(npc_ref, idx):
 	npc = npc_ref
 	npc_idx = idx
-	# Set picture
-	if npc.profile_pic and typeof(npc.profile_pic) == TYPE_OBJECT:
-		profile_pic.texture = npc.profile_pic
-	else:
-		profile_pic.texture = preload("res://assets/prof_pics/silhouette.png") # fallback
+        # Set portrait
+        if npc.portrait_config != null:
+                portrait.apply_config(npc.portrait_config)
 	# Set name
 	name_label.text = npc.full_name
 	type_label.text = npc.chat_battle_type

--- a/components/apps/fumble/match_button.tscn
+++ b/components/apps/fumble/match_button.tscn
@@ -1,7 +1,8 @@
-[gd_scene load_steps=3 format=3 uid="uid://3e434irx0gng"]
+[gd_scene load_steps=4 format=3 uid="uid://3e434irx0gng"]
 
 [ext_resource type="Texture2D" uid="uid://pld574giprix" path="res://assets/prof_pics/silhouette.png" id="1_jare7"]
 [ext_resource type="Script" uid="uid://fq44llbp4oi0" path="res://components/apps/fumble/match_button.gd" id="2_j67un"]
+[ext_resource type="PackedScene" uid="uid://portrait_view" path="res://components/portrait/portrait_view.tscn" id="3_dvkw6"]
 
 [node name="MatchButton" type="Button"]
 custom_minimum_size = Vector2(128, 128)
@@ -22,7 +23,7 @@ theme_override_constants/margin_top = 15
 theme_override_constants/margin_right = 5
 theme_override_constants/margin_bottom = 5
 
-[node name="ProfilePic" type="TextureRect" parent="MarginContainer"]
+[node name="ProfilePic" parent="MarginContainer" instance=ExtResource("3_dvkw6")]
 unique_name_in_owner = true
 layout_mode = 2
 


### PR DESCRIPTION
## Summary
- Render NPC portraits using stored `portrait_config` instead of `profile_pic`
- Swap Fumble match, profile, and battle UI scenes to use `PortraitView` nodes

## Testing
- `godot --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a1fc809c188325b99f2ada4e7e1fe4