### PR TITLE
Display autosave countdown in settings

### DIFF
--- a/components/apps/app_scenes/settings.tscn
+++ b/components/apps/app_scenes/settings.tscn
@@ -99,11 +99,19 @@ text = "Windowed"
 custom_minimum_size = Vector2(0, 15)
 layout_mode = 2
 
-[node name="AutosaveCheckBox" type="CheckBox" parent="Panel/MarginContainer/TabContainer/General/HBoxContainer/VBoxContainer"]
+[node name="AutosaveRow" type="HBoxContainer" parent="Panel/MarginContainer/TabContainer/General/HBoxContainer/VBoxContainer"]
+layout_mode = 2
+
+[node name="AutosaveCheckBox" type="CheckBox" parent="Panel/MarginContainer/TabContainer/General/HBoxContainer/VBoxContainer/AutosaveRow"]
 unique_name_in_owner = true
 layout_mode = 2
 focus_mode = 0
 text = "Autosave"
+
+[node name="AutosaveTimerLabel" type="Label" parent="Panel/MarginContainer/TabContainer/General/HBoxContainer/VBoxContainer/AutosaveRow"]
+unique_name_in_owner = true
+layout_mode = 2
+text = ""
 
 [node name="Control" type="Control" parent="Panel/MarginContainer/TabContainer/General/HBoxContainer"]
 custom_minimum_size = Vector2(50, 0)

--- a/components/settings_window.gd
+++ b/components/settings_window.gd
@@ -4,6 +4,7 @@ extends Pane
 @onready var fullscreen_check_box: CheckBox = %FullscreenCheckBox
 @onready var windowed_check_box: CheckBox = %WindowedCheckBox
 @onready var autosave_check_box: CheckBox = %AutosaveCheckBox
+@onready var autosave_timer_label: Label = %AutosaveTimerLabel
 
 @onready var blue_warp_button: CheckButton = %BlueWarpButton
 @onready var comic_dots1_button: CheckButton = %ComicDots1Button
@@ -11,17 +12,19 @@ extends Pane
 
 
 func _ready() -> void:
-	update_checked_mode()
-	#app_title = "Settings"
-	#emit_signal("title_updated", app_title)
-	# Disable fullscreen if running in embedded mode
+        update_checked_mode()
+        #app_title = "Settings"
+        #emit_signal("title_updated", app_title)
+        # Disable fullscreen if running in embedded mode
 	if OS.has_feature("editor") or DisplayServer.get_name() == "headless":
 		fullscreen_check_box.disabled = true
 	#%SiggyButton.toggled_on = Siggy.toggled_on
-	autosave_check_box.button_pressed = TimeManager.autosave_enabled
-	blue_warp_button.button_pressed = Events.is_desktop_background_visible("BlueWarp")
-	comic_dots1_button.button_pressed = Events.is_desktop_background_visible("ComicDots1")
-	comic_dots2_button.button_pressed = Events.is_desktop_background_visible("ComicDots2")
+        autosave_check_box.button_pressed = TimeManager.autosave_enabled
+        _update_autosave_timer_label()
+        TimeManager.minute_passed.connect(_on_minute_passed)
+        blue_warp_button.button_pressed = Events.is_desktop_background_visible("BlueWarp")
+        comic_dots1_button.button_pressed = Events.is_desktop_background_visible("ComicDots1")
+        comic_dots2_button.button_pressed = Events.is_desktop_background_visible("ComicDots2")
 
 func update_checked_mode() -> void:
 	var mode = DisplayServer.window_get_mode()
@@ -58,7 +61,8 @@ func _on_siggy_button_toggled(toggled_on: bool) -> void:
 		%SiggyButton.text = "Siggy. Please come back. I miss you"
 
 func _on_autosave_check_box_toggled(toggled_on: bool) -> void:
-	TimeManager.autosave_enabled = toggled_on
+        TimeManager.autosave_enabled = toggled_on
+        _update_autosave_timer_label()
 
 func _on_blue_warp_button_toggled(toggled_on: bool) -> void:
 	Events.set_desktop_background_visible("BlueWarp", toggled_on)
@@ -67,4 +71,20 @@ func _on_comic_dots_1_button_toggled(toggled_on: bool) -> void:
 	Events.set_desktop_background_visible("ComicDots1", toggled_on)
 
 func _on_comic_dots_2_button_toggled(toggled_on: bool) -> void:
-	Events.set_desktop_background_visible("ComicDots2", toggled_on)
+        Events.set_desktop_background_visible("ComicDots2", toggled_on)
+
+func _on_minute_passed(_total_minutes: int) -> void:
+        _update_autosave_timer_label()
+
+func _update_autosave_timer_label() -> void:
+        if not TimeManager.autosave_enabled:
+                autosave_timer_label.text = "Autosave disabled"
+                return
+        if not Engine.has_singleton("SaveManager") or SaveManager.current_slot_id <= 0:
+                autosave_timer_label.text = "No save loaded"
+                return
+        var total_minutes_left = TimeManager.autosave_interval * 60 - (TimeManager.autosave_hour_counter * 60 + TimeManager.current_minute)
+        total_minutes_left = max(total_minutes_left, 0)
+        var hours = total_minutes_left / 60
+        var minutes = total_minutes_left % 60
+        autosave_timer_label.text = "%d:%02d" % [hours, minutes]


### PR DESCRIPTION
## Summary
- Add label next to the autosave toggle to show time remaining before the next autosave
- Update label every in-game minute using TimeManager and SaveManager data

## Testing
- `godot3-server --headless --path . -s tests/bill_manager_popup_test.gd` *(fails: project uses newer config version)*
- `godot3-server --headless --path . -s tests/chart_component_test.gd` *(fails: project uses newer config version)*

------
https://chatgpt.com/codex/tasks/task_e_68a42a4a7120832596c2737e09cdfbf3