### PR TITLE
Add SuitorPopup for NPC relationships

### DIFF
--- a/components/npc/npc.gd
+++ b/components/npc/npc.gd
@@ -15,6 +15,10 @@ extends Resource
 @export var occupation: String = "Funemployed"
 @export var relationship_status: String = "Single"
 
+enum RelationshipStage { STRANGER, TALKING, DATING, SERIOUS, ENGAGED, MARRIED, DIVORCED, EX }
+@export var relationship_stage: RelationshipStage = RelationshipStage.STRANGER
+@export_range(0, 100, 0.1) var relationship_progress: float = 0.0
+
 # Relationship with Player
 @export_range(-100, 100, 0.1) var affinity: float = 0.0 # 0–100
 @export_range(0, 100, 0.1) var rizz: int
@@ -117,9 +121,11 @@ func to_dict() -> Dictionary:
 		"last_name": last_name,
 		"gender_vector": { "x": gender_vector.x, "y": gender_vector.y, "z": gender_vector.z },
 		"username": username,
-		"occupation": occupation,
-		"relationship_status": relationship_status,
-		"affinity": affinity,
+                "occupation": occupation,
+                "relationship_status": relationship_status,
+                "relationship_stage": relationship_stage,
+                "relationship_progress": relationship_progress,
+                "affinity": affinity,
 		"rizz": rizz,
 		"attractiveness": attractiveness,
 		"income": income,
@@ -166,8 +172,10 @@ static func from_dict(data: Dictionary) -> NPC:
 
 	npc.username          = _safe_string(data.get("username"))
 	npc.occupation        = _safe_string(data.get("occupation"), "Funemployed")
-	npc.relationship_status = _safe_string(data.get("relationship_status"), "Single")
-	npc.affinity          = _safe_float(data.get("affinity"), 0.0)
+       npc.relationship_status = _safe_string(data.get("relationship_status"), "Single")
+       npc.relationship_stage = _safe_int(data.get("relationship_stage"), RelationshipStage.STRANGER)
+       npc.relationship_progress = _safe_float(data.get("relationship_progress"))
+       npc.affinity          = _safe_float(data.get("affinity"), 0.0)
 	npc.rizz              = _safe_int(data.get("rizz"), 0)
 	npc.attractiveness    = _safe_int(data.get("attractiveness"), 0)
 	npc.income            = _safe_int(data.get("income"), 0)

--- a/components/popups/suitor_popup.gd
+++ b/components/popups/suitor_popup.gd
@@ -1,0 +1,109 @@
+extends Pane
+class_name SuitorPopup
+
+const STAGE_NAMES := ["STRANGER", "TALKING", "DATING", "SERIOUS", "ENGAGED", "MARRIED", "DIVORCED", "EX"]
+
+@onready var name_label: Label = %NameLabel
+@onready var portrait_view: Control = %Portrait
+@onready var relationship_stage_label: Label = %RelationshipStageLabel
+@onready var relationship_bar: StatProgressBar = %RelationshipBar
+@onready var next_stage_button: Button = %NextStageButton
+@onready var affinity_bar: StatProgressBar = %AffinityBar
+@onready var gift_button: Button = %GiftButton
+@onready var date_button: Button = %DateButton
+@onready var breakup_button: Button = %BreakupButton
+
+var npc: NPC
+var progress_paused: bool = false
+
+func setup(target: NPC) -> void:
+	npc = target
+	name_label.text = npc.full_name
+	if portrait_view.has_method("apply_config") and npc.portrait_config:
+		portrait_view.portrait_creator_enabled = false
+		portrait_view.apply_config(npc.portrait_config)
+	_update_all()
+
+func _ready() -> void:
+	gift_button.pressed.connect(_on_gift_pressed)
+	date_button.pressed.connect(_on_date_pressed)
+	breakup_button.pressed.connect(_on_breakup_pressed)
+	next_stage_button.pressed.connect(_on_next_stage_pressed)
+
+func _process(delta: float) -> void:
+	if npc == null or progress_paused or npc.relationship_stage == NPC.RelationshipStage.EX:
+		return
+	var rate = max(npc.affinity, 0.0) * 0.1
+	npc.relationship_progress += rate * delta
+	if npc.relationship_progress >= 100.0:
+		npc.relationship_progress = 100.0
+		progress_paused = true
+		next_stage_button.visible = true
+	_update_relationship_bar()
+	_update_breakup_button_text()
+
+func _update_all() -> void:
+	_update_relationship_bar()
+	_update_affinity_bar()
+	_update_breakup_button_text()
+
+func _update_relationship_bar() -> void:
+	var current_stage: int = npc.relationship_stage
+	var next_stage: int = min(current_stage + 1, STAGE_NAMES.size() - 1)
+	relationship_stage_label.text = "%s -> %s" % [STAGE_NAMES[current_stage], STAGE_NAMES[next_stage]]
+	relationship_bar.max_value = 100
+	relationship_bar.update_value(npc.relationship_progress)
+
+func _update_affinity_bar() -> void:
+	affinity_bar.max_value = 100
+	affinity_bar.update_value(npc.affinity)
+
+func _update_breakup_button_text() -> void:
+	var stage_idx := max(1, npc.relationship_stage)
+	var base := pow(10, stage_idx - 1)
+	var reward := (0.1 + (npc.relationship_progress / 100.0) * 0.9) * base
+	breakup_button.text = "Breakup for %.2f Ex" % reward
+
+func _on_next_stage_pressed() -> void:
+	next_stage_button.visible = false
+	progress_paused = false
+	if npc.relationship_stage < NPC.RelationshipStage.EX:
+		npc.relationship_stage += 1
+		npc.relationship_progress = 0.0
+	_update_all()
+
+func _on_gift_pressed() -> void:
+	if PortfolioManager.attempt_spend(25.0):
+		npc.affinity = min(npc.affinity + 5.0, 100.0)
+		_update_affinity_bar()
+
+func _on_date_pressed() -> void:
+	if not PortfolioManager.attempt_spend(200.0):
+		return
+	if npc.relationship_stage == NPC.RelationshipStage.TALKING and npc.relationship_progress < 99.0:
+		npc.relationship_progress = 99.0
+		progress_paused = true
+		next_stage_button.visible = true
+	else:
+		npc.relationship_progress = min(npc.relationship_progress + 25.0, 100.0)
+		if npc.relationship_progress >= 100.0:
+			progress_paused = true
+			next_stage_button.visible = true
+	_update_relationship_bar()
+	_update_breakup_button_text()
+
+func _on_breakup_pressed() -> void:
+	var stage_idx := max(1, npc.relationship_stage)
+	var base := pow(10, stage_idx - 1)
+	var reward := (0.1 + (npc.relationship_progress / 100.0) * 0.9) * base
+	var current_ex := PlayerManager.get_var("ex", 0.0)
+	PlayerManager.set_var("ex", current_ex + reward)
+	npc.relationship_stage = NPC.RelationshipStage.EX
+	npc.relationship_progress = 0.0
+	npc.affinity *= 0.2
+	progress_paused = true
+	next_stage_button.visible = false
+	gift_button.disabled = true
+	date_button.disabled = true
+	_update_all()
+

--- a/components/popups/suitor_popup.tscn
+++ b/components/popups/suitor_popup.tscn
@@ -1,0 +1,67 @@
+[gd_scene load_steps=4 format=3]
+
+[ext_resource type="Theme" path="res://assets/windows_95_theme.tres" id="1"]
+[ext_resource type="Script" path="res://components/popups/suitor_popup.gd" id="2"]
+[ext_resource type="Script" path="res://components/apps/fumble/stat_progress_bar.gd" id="3"]
+[ext_resource type="PackedScene" path="res://components/portrait/portrait_view.tscn" id="4"]
+
+[node name="SuitorPopup" type="Panel"]
+	theme = ExtResource("1")
+	script = ExtResource("2")
+	default_window_size = Vector2(400, 500)
+	is_popup = true
+	window_title = "Suitor"
+
+[node name="MarginContainer" type="MarginContainer" parent="."]
+	anchors_preset = 15
+	anchor_right = 1.0
+	anchor_bottom = 1.0
+	grow_horizontal = 2
+	grow_vertical = 2
+	theme_override_constants/margin_left = 8
+	theme_override_constants/margin_top = 8
+	theme_override_constants/margin_right = 8
+	theme_override_constants/margin_bottom = 8
+
+[node name="VBox" type="VBoxContainer" parent="MarginContainer"]
+	theme_override_constants/separation = 8
+
+[node name="NameLabel" type="Label" parent="MarginContainer/VBox"]
+	unique_name_in_owner = true
+
+[node name="Portrait" parent="MarginContainer/VBox" instance=ExtResource("4")]
+	unique_name_in_owner = true
+
+[node name="RelationshipStageLabel" type="Label" parent="MarginContainer/VBox"]
+	unique_name_in_owner = true
+
+[node name="RelationshipBar" type="ProgressBar" parent="MarginContainer/VBox"]
+	unique_name_in_owner = true
+	script = ExtResource("3")
+	max_value = 100.0
+
+[node name="NextStageButton" type="Button" parent="MarginContainer/VBox"]
+	unique_name_in_owner = true
+	text = "Take this relationship to the next stage"
+	visible = false
+
+[node name="AffinityBar" type="ProgressBar" parent="MarginContainer/VBox"]
+	unique_name_in_owner = true
+	script = ExtResource("3")
+	max_value = 100.0
+
+[node name="Buttons" type="HBoxContainer" parent="MarginContainer/VBox"]
+	theme_override_constants/separation = 8
+
+[node name="GiftButton" type="Button" parent="MarginContainer/VBox/Buttons"]
+	unique_name_in_owner = true
+	text = "Gift"
+
+[node name="DateButton" type="Button" parent="MarginContainer/VBox/Buttons"]
+	unique_name_in_owner = true
+	text = "Date"
+
+[node name="BreakupButton" type="Button" parent="MarginContainer/VBox/Buttons"]
+	unique_name_in_owner = true
+	text = "Breakup"
+


### PR DESCRIPTION
## Summary
- track NPC relationship stage and progress with new stats
- add interactive SuitorPopup showing portrait, progression, affinity, and breakup rewards

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4c86a5ab8832590d825be9d36b2bc