### PR TITLE
Persist Fumble bio and repopulate swipes

### DIFF
--- a/autoloads/player_manager.gd
+++ b/autoloads/player_manager.gd
@@ -6,10 +6,11 @@ var default_user_data: Dictionary = {
 	# Identity
 	"name": "",
 	"username": "",
-	"pronouns": "",
-	"attracted_to": "",
-	"profile_picture_path": "",
-	"background_path": "",
+        "pronouns": "",
+        "attracted_to": "",
+        "profile_picture_path": "",
+        "background_path": "",
+        "bio": "",
 
 	# Core Stats
 	"alpha": 0.0,

--- a/components/apps/fumble/fumble.tscn
+++ b/components/apps/fumble/fumble.tscn
@@ -144,7 +144,8 @@ layout_mode = 2
 size_flags_vertical = 0
 text = "Bio:"
 
-[node name="TextEdit" type="TextEdit" parent="MarginContainer/VBoxContainer/SelfTab/MarginContainer/VBoxContainer2/VBoxContainer3/HBoxContainer"]
+[node name="BioTextEdit" type="TextEdit" parent="MarginContainer/VBoxContainer/SelfTab/MarginContainer/VBoxContainer2/VBoxContainer3/HBoxContainer"]
+unique_name_in_owner = true
 custom_minimum_size = Vector2(0, 48)
 layout_mode = 2
 size_flags_horizontal = 3


### PR DESCRIPTION
## Summary
- Save the player's Fumble bio and restore it when reopening the app
- Repopulate swipe cards when the app becomes visible and the stack is empty

## Testing
- `godot3 --headless --check-only` *(fails: incompatible project config version)*

------
https://chatgpt.com/codex/tasks/task_e_68a26091f7a48325809cb6e927bf6332