### PR TITLE
Refactor portrait layer layout

### DIFF
--- a/components/portrait/portrait_creator.gd
+++ b/components/portrait/portrait_creator.gd
@@ -8,7 +8,7 @@ var layer_controls: Dictionary = {}
 var hair_color_sync := true
 
 @onready var preview: PortraitView = %Preview
-@onready var layers_container: VBoxContainer = %Layers
+@onready var layers_container: HBoxContainer = %Layers
 @onready var name_edit: LineEdit = %NameEdit
 @onready var generate_button: Button = %Generate
 @onready var randomize_button: Button = %Randomize
@@ -29,39 +29,39 @@ func _ready() -> void:
 
 
 func _setup_layers() -> void:
-	for layer in PortraitCache.layers_order():
-		var info := PortraitCache.layer_info(layer)
-		config.indices[layer] = 0
-		config.colors[layer] = Color.WHITE
-		var row := HBoxContainer.new()
-		row.name = layer
-		var label := Label.new()
-		label.text = layer.capitalize()
-		row.add_child(label)
-		var index_btn := OptionButton.new()
-		index_btn.name = "Index"
-		var tex_arr: Array = info.get("textures", [])
-		index_btn.add_item("0", 0)
-		for i in range(tex_arr.size()):
-				index_btn.add_item(str(i + 1), i + 1)
-		index_btn.item_selected.connect(_on_index_changed.bind(layer))
-		row.add_child(index_btn)
-		var color_btn := ColorPickerButton.new()
-		color_btn.name = "Color"
-		color_btn.custom_minimum_size = Vector2(15, 0)
-		color_btn.color_changed.connect(_on_color_changed.bind(layer))
-		row.add_child(color_btn)
-		if layer == "hair" or layer == "hair_back":
-				var sync_chk := CheckBox.new()
-				sync_chk.name = "Sync"
-				sync_chk.text = "Sync"
-				sync_chk.button_pressed = hair_color_sync
-				sync_chk.toggled.connect(_on_hair_sync_toggled.bind(layer))
-				row.add_child(sync_chk)
-				layer_controls[layer] = {"index": index_btn, "color": color_btn, "sync": sync_chk}
-		else:
-				layer_controls[layer] = {"index": index_btn, "color": color_btn}
-		layers_container.add_child(row)
+        for layer in PortraitCache.layers_order():
+                var info := PortraitCache.layer_info(layer)
+                config.indices[layer] = 0
+                config.colors[layer] = Color.WHITE
+                var col := VBoxContainer.new()
+                col.name = layer
+                var label := Label.new()
+                label.text = layer.capitalize()
+                col.add_child(label)
+                var index_btn := OptionButton.new()
+                index_btn.name = "Index"
+                var tex_arr: Array = info.get("textures", [])
+                index_btn.add_item("0", 0)
+                for i in range(tex_arr.size()):
+                                index_btn.add_item(str(i + 1), i + 1)
+                index_btn.item_selected.connect(_on_index_changed.bind(layer))
+                col.add_child(index_btn)
+                var color_btn := ColorPickerButton.new()
+                color_btn.name = "Color"
+                color_btn.custom_minimum_size = Vector2(15, 0)
+                color_btn.color_changed.connect(_on_color_changed.bind(layer))
+                col.add_child(color_btn)
+                if layer == "hair" or layer == "hair_back":
+                                var sync_chk := CheckBox.new()
+                                sync_chk.name = "Sync"
+                                sync_chk.text = "Sync"
+                                sync_chk.button_pressed = hair_color_sync
+                                sync_chk.toggled.connect(_on_hair_sync_toggled.bind(layer))
+                                col.add_child(sync_chk)
+                                layer_controls[layer] = {"index": index_btn, "color": color_btn, "sync": sync_chk}
+                else:
+                                layer_controls[layer] = {"index": index_btn, "color": color_btn}
+                layers_container.add_child(col)
 
 
 func _on_index_changed(idx: int, layer: String) -> void:

--- a/components/portrait/portrait_creator.tscn
+++ b/components/portrait/portrait_creator.tscn
@@ -49,9 +49,10 @@ layout_mode = 2
 size_flags_horizontal = 4
 size_flags_vertical = 6
 
-[node name="Layers" type="VBoxContainer" parent="MarginContainer/VBox"]
+[node name="Layers" type="HBoxContainer" parent="MarginContainer/VBox"]
 unique_name_in_owner = true
 layout_mode = 2
+size_flags_horizontal = 4
 size_flags_vertical = 3
 
 [node name="Buttons" type="HBoxContainer" parent="MarginContainer/VBox"]


### PR DESCRIPTION
## Summary
- Arrange portrait creator layers horizontally with vertical controls for each layer
- Update scene container to use an HBox of VBoxes

## Testing
- `godot3 --version`
- `godot3 --headless --path . -q` *(fails: Can't open project due to config version mismatch, expected Godot4)*

------
https://chatgpt.com/codex/tasks/task_e_68a250d61c1c83259e7388012574c71a