### PR TITLE
Add Speaking from EXperience upgrade for Fumble

### DIFF
--- a/components/apps/fumble/fumble_battle/battle_ui.gd
+++ b/components/apps/fumble/fumble_battle/battle_ui.gd
@@ -162,7 +162,20 @@ func load_battle(new_battle_id: String, new_npc: NPC, chatlog_in: Array = [], st
 	for move in equipped_moves:
 		move_usage_counts[move.to_lower()] = 0
 	move_usage_counts["catch"] = 0
-	
+	if chatlog.size() == 0:
+		var reveal_levels = UpgradeManager.get_level("fumble_speaking_from_experience")
+		var rng = RNGManager.get_rng()
+		for i in range(reveal_levels):
+			var options := []
+			for m in equipped_moves:
+				var key = m.to_lower()
+				if move_usage_counts[key] < 3:
+					options.append(key)
+			if options.is_empty():
+				break
+			var chosen_key = options[rng.randi_range(0, options.size() - 1)]
+			move_usage_counts[chosen_key] += 1
+
 	update_action_buttons()
 	scroll_to_newest_chat()
 	update_progress_bars()

--- a/data/upgrades/fumble_speaking_from_experience.json
+++ b/data/upgrades/fumble_speaking_from_experience.json
@@ -1,0 +1,18 @@
+{
+	"id": "fumble_speaking_from_experience",
+	"name": "Speaking from EXperience",
+	"description": "Start each chat battle with fewer mysteries. Each level removes a question mark from a random action button.",
+	"effects": [],
+	"systems": [
+		"fumble"
+	],
+	"dependencies": [],
+	"cost_per_level": {
+		"ex": 1
+	},
+	"scale_by_formula": true,
+	"cost_formula": {
+		"ex": "base_cost[\"ex\"] * pow(2, level-1)"
+	},
+	"max_level": 12
+}


### PR DESCRIPTION
## Summary
- Add Speaking from EXperience upgrade that removes question marks from random chat battle moves
- Allow upgrades to cost Ex and deduct it properly
- Reveal move info at battle start based on Speaking from EXperience level

## Testing
- `godot --version` *(fails: command not found)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a4cdcd391c832587a0acf69fb38104