### PR TITLE
feat: rework portrait creator

### DIFF
--- a/components/portrait/portrait_creator.gd
+++ b/components/portrait/portrait_creator.gd
@@ -9,15 +9,22 @@ var layer_controls: Dictionary = {}
 @onready var preview: PortraitView = %Preview
 @onready var layers_container: VBoxContainer = %Layers
 @onready var name_edit: LineEdit = %NameEdit
+@onready var generate_button: Button = %Generate
 @onready var randomize_button: Button = %Randomize
 @onready var apply_button: Button = %Apply
 
+const PortraitFactory = preload("res://resources/portraits/portrait_factory.gd")
+
+
 func _ready() -> void:
 	_setup_layers()
+	_sync_ui_with_config()
 	name_edit.text_changed.connect(_on_name_changed)
+	generate_button.pressed.connect(_on_generate_pressed)
 	randomize_button.pressed.connect(_on_randomize_pressed)
 	apply_button.pressed.connect(_on_apply_pressed)
 	preview.apply_config(config)
+
 
 func _setup_layers() -> void:
 	for layer in PortraitCache.layers_order():
@@ -36,84 +43,62 @@ func _setup_layers() -> void:
 			index_btn.add_item(str(i + 1), i)
 		index_btn.item_selected.connect(_on_index_changed.bind(layer))
 		row.add_child(index_btn)
-		var color_btn := OptionButton.new()
+		var color_btn := ColorPickerButton.new()
 		color_btn.name = "Color"
-		var colors_arr: Array = info.get("colors", [])
-		for i in range(colors_arr.size()):
-			var cstr = colors_arr[i]
-			color_btn.add_item(cstr, i)
-		color_btn.item_selected.connect(_on_color_changed.bind(layer))
+		color_btn.color_changed.connect(_on_color_changed.bind(layer))
 		row.add_child(color_btn)
 		layers_container.add_child(row)
 		layer_controls[layer] = {"index": index_btn, "color": color_btn}
+
 
 func _on_index_changed(layer: String, idx: int) -> void:
 	config.indices[layer] = idx
 	preview.apply_config(config)
 
-func _on_color_changed(layer: String, idx: int) -> void:
-	var info := PortraitCache.layer_info(layer)
-	var colors_arr: Array = info.get("colors", [])
-	if idx >= 0 and idx < colors_arr.size():
-			var chosen := Color(colors_arr[idx])
-			if layer == "hair" or layer == "hair_back":
-					config.colors["hair"] = chosen
-					config.colors["hair_back"] = chosen
-					var other := "hair_back" if layer == "hair" else "hair"
-					var btns = layer_controls.get(other, {})
-					if btns.has("color") and btns["color"] is OptionButton:
-							btns["color"].select(idx)
-			else:
-					config.colors[layer] = chosen
+
+func _on_color_changed(layer: String, color: Color) -> void:
+	if layer == "hair" or layer == "hair_back":
+		config.colors["hair"] = color
+		config.colors["hair_back"] = color
+		var other := "hair_back" if layer == "hair" else "hair"
+		var btns = layer_controls.get(other, {})
+		if btns.has("color") and btns["color"] is ColorPickerButton:
+			btns["color"].color = color
+	else:
+		config.colors[layer] = color
 	preview.apply_config(config)
+
 
 func _on_name_changed(new_text: String) -> void:
 	config.name = new_text
 
+
 func _on_randomize_pressed() -> void:
-		var rng := RandomNumberGenerator.new()
-		config.seed = rng.randi()
-		rng.seed = config.seed
-		var hair_color_idx := 0
-		var hair_color := Color.WHITE
-		for layer in PortraitCache.layers_order():
-				var info := PortraitCache.layer_info(layer)
-				var tex_arr: Array = info.get("textures", [])
-				var max_index = tex_arr.size()
-				var idx = 0
-				if max_index > 0:
-						idx = rng.randi_range(0, max_index - 1)
-				config.indices[layer] = idx
-				var btns = layer_controls.get(layer, {})
-				if btns.has("index") and btns["index"] is OptionButton:
-						btns["index"].select(idx)
-				var colors_arr: Array = info.get("colors", [])
-				var color_idx = 0
-				if colors_arr.size() > 0:
-						color_idx = rng.randi_range(0, colors_arr.size() - 1)
-				if layer == "hair":
-						if colors_arr.size() > 0:
-								hair_color_idx = color_idx
-								hair_color = Color(colors_arr[color_idx])
-								config.colors["hair"] = hair_color
-								if btns.has("color") and btns["color"] is OptionButton:
-										btns["color"].select(color_idx)
-				elif layer == "hair_back":
-						if colors_arr.size() > 0:
-								config.colors["hair_back"] = Color(colors_arr[color_idx])
-								if btns.has("color") and btns["color"] is OptionButton:
-										btns["color"].select(color_idx)
-				else:
-						if colors_arr.size() > 0:
-								config.colors[layer] = Color(colors_arr[color_idx])
-								if btns.has("color") and btns["color"] is OptionButton:
-										btns["color"].select(color_idx)
-		if config.indices.get("hair", 0) > 0:
-				config.colors["hair_back"] = hair_color
-				var hb_btns = layer_controls.get("hair_back", {})
-				if hb_btns.has("color") and hb_btns["color"] is OptionButton:
-						hb_btns["color"].select(hair_color_idx)
-		preview.apply_config(config)
+	var rng := RandomNumberGenerator.new()
+	config = PortraitFactory.generate_config_for_name(str(rng.randi()))
+	config.name = name_edit.text
+	_sync_ui_with_config()
+	preview.apply_config(config)
+
+
+func _on_generate_pressed() -> void:
+	config = PortraitFactory.generate_config_for_name(name_edit.text)
+	_sync_ui_with_config()
+	preview.apply_config(config)
+
 
 func _on_apply_pressed() -> void:
 	emit_signal("applied", config)
+
+
+func _sync_ui_with_config() -> void:
+	for layer in PortraitCache.layers_order():
+		var idx := config.indices.get(layer, 0)
+		var btns = layer_controls.get(layer, {})
+		if btns.has("index") and btns["index"] is OptionButton:
+			btns["index"].select(idx)
+		var col := config.colors.get(layer, Color.WHITE)
+		if layer == "hair_back":
+			col = config.colors.get("hair_back", config.colors.get("hair", Color.WHITE))
+		if btns.has("color") and btns["color"] is ColorPickerButton:
+			btns["color"].color = col

--- a/components/portrait/portrait_creator.tscn
+++ b/components/portrait/portrait_creator.tscn
@@ -21,9 +21,17 @@ anchor_right = 1.0
 offset_bottom = 67.0
 grow_horizontal = 2
 
-[node name="NameEdit" type="LineEdit" parent="VBox"]
+[node name="NameRow" type="HBoxContainer" parent="VBox"]
+layout_mode = 2
+
+[node name="NameEdit" type="LineEdit" parent="VBox/NameRow"]
 unique_name_in_owner = true
 layout_mode = 2
+
+[node name="Generate" type="Button" parent="VBox/NameRow"]
+unique_name_in_owner = true
+layout_mode = 2
+text = "Generate Portrait"
 
 [node name="Preview" parent="VBox" instance=ExtResource("2")]
 unique_name_in_owner = true


### PR DESCRIPTION
## Summary
- add generate portrait button based on name
- replace palette options with color pickers
- randomize and generate portraits using PortraitFactory

## Testing
- `gdformat components/portrait/portrait_creator.gd`
- `godot3 --headless --quit` *(fails: project requires Godot 4)*

------
https://chatgpt.com/codex/tasks/task_e_68a217d4c478832590c87a333d0e1cbb