### PR TITLE
Fix autosave timer save detection

### DIFF
--- a/components/settings_window.gd
+++ b/components/settings_window.gd
@@ -77,14 +77,14 @@ func _on_minute_passed(_total_minutes: int) -> void:
 		_update_autosave_timer_label()
 
 func _update_autosave_timer_label() -> void:
-		if not TimeManager.autosave_enabled:
-				autosave_timer_label.text = "Autosave disabled"
-				return
-		if not Engine.has_singleton("SaveManager") or SaveManager.current_slot_id <= 0:
-				autosave_timer_label.text = "No save loaded"
-				return
-		var total_minutes_left = TimeManager.autosave_interval * 60 - (TimeManager.autosave_hour_counter * 60 + TimeManager.current_minute)
-		total_minutes_left = max(total_minutes_left, 0)
-		var hours = total_minutes_left / 60
-		var minutes = total_minutes_left % 60
-		autosave_timer_label.text = "%d:%02d" % [hours, minutes]
+        if not TimeManager.autosave_enabled:
+                autosave_timer_label.text = "Autosave disabled"
+                return
+        if not is_instance_valid(SaveManager) or SaveManager.current_slot_id <= 0:
+                autosave_timer_label.text = "No save loaded"
+                return
+        var total_minutes_left = TimeManager.autosave_interval * 60 - (TimeManager.autosave_hour_counter * 60 + TimeManager.current_minute)
+        total_minutes_left = max(total_minutes_left, 0)
+        var hours = total_minutes_left / 60
+        var minutes = total_minutes_left % 60
+        autosave_timer_label.text = "%d:%02d" % [hours, minutes]


### PR DESCRIPTION
## Summary
- fix autosave timer by checking SaveManager instance directly

## Testing
- `godot --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a42f333e6c8325b0a8ca5e4bed0555