### PR TITLE
Sync hair and hairback colors in portraits

### DIFF
--- a/components/portrait/portrait_creator.gd
+++ b/components/portrait/portrait_creator.gd
@@ -52,38 +52,68 @@ func _on_index_changed(layer: String, idx: int) -> void:
 	preview.apply_config(config)
 
 func _on_color_changed(layer: String, idx: int) -> void:
-	var info := PortraitCache.layer_info(layer)
-	var colors_arr: Array = info.get("colors", [])
-	if idx >= 0 and idx < colors_arr.size():
-		config.colors[layer] = Color(colors_arr[idx])
-	preview.apply_config(config)
+        var info := PortraitCache.layer_info(layer)
+        var colors_arr: Array = info.get("colors", [])
+        if idx >= 0 and idx < colors_arr.size():
+                var chosen := Color(colors_arr[idx])
+                if layer == "hair" or layer == "hair_back":
+                        config.colors["hair"] = chosen
+                        config.colors["hair_back"] = chosen
+                        var other := "hair_back" if layer == "hair" else "hair"
+                        var btns = layer_controls.get(other, {})
+                        if btns.has("color") and btns["color"] is OptionButton:
+                                btns["color"].select(idx)
+                else:
+                        config.colors[layer] = chosen
+        preview.apply_config(config)
 
 func _on_name_changed(new_text: String) -> void:
 	config.name = new_text
 
 func _on_randomize_pressed() -> void:
-	var rng := RandomNumberGenerator.new()
-	config.seed = rng.randi()
-	rng.seed = config.seed
-	for layer in PortraitCache.layers_order():
-		var info := PortraitCache.layer_info(layer)
-		var tex_arr: Array = info.get("textures", [])
-		var max_index = tex_arr.size()
-		var idx = 0
-		if max_index > 0:
-			idx = rng.randi_range(0, max_index - 1)
-		config.indices[layer] = idx
-		var btns = layer_controls.get(layer, {})
-		if btns.has("index") and btns["index"] is OptionButton:
-			btns["index"].select(idx)
-		var colors_arr: Array = info.get("colors", [])
-		var color_idx = 0
-		if colors_arr.size() > 0:
-			color_idx = rng.randi_range(0, colors_arr.size() - 1)
-			config.colors[layer] = Color(colors_arr[color_idx])
-			if btns.has("color") and btns["color"] is OptionButton:
-				btns["color"].select(color_idx)
-	preview.apply_config(config)
+        var rng := RandomNumberGenerator.new()
+        config.seed = rng.randi()
+        rng.seed = config.seed
+        var hair_color_idx := 0
+        var hair_color := Color.WHITE
+        for layer in PortraitCache.layers_order():
+                var info := PortraitCache.layer_info(layer)
+                var tex_arr: Array = info.get("textures", [])
+                var max_index = tex_arr.size()
+                var idx = 0
+                if max_index > 0:
+                        idx = rng.randi_range(0, max_index - 1)
+                config.indices[layer] = idx
+                var btns = layer_controls.get(layer, {})
+                if btns.has("index") and btns["index"] is OptionButton:
+                        btns["index"].select(idx)
+                var colors_arr: Array = info.get("colors", [])
+                var color_idx = 0
+                if colors_arr.size() > 0:
+                        color_idx = rng.randi_range(0, colors_arr.size() - 1)
+                if layer == "hair":
+                        if colors_arr.size() > 0:
+                                hair_color_idx = color_idx
+                                hair_color = Color(colors_arr[color_idx])
+                                config.colors["hair"] = hair_color
+                                if btns.has("color") and btns["color"] is OptionButton:
+                                        btns["color"].select(color_idx)
+                elif layer == "hair_back":
+                        if colors_arr.size() > 0:
+                                config.colors["hair_back"] = Color(colors_arr[color_idx])
+                                if btns.has("color") and btns["color"] is OptionButton:
+                                        btns["color"].select(color_idx)
+                else:
+                        if colors_arr.size() > 0:
+                                config.colors[layer] = Color(colors_arr[color_idx])
+                                if btns.has("color") and btns["color"] is OptionButton:
+                                        btns["color"].select(color_idx)
+        if config.indices.get("hair", 0) > 0:
+                config.colors["hair_back"] = hair_color
+                var hb_btns = layer_controls.get("hair_back", {})
+                if hb_btns.has("color") and hb_btns["color"] is OptionButton:
+                        hb_btns["color"].select(hair_color_idx)
+        preview.apply_config(config)
 
 func _on_apply_pressed() -> void:
 	emit_signal("applied", config)

--- a/components/portrait/portrait_view.gd
+++ b/components/portrait/portrait_view.gd
@@ -5,15 +5,20 @@ func _ready() -> void:
 	pass
 
 func apply_config(cfg: PortraitConfig) -> void:
-	for layer in PortraitCache.layers_order():
-		var rect: TextureRect = get_node_or_null(layer)
-		if rect == null:
-			continue
-		var idx: int = cfg.indices.get(layer, 0)
-		var tex := PortraitCache.get_texture(layer, idx)
-		rect.texture = tex
-		var col_val = cfg.colors.get(layer, Color.WHITE)
-		if col_val is String:
-			rect.modulate = Color(col_val)
-		else:
-			rect.modulate = col_val
+        for layer in PortraitCache.layers_order():
+                var rect: TextureRect = get_node_or_null(layer)
+                if rect == null:
+                        continue
+                var idx: int = cfg.indices.get(layer, 0)
+                var tex := PortraitCache.get_texture(layer, idx)
+                rect.texture = tex
+                var col_val = cfg.colors.get(layer, Color.WHITE)
+                if col_val is String:
+                        rect.modulate = Color(col_val)
+                else:
+                        rect.modulate = col_val
+        if cfg.indices.get("hair", 0) > 0 and cfg.indices.get("hair_back", 0) > 0:
+                var hair_rect: TextureRect = get_node_or_null("hair")
+                var hair_back_rect: TextureRect = get_node_or_null("hair_back")
+                if hair_rect != null and hair_back_rect != null:
+                        hair_back_rect.modulate = hair_rect.modulate

--- a/resources/portraits/portrait_factory.gd
+++ b/resources/portraits/portrait_factory.gd
@@ -19,32 +19,42 @@ static func generate_config_for_name(full_name: String) -> PortraitConfig:
 	cfg.name = full_name
 	cfg.seed = seed
 
-	for layer in PortraitCache.layers_order():
-		var info := PortraitCache.layer_info(layer)
-		var textures := info.get("textures", []) as Array
-		var count := textures.size()
-		var idx := 0
+        for layer in PortraitCache.layers_order():
+                var info := PortraitCache.layer_info(layer)
+                var textures := info.get("textures", []) as Array
+                var count := textures.size()
+                var idx := 0
 
-		match layer:
-			"face":
-				if count > 0:
-					idx = rng.randi_range(1, count)
-			"hair_back":
-				if count > 0 and rng.randf() < 0.4:
-					idx = rng.randi_range(1, count)
-			"hair":
-				if count > 0 and rng.randf() < 0.95:
-					idx = rng.randi_range(1, count)
-			_:
-				# Eyes/Nose/Mouth/Shirt: 0.1% chance to be missing
-				if count > 0 and rng.randf() >= 0.001:
-					idx = rng.randi_range(1, count)
+                match layer:
+                        "face":
+                                if count > 0:
+                                        idx = rng.randi_range(1, count)
+                        "hair_back":
+                                if count > 0 and rng.randf() < 0.4:
+                                        idx = rng.randi_range(1, count)
+                        "hair":
+                                if count > 0 and rng.randf() < 0.95:
+                                        idx = rng.randi_range(1, count)
+                        _:
+                                # Eyes/Nose/Mouth/Shirt: 0.1% chance to be missing
+                                if count > 0 and rng.randf() >= 0.001:
+                                        idx = rng.randi_range(1, count)
 
-		cfg.indices[layer] = idx
-		if idx > 0:
-			cfg.colors[layer] = Color(rng.randf(), rng.randf(), rng.randf(), 1.0)
+                cfg.indices[layer] = idx
+                if idx > 0 and layer != "hair" and layer != "hair_back":
+                        cfg.colors[layer] = Color(rng.randf(), rng.randf(), rng.randf(), 1.0)
 
-	return cfg
+        var hair_idx = cfg.indices.get("hair", 0)
+        var hair_back_idx = cfg.indices.get("hair_back", 0)
+        if hair_idx > 0:
+                var col = Color(rng.randf(), rng.randf(), rng.randf(), 1.0)
+                cfg.colors["hair"] = col
+                if hair_back_idx > 0:
+                        cfg.colors["hair_back"] = col
+        elif hair_back_idx > 0:
+                cfg.colors["hair_back"] = Color(rng.randf(), rng.randf(), rng.randf(), 1.0)
+
+        return cfg
 
 static func ensure_config_for_npc(idx: int, full_name: String) -> PortraitConfig:
 	var slot_id := SaveManager.current_slot_id


### PR DESCRIPTION
## Summary
- Ensure portrait generation assigns hair_back the same color as hair
- Keep hair and hair_back color selectors synchronized in portrait creator UI
- Force portrait view to apply hair color to hair_back when both layers are present

## Testing
- `gdformat resources/portraits/portrait_factory.gd components/portrait/portrait_creator.gd components/portrait/portrait_view.gd` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68a201d48b5483258a8abb461c06c2b1