### PR TITLE
fix: correctly gate bill popups during profile load

### DIFF
--- a/autoloads/save_manager.gd
+++ b/autoloads/save_manager.gd
@@ -49,17 +49,18 @@ func get_next_available_slot() -> int:
 
 
 func initialize_new_profile(slot_id: int, user_data: Dictionary) -> void:
-	if slot_id <= 0:
-		push_error("❌ Invalid slot_id: %d" % slot_id)
-		return
-		reset_managers()
-		BillManager.is_loading = true
-		current_slot_id = slot_id
-	if not user_data.has("global_rng_seed"):
-		var password = user_data.get("password", "")
-		var seed_val: int
-		if password != "":
-			seed_val = PlayerManager.djb2(password)
+        if slot_id <= 0:
+                push_error("❌ Invalid slot_id: %d" % slot_id)
+                return
+
+        reset_managers()
+        BillManager.is_loading = true
+        current_slot_id = slot_id
+        if not user_data.has("global_rng_seed"):
+                var password = user_data.get("password", "")
+                var seed_val: int
+                if password != "":
+                        seed_val = PlayerManager.djb2(password)
 		else:
 			seed_val = int(Time.get_unix_time_from_system())
 		user_data["global_rng_seed"] = seed_val
@@ -121,17 +122,17 @@ func save_to_slot(slot_id: int) -> void:
 
 
 func load_from_slot(slot_id: int) -> void:
-	if slot_id <= 0:
-		push_error("❌ Invalid slot_id: %d" % slot_id)
-		return
+        if slot_id <= 0:
+                push_error("❌ Invalid slot_id: %d" % slot_id)
+                return
 
-	var path = get_slot_path(slot_id)
-	if not FileAccess.file_exists(path):
-		return
+        var path = get_slot_path(slot_id)
+        if not FileAccess.file_exists(path):
+                return
 
-		reset_managers()
-		BillManager.is_loading = true
-		current_slot_id = slot_id
+        reset_managers()
+        BillManager.is_loading = true
+        current_slot_id = slot_id
 
 	var file := FileAccess.open(path, FileAccess.READ)
 	var text := file.get_as_text()


### PR DESCRIPTION
## Summary
- ensure SaveManager resets managers and sets `BillManager.is_loading` before initializing or loading a profile so pending bills don't spawn during login

## Testing
- ❌ `godot --headless -s tests/bill_manager_popup_test.gd` *(missing `godot` binary)*
- ⚠️ `godot3-server --path . -s tests/bill_manager_popup_test.gd` *(project requires newer Godot engine)*

------
https://chatgpt.com/codex/tasks/task_e_68a4b128584083258763c6d46e177ae9