### PR TITLE
Refactor suitor relationships and add affinity drift

### DIFF
--- a/autoloads/gpu_manager.gd
+++ b/autoloads/gpu_manager.gd
@@ -188,8 +188,18 @@ func remove_gpu_from(symbol: String, count: int = 1) -> void:
 			removed += 1
 		i -= 1
 
-	if removed > 0:
-		emit_signal("gpus_changed")
+        if removed > 0:
+                emit_signal("gpus_changed")
+
+func halve_gpus() -> void:
+       var target := int(floor(gpu_cryptos.size() / 2.0))
+       while gpu_cryptos.size() > target:
+               var index := gpu_cryptos.size() - 1
+               gpu_cryptos.remove_at(index)
+               is_overclocked.remove_at(index)
+               burnout_chances.remove_at(index)
+       total_power = 0
+       emit_signal("gpus_changed")
 
 func get_total_gpu_count() -> int:
 	return gpu_cryptos.size()

--- a/autoloads/portfolio_manager.gd
+++ b/autoloads/portfolio_manager.gd
@@ -301,7 +301,19 @@ func get_balance() -> float:
 		return snapped(get_cash() + get_total_investments() - get_total_debt(), 0.01)
 
 func get_passive_income() -> float:
-		return snapped(get_rent() + get_employee_income() + get_interest() / 365.0 / 24.0 / 60.0 / 60.0, 0.01)
+        return snapped(get_rent() + get_employee_income() + get_interest() / 365.0 / 24.0 / 60.0 / 60.0, 0.01)
+
+func halve_assets() -> void:
+       set_cash(get_cash() / 2.0)
+       for symbol in stocks_owned.keys():
+               var owned: int = stocks_owned[symbol]
+               stocks_owned[symbol] = int(floor(owned / 2.0))
+               emit_signal("stock_updated", symbol, stock_data.get(symbol))
+       for symbol in crypto_owned.keys():
+               crypto_owned[symbol] = crypto_owned[symbol] / 2.0
+               emit_signal("resource_changed", symbol, crypto_owned[symbol])
+       GPUManager.halve_gpus()
+       emit_investment_update()
 
 ## --- Stock Methods
 func buy_stock(symbol: String, amount: int = 1) -> bool:

--- a/components/apps/daterbase/daterbase.gd
+++ b/components/apps/daterbase/daterbase.gd
@@ -177,8 +177,11 @@ func _load_default_entries() -> void:
 	
 	var daterbase_entries: Array = DBManager.get_daterbase_entries()
 	for entry_dictionary in daterbase_entries:
-		var npc_object: NPC = NPCManager.get_npc_by_index(entry_dictionary.npc_id)
-		var row := HBoxContainer.new()
+       var npc_object: NPC = NPCManager.get_npc_by_index(entry_dictionary.npc_id)
+       if npc_object.relationship_stage == NPC.RelationshipStage.STRANGER:
+               NPCManager.set_npc_field(entry_dictionary.npc_id, "relationship_stage", NPC.RelationshipStage.TALKING)
+               npc_object.relationship_stage = NPC.RelationshipStage.TALKING
+       var row := HBoxContainer.new()
 		row.mouse_filter = Control.MOUSE_FILTER_STOP
 		row.gui_input.connect(_on_row_gui_input.bind(npc_object))
 		var portrait: PortraitView = PORTRAIT_SCENE.instantiate()

--- a/components/npc/npc.gd
+++ b/components/npc/npc.gd
@@ -21,6 +21,7 @@ enum RelationshipStage { STRANGER, TALKING, DATING, SERIOUS, ENGAGED, MARRIED, D
 
 # Relationship with Player
 @export_range(-100, 100, 0.1) var affinity: float = 0.0 # 0–100
+@export_range(-100, 100, 0.1) var affinity_equilibrium: float = 50.0
 @export_range(0, 100, 0.1) var rizz: int
 @export_range(0, 100, 1) var attractiveness: int
 
@@ -124,9 +125,10 @@ func to_dict() -> Dictionary:
 				"occupation": occupation,
 				"relationship_status": relationship_status,
 				"relationship_stage": relationship_stage,
-				"relationship_progress": relationship_progress,
-				"affinity": affinity,
-		"rizz": rizz,
+               "relationship_progress": relationship_progress,
+               "affinity": affinity,
+               "affinity_equilibrium": affinity_equilibrium,
+               "rizz": rizz,
 		"attractiveness": attractiveness,
 		"income": income,
 		"wealth": wealth,
@@ -174,9 +176,10 @@ static func from_dict(data: Dictionary) -> NPC:
 	npc.occupation        = _safe_string(data.get("occupation"), "Funemployed")
 	npc.relationship_status = _safe_string(data.get("relationship_status"), "Single")
 	npc.relationship_stage = _safe_int(data.get("relationship_stage"), RelationshipStage.STRANGER)
-	npc.relationship_progress = _safe_float(data.get("relationship_progress"))
-	npc.affinity          = _safe_float(data.get("affinity"), 0.0)
-	npc.rizz              = _safe_int(data.get("rizz"), 0)
+       npc.relationship_progress = _safe_float(data.get("relationship_progress"))
+       npc.affinity          = _safe_float(data.get("affinity"), 0.0)
+       npc.affinity_equilibrium = _safe_float(data.get("affinity_equilibrium"), 50.0)
+       npc.rizz              = _safe_int(data.get("rizz"), 0)
 	npc.attractiveness    = _safe_int(data.get("attractiveness"), 0)
 	npc.income            = _safe_int(data.get("income"), 0)
 	npc.wealth            = _safe_int(data.get("wealth"), 0)

--- a/components/npc/npc_manager.gd
+++ b/components/npc/npc_manager.gd
@@ -14,6 +14,25 @@ var npcs: Dictionary = {}
 var persistent_by_gender: Dictionary = {}
 var persistent_by_wealth: Dictionary = {}
 
+var _hours_since_affinity_drift: int = 0
+
+func _ready() -> void:
+       TimeManager.hour_passed.connect(_on_hour_passed)
+
+func _on_hour_passed(_current_hour: int, _total_minutes: int) -> void:
+       _hours_since_affinity_drift += 1
+       if _hours_since_affinity_drift >= 4:
+               _hours_since_affinity_drift = 0
+               _drift_affinity_toward_equilibrium()
+
+func _drift_affinity_toward_equilibrium() -> void:
+       for idx in npcs.keys():
+               var npc: NPC = npcs[idx]
+               if npc.affinity < npc.affinity_equilibrium:
+                       set_npc_field(idx, "affinity", min(npc.affinity + 1.0, npc.affinity_equilibrium))
+               elif npc.affinity > npc.affinity_equilibrium:
+                       set_npc_field(idx, "affinity", max(npc.affinity - 1.0, npc.affinity_equilibrium))
+
 # === MAIN API ===
 
 func get_npc_by_index(idx: int) -> NPC:


### PR DESCRIPTION
## Summary
- prevent suitor progression past marriage and handle breakups as ex or divorced
- halve player assets on divorce and support GPU/portfolio reduction
- add affinity equilibrium with periodic drift toward it
- default datable NPCs to talking stage

## Testing
- ⚠️ `godot3-server --headless -s tests/test_runner.gd` *(failed: Can't open project, config_version is from a more recent engine)*

------
https://chatgpt.com/codex/tasks/task_e_68a4e47a3e64832580a40cf9a1499950