### PR TITLE
Fix live portrait preview updates and color picker size

### DIFF
--- a/components/apps/fumble/fumble.tscn
+++ b/components/apps/fumble/fumble.tscn
@@ -158,7 +158,7 @@ layout_mode = 2
 text = "Your Gender:"
 
 [node name="ColorPickerButton" type="ColorPickerButton" parent="MarginContainer/VBoxContainer/SelfTab/MarginContainer/VBoxContainer2/VBoxContainer/HBoxContainer5"]
-custom_minimum_size = Vector2(16, 16)
+custom_minimum_size = Vector2(15, 16)
 layout_mode = 2
 focus_mode = 0
 

--- a/components/portrait/portrait_creator.gd
+++ b/components/portrait/portrait_creator.gd
@@ -36,37 +36,38 @@ func _setup_layers() -> void:
 		var label := Label.new()
 		label.text = layer.capitalize()
 		row.add_child(label)
-		var index_btn := OptionButton.new()
-		index_btn.name = "Index"
-		var tex_arr: Array = info.get("textures", [])
-		for i in range(tex_arr.size()):
-			index_btn.add_item(str(i + 1), i)
-		index_btn.item_selected.connect(_on_index_changed.bind(layer))
-		row.add_child(index_btn)
-		var color_btn := ColorPickerButton.new()
-		color_btn.name = "Color"
-		color_btn.color_changed.connect(_on_color_changed.bind(layer))
-		row.add_child(color_btn)
-		layers_container.add_child(row)
-		layer_controls[layer] = {"index": index_btn, "color": color_btn}
+                var index_btn := OptionButton.new()
+                index_btn.name = "Index"
+                var tex_arr: Array = info.get("textures", [])
+                for i in range(tex_arr.size()):
+                        index_btn.add_item(str(i + 1), i)
+                index_btn.item_selected.connect(_on_index_changed.bind(layer))
+                row.add_child(index_btn)
+                var color_btn := ColorPickerButton.new()
+                color_btn.name = "Color"
+                color_btn.custom_minimum_size = Vector2(15, 0)
+                color_btn.color_changed.connect(_on_color_changed.bind(layer))
+                row.add_child(color_btn)
+                layers_container.add_child(row)
+                layer_controls[layer] = {"index": index_btn, "color": color_btn}
 
 
-func _on_index_changed(layer: String, idx: int) -> void:
-	config.indices[layer] = idx
-	preview.apply_config(config)
+func _on_index_changed(idx: int, layer: String) -> void:
+        config.indices[layer] = idx
+        preview.apply_config(config)
 
 
-func _on_color_changed(layer: String, color: Color) -> void:
-	if layer == "hair" or layer == "hair_back":
-		config.colors["hair"] = color
-		config.colors["hair_back"] = color
-		var other := "hair_back" if layer == "hair" else "hair"
-		var btns = layer_controls.get(other, {})
-		if btns.has("color") and btns["color"] is ColorPickerButton:
-			btns["color"].color = color
-	else:
-		config.colors[layer] = color
-	preview.apply_config(config)
+func _on_color_changed(color: Color, layer: String) -> void:
+        if layer == "hair" or layer == "hair_back":
+                config.colors["hair"] = color
+                config.colors["hair_back"] = color
+                var other := "hair_back" if layer == "hair" else "hair"
+                var btns = layer_controls.get(other, {})
+                if btns.has("color") and btns["color"] is ColorPickerButton:
+                        btns["color"].color = color
+        else:
+                config.colors[layer] = color
+        preview.apply_config(config)
 
 
 func _on_name_changed(new_text: String) -> void:


### PR DESCRIPTION
## Summary
- fix layer change handlers so PortraitCreator preview updates live
- ensure color picker controls maintain at least 15px width

## Testing
- `godot --headless --check components/portrait/portrait_creator.gd` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a21ddd445c83259134c23801c7c24d