### PR TITLE
feat: add upgrade cooldowns

### DIFF
--- a/autoloads/upgrade_manager.gd
+++ b/autoloads/upgrade_manager.gd
@@ -23,10 +23,11 @@ signal levels_changed ## Emitted when levels are loaded or reset
 
 var upgrades: Dictionary = {}  # id -> upgrade data
 var player_levels: Dictionary = {}  # id -> purchased count
+var cooldowns: Dictionary = {}  # id -> {"start": int, "base": float}
 
 const EXPECTED_KEYS := [
-	"id", "name", "description", "effects", "systems", "dependencies",
-	"max_level", "repeatable", "cost_per_level", "scale_by_formula", "cost_formula"
+        "id", "name", "description", "effects", "systems", "dependencies",
+        "max_level", "repeatable", "cooldown", "cost_per_level", "scale_by_formula", "cost_formula"
 ]
 
 func _ready() -> void:
@@ -100,8 +101,10 @@ func _validate_upgrade(data: Dictionary, file_path: String) -> bool:
 		if typeof(formula) != TYPE_STRING and typeof(formula) != TYPE_DICTIONARY:
 			push_error("UpgradeManager: cost_formula for %s must be String or Dictionary" % id)
 
-	if not data.has("repeatable"):
-		data["repeatable"] = true
+        if not data.has("repeatable"):
+                data["repeatable"] = true
+        if not data.has("cooldown"):
+                data["cooldown"] = -1
 
 	return true
 
@@ -266,14 +269,16 @@ func _deduct_currency(currency: String, amount: float) -> bool:
 		"click",
 		Color.YELLOW
 	)
-	return true
+        return true
 
 func can_purchase(id: String) -> bool:
-	if is_locked(id):
-		return false
-	var max := max_level(id)
-	if max != -1 and get_level(id) >= max:
-		return false
+        if is_locked(id):
+                return false
+        if get_cooldown_remaining(id) > 0:
+                return false
+        var max := max_level(id)
+        if max != -1 and get_level(id) >= max:
+                return false
 	var cost := get_cost_for_next_level(id)
 	for currency in cost.keys():
 		var amount: float = cost[currency]
@@ -297,24 +302,55 @@ func purchase(id: String) -> bool:
 	if upgrade == null:
 		return false
 	var cost := get_cost_for_next_level(id)
-	for currency in cost.keys():
-		if not _deduct_currency(currency, cost[currency]):
-			return false
-	var level := get_level(id) + 1
-	player_levels[id] = level
-	print("UpgradeManager.purchase: emitting upgrade_purchased for", id, "level", level)
-	upgrade_purchased.emit(id, level)
-	return true
+        for currency in cost.keys():
+                if not _deduct_currency(currency, cost[currency]):
+                        return false
+        var level := get_level(id) + 1
+        player_levels[id] = level
+        var cd = float(upgrade.get("cooldown", -1))
+        if cd > 0:
+                cooldowns[id] = {"start": TimeManager.total_minutes_elapsed, "base": cd}
+        elif cooldowns.has(id):
+                cooldowns.erase(id)
+        print("UpgradeManager.purchase: emitting upgrade_purchased for", id, "level", level)
+        upgrade_purchased.emit(id, level)
+        return true
+
+func get_cooldown_remaining(id: String) -> float:
+        if not cooldowns.has(id):
+                return 0.0
+        var data = cooldowns[id]
+        var base := float(data.get("base", -1))
+        if base <= 0:
+                cooldowns.erase(id)
+                return 0.0
+        var start := int(data.get("start", TimeManager.total_minutes_elapsed))
+        var elapsed := TimeManager.total_minutes_elapsed - start
+        var mult := StatManager.get_stat("upgrade_cooldown_multiplier", 1.0)
+        var remaining := base * mult - elapsed
+        if remaining <= 0:
+                cooldowns.erase(id)
+                return 0.0
+        return remaining
 
 ## --- Save / Load ---------------------------------------------------
 
 func get_save_data() -> Dictionary:
-	return player_levels.duplicate(true)
+        return {
+                "levels": player_levels.duplicate(true),
+                "cooldowns": cooldowns.duplicate(true)
+        }
 
 func load_from_data(data: Dictionary) -> void:
-	player_levels = data.duplicate(true)
-	emit_signal("levels_changed")
+        if data.has("levels"):
+                player_levels = data.get("levels", {}).duplicate(true)
+                cooldowns = data.get("cooldowns", {}).duplicate(true)
+        else:
+                player_levels = data.duplicate(true)
+                cooldowns.clear()
+        emit_signal("levels_changed")
 
 func reset() -> void:
-	player_levels.clear()
-	emit_signal("levels_changed")
+        player_levels.clear()
+        cooldowns.clear()
+        emit_signal("levels_changed")

--- a/components/upgrade_scenes/upgrade_tooltip.gd
+++ b/components/upgrade_scenes/upgrade_tooltip.gd
@@ -11,7 +11,8 @@ extends PanelContainer
 var current_upgrade: Dictionary = {}
 
 func _ready() -> void:
-	hide_tooltip()
+        hide_tooltip()
+        TimeManager.minute_passed.connect(_on_minute_passed)
 
 func show_tooltip(upgrade: Dictionary):
 		current_upgrade = upgrade
@@ -54,9 +55,9 @@ func _update_display() -> void:
 		else:
 				buy_button.text = "Maxed Out" if maxed else "Buy"
 
-	var status = get_status_text(current_upgrade)
-	status_label.text = status
-	status_label.visible = status != ""
+        var status = get_status_text(current_upgrade)
+        status_label.text = status
+        status_label.visible = status != ""
 
 	close_button.disabled = false
 
@@ -103,17 +104,43 @@ func get_status_text(upgrade: Dictionary) -> String:
 	if UpgradeManager.max_level(id) != -1 and level >= UpgradeManager.max_level(id):
 					return "Maxed Out"
 	
-	if UpgradeManager.is_locked(id):
-		return "Locked"
-	
-	var cost = UpgradeManager.get_cost_for_next_level(id)
-	for currency in cost.keys():
-		if currency == "cash" and PortfolioManager.cash < cost[currency]:
-			return "Not enough funds"
-		if currency != "cash" and PortfolioManager.get_crypto_amount(currency) < cost[currency]:
-			return "Not enough funds"
-	
-	return ""
+        if UpgradeManager.is_locked(id):
+                return "Locked"
+
+        var remaining = ceil(UpgradeManager.get_cooldown_remaining(id))
+        if remaining > 0:
+                return "Cooldown: %s" % _format_minutes(int(remaining))
+
+        var cost = UpgradeManager.get_cost_for_next_level(id)
+        for currency in cost.keys():
+                if currency == "cash" and PortfolioManager.cash < cost[currency]:
+                        return "Not enough funds"
+                if currency != "cash" and PortfolioManager.get_crypto_amount(currency) < cost[currency]:
+                        return "Not enough funds"
+
+        return ""
+
+func _on_minute_passed(_m: int) -> void:
+        if current_upgrade.is_empty():
+                return
+        _update_display()
+
+func _format_minutes(minutes: int) -> String:
+        var days = minutes / (24 * 60)
+        var hours = (minutes % (24 * 60)) / 60
+        var mins = minutes % 60
+        var parts: Array[String] = []
+        if days > 0:
+                parts.append("%dd" % days)
+        if hours > 0:
+                parts.append("%dh" % hours)
+        if mins > 0 or parts.is_empty():
+                parts.append("%dm" % mins)
+        return " ".join(parts)
+
+func _exit_tree() -> void:
+        if TimeManager.minute_passed.is_connected(_on_minute_passed):
+                TimeManager.minute_passed.disconnect(_on_minute_passed)
 
 
 func _on_close_button_pressed() -> void:

--- a/data/stats/base_stats.json
+++ b/data/stats/base_stats.json
@@ -7,5 +7,6 @@
   "power_per_click": 1.0,
   "cash_per_score": 0.01,
   "autopilot_cost": 1.0,
-  "worm_yield": 1.0
+  "worm_yield": 1.0,
+  "upgrade_cooldown_multiplier": 1.0
 }

--- a/data/upgrades/fumble_personal_trainer.json
+++ b/data/upgrades/fumble_personal_trainer.json
@@ -14,9 +14,9 @@
   ],
   "dependencies": [],
   "cost_per_level": {
-		"cash": 1500
+                "cash": 1500
   },
-  "max_level": 1,
-  "repeatable": false,
+  "max_level": 10,
+  "cooldown": 10080,
   "scale_by_formula": false
 }

--- a/data/upgrades/upgrade_ui.gd
+++ b/data/upgrades/upgrade_ui.gd
@@ -13,21 +13,24 @@ var is_locked: bool = false
 @onready var level_label: Label = %LevelLabel
 @onready var cost_label: Label = %CostLabel
 @onready var buy_button: Button = %BuyButton
+@onready var cooldown_label: Label = %CooldownLabel
 
 func _ready() -> void:
-	buy_button.pressed.connect(_on_buy_button_pressed)
+        buy_button.pressed.connect(_on_buy_button_pressed)
+        TimeManager.minute_passed.connect(_on_minute_passed)
 
 func set_upgrade(upgrade: Dictionary) -> void:
 	upgrade_data = upgrade
 	name_label.text = upgrade.get("name", upgrade.get("id", "???"))
 	desc_label.text = upgrade.get("description", "")
-	set_level(StatManager.get_upgrade_level(upgrade["id"]))
-	_refresh_cost()
-	set_locked(UpgradeManager.is_locked(upgrade["id"]))
+        set_level(StatManager.get_upgrade_level(upgrade["id"]))
+        _refresh_cost()
+        set_locked(UpgradeManager.is_locked(upgrade["id"]))
+        _update_cooldown()
 
 func set_locked(locked: bool) -> void:
-	is_locked = locked
-	buy_button.disabled = locked
+        is_locked = locked
+        buy_button.disabled = locked
 	if locked:
 			self.modulate = Color(0.6, 0.6, 0.6, 1.0) # Greyed out
 	else:
@@ -39,7 +42,8 @@ func set_level(level: int) -> void:
 				level_label.text = "Level: %d" % level
 		else:
 				level_label.text = "PURCHASED" if level > 0 else ""
-		buy_button.disabled = is_locked or not UpgradeManager.can_purchase(upgrade_data.get("id", ""))
+                buy_button.disabled = is_locked or not UpgradeManager.can_purchase(upgrade_data.get("id", ""))
+        _update_cooldown()
 
 func _refresh_cost() -> void:
 	var cost = UpgradeManager.get_cost_for_next_level(upgrade_data["id"])
@@ -59,7 +63,38 @@ func _refresh_cost() -> void:
 	cost_label.text = "Cost: " + " / ".join(cost_strs)
 
 func _on_buy_button_pressed() -> void:
-	emit_signal("purchase_requested", upgrade_data["id"])
+        emit_signal("purchase_requested", upgrade_data["id"])
 
 func _on_PurchaseButton_pressed() -> void:
-	emit_signal("buy_requested", upgrade_data["id"])
+        emit_signal("buy_requested", upgrade_data["id"])
+
+func _on_minute_passed(_m: int) -> void:
+        _update_cooldown()
+
+func _update_cooldown() -> void:
+        if upgrade_data.is_empty():
+                cooldown_label.text = ""
+                return
+        var remaining = ceil(UpgradeManager.get_cooldown_remaining(upgrade_data.get("id", "")))
+        if remaining > 0:
+                cooldown_label.text = "Ready in %s" % _format_minutes(int(remaining))
+        else:
+                cooldown_label.text = ""
+        buy_button.disabled = is_locked or not UpgradeManager.can_purchase(upgrade_data.get("id", ""))
+
+func _format_minutes(minutes: int) -> String:
+        var days = minutes / (24 * 60)
+        var hours = (minutes % (24 * 60)) / 60
+        var mins = minutes % 60
+        var parts: Array[String] = []
+        if days > 0:
+                parts.append("%dd" % days)
+        if hours > 0:
+                parts.append("%dh" % hours)
+        if mins > 0 or parts.is_empty():
+                parts.append("%dm" % mins)
+        return " ".join(parts)
+
+func _exit_tree() -> void:
+        if TimeManager.minute_passed.is_connected(_on_minute_passed):
+                TimeManager.minute_passed.disconnect(_on_minute_passed)

--- a/data/upgrades/upgrade_ui.tscn
+++ b/data/upgrades/upgrade_ui.tscn
@@ -81,6 +81,13 @@ size_flags_horizontal = 3
 size_flags_stretch_ratio = 0.25
 text = "Cost: $1"
 
+[node name="CooldownLabel" type="Label" parent="MarginContainer/VBoxContainer/HBoxContainer2/VBoxContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_stretch_ratio = 0.25
+text = ""
+
 [node name="BuyButton" type="Button" parent="MarginContainer/VBoxContainer/HBoxContainer2/VBoxContainer"]
 unique_name_in_owner = true
 layout_mode = 2


### PR DESCRIPTION
## Summary
- support upgrade cooldowns with adjustable durations
- expose cooldown multiplier stat for upgrade-based reductions
- show live cooldown timers in upgrade UI and tooltips
- add 1-week cooldown and 10-level cap to Personal Trainer

## Testing
- `godot3 --headless --path . --check-only` *(fails: Can't open project at '/workspace/SigmaSim/project.godot', its `config_version` (5) is from a more recent and incompatible version of the engine. Expected config version: 4.)*

------
https://chatgpt.com/codex/tasks/task_e_68a218ca8f048325b17c11cb60f51e1d