### PR TITLE
Scale portrait textures to crisp 2×

### DIFF
--- a/components/portrait/portrait_view.gd
+++ b/components/portrait/portrait_view.gd
@@ -1,19 +1,30 @@
-extends Control
 class_name PortraitView
+extends Control
 
 func _ready() -> void:
 	pass
 
 func apply_config(cfg: PortraitConfig) -> void:
-	for layer in PortraitCache.layers_order():
-		var rect: TextureRect = get_node_or_null(layer)
-		if rect == null:
-			continue
-		var idx: int = cfg.indices.get(layer, 0)
-		var tex := PortraitCache.get_texture(layer, idx)
-		rect.texture = tex
-		var col_val = cfg.colors.get(layer, Color.WHITE)
-		if col_val is String:
-			rect.modulate = Color(col_val)
-		else:
-			rect.modulate = col_val
+        for layer in PortraitCache.layers_order():
+                var rect: TextureRect = get_node_or_null(layer)
+                if rect == null:
+                        continue
+                var idx: int = cfg.indices.get(layer, 0)
+                var tex := PortraitCache.get_texture(layer, idx)
+                rect.texture = tex
+
+                # Ensure crisp pixel-art rendering and scale to 2× the source size.
+                # custom_minimum_size keeps Containers from shrinking the rect.
+                # A project-wide default for NEAREST filtering can be set under
+                # Rendering → Textures → Default Texture Filter.
+                rect.texture_filter = CanvasItem.TEXTURE_FILTER_NEAREST
+                rect.stretch_mode = TextureRect.STRETCH_SCALE
+                var scaled_size: Vector2 = tex.get_size() * 2
+                rect.custom_minimum_size = scaled_size
+                rect.size = scaled_size
+
+                var col_val = cfg.colors.get(layer, Color.WHITE)
+                if col_val is String:
+                        rect.modulate = Color(col_val)
+                else:
+                        rect.modulate = col_val


### PR DESCRIPTION
## Summary
- Ensure each portrait layer uses NEAREST filtering and STRETCH_SCALE
- Scale layers to 2× their native size via `custom_minimum_size` and `size` so containers can't shrink them
- Document option for global NEAREST filtering in project settings

## Testing
- `gdlint components/portrait/portrait_view.gd`
- `godot --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a20b2af9ec83258a1ce25a4ddce87b