### PR TITLE
Scale up Fumble NPC portraits

### DIFF
--- a/components/apps/fumble/fumble_battle/battle_ui.tscn
+++ b/components/apps/fumble/fumble_battle/battle_ui.tscn
@@ -395,7 +395,7 @@ size_flags_vertical = 4
 
 [node name="NPCProfilePic" parent="MarginContainer/VBoxContainer/HBoxContainer/NPCMarginContainer/VBoxContainer4/PanelContainer2/MarginContainer/VBoxContainer" instance=ExtResource("13_pv")]
 unique_name_in_owner = true
-custom_minimum_size = Vector2(64, 64)
+custom_minimum_size = Vector2(128, 128)
 layout_mode = 2
 size_flags_horizontal = 4
 

--- a/components/apps/fumble/fumble_profile_ui.tscn
+++ b/components/apps/fumble/fumble_profile_ui.tscn
@@ -58,6 +58,7 @@ theme_override_constants/separation = 8
 
 [node name="ProfilePic" parent="ProfileMarginContainer/ScrollContainer/VBoxContainer" instance=ExtResource("5_pv")]
 unique_name_in_owner = true
+custom_minimum_size = Vector2(128, 128)
 layout_mode = 2
 size_flags_horizontal = 4
 

--- a/components/apps/fumble/match_button.tscn
+++ b/components/apps/fumble/match_button.tscn
@@ -25,6 +25,7 @@ theme_override_constants/margin_bottom = 5
 
 [node name="ProfilePic" parent="MarginContainer" instance=ExtResource("3_dvkw6")]
 unique_name_in_owner = true
+custom_minimum_size = Vector2(128, 128)
 layout_mode = 2
 
 [node name="AttractivenessLabel" type="Label" parent="MarginContainer"]

--- a/components/portrait/portrait_view.tscn
+++ b/components/portrait/portrait_view.tscn
@@ -9,21 +9,49 @@ script = ExtResource("1")
 
 [node name="shirt" type="TextureRect" parent="."]
 layout_mode = 2
+size_flags_horizontal = 4
+size_flags_vertical = 4
+expand_mode = 3
+stretch_mode = 5
 
 [node name="hair_back" type="TextureRect" parent="."]
 layout_mode = 2
+size_flags_horizontal = 4
+size_flags_vertical = 4
+expand_mode = 3
+stretch_mode = 5
 
 [node name="face" type="TextureRect" parent="."]
 layout_mode = 2
+size_flags_horizontal = 4
+size_flags_vertical = 4
+expand_mode = 3
+stretch_mode = 5
 
 [node name="eyes" type="TextureRect" parent="."]
 layout_mode = 2
+size_flags_horizontal = 4
+size_flags_vertical = 4
+expand_mode = 3
+stretch_mode = 5
 
 [node name="nose" type="TextureRect" parent="."]
 layout_mode = 2
+size_flags_horizontal = 4
+size_flags_vertical = 4
+expand_mode = 3
+stretch_mode = 5
 
 [node name="mouth" type="TextureRect" parent="."]
 layout_mode = 2
+size_flags_horizontal = 4
+size_flags_vertical = 4
+expand_mode = 3
+stretch_mode = 5
 
 [node name="hair" type="TextureRect" parent="."]
 layout_mode = 2
+size_flags_horizontal = 4
+size_flags_vertical = 4
+expand_mode = 3
+stretch_mode = 5


### PR DESCRIPTION
## Summary
- Double size of NPC portraits throughout Fumble
- Adjust match buttons, profile view, and battle UI to use larger portrait views
- Allow portrait textures to expand so actual images grow, not just their containers

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a1fffe542883258781498ea62945fe