### PR TITLE
Use persistent Main scene for login and desktop transitions

### DIFF
--- a/autoloads/game_manager.gd
+++ b/autoloads/game_manager.gd
@@ -10,8 +10,6 @@ var in_game: bool = false
 
 
 var pause_screen_instance: PauseScreen = null
-var desktop_scene := preload("res://components/desktop_env.tscn")
-var login_scene := preload("res://components/ui/log_in_ui.tscn")
 
 #Deprecated
 const _ForceRegisterWorker := preload("res://resources/workers/worker.gd")
@@ -156,12 +154,18 @@ func _close_pause_screen():
 func load_login_screen():
 	in_game = false
 	TimeManager.set_time_paused(true)
-	get_tree().change_scene_to_packed(login_scene)
+	var main = get_tree().current_scene
+	if main and main.has_method("show_login_ui"):
+		main.show_login_ui()
+
 
 func load_desktop_env(slot_id: int = SaveManager.current_slot_id):
 	in_game = true
 	SaveManager.current_slot_id = slot_id
-	get_tree().change_scene_to_packed(desktop_scene)
+	var main = get_tree().current_scene
+	if main and main.has_method("show_desktop_env"):
+		main.show_desktop_env(slot_id)
+
 
 # Save and load functionality (optional, depends on how you handle it)
 func save_game():

--- a/components/main.gd
+++ b/components/main.gd
@@ -1,0 +1,23 @@
+extends Node
+
+var login_scene := preload("res://components/ui/log_in_ui.tscn")
+var desktop_scene := preload("res://components/desktop_env.tscn")
+var current_screen: Node
+
+func _ready() -> void:
+	show_login_ui()
+
+func show_login_ui() -> void:
+	_switch_screen(login_scene.instantiate())
+	GameManager.in_game = false
+
+func show_desktop_env(slot_id: int = SaveManager.current_slot_id) -> void:
+	SaveManager.current_slot_id = slot_id
+	_switch_screen(desktop_scene.instantiate())
+	GameManager.in_game = true
+
+func _switch_screen(screen: Node) -> void:
+	if current_screen and is_instance_valid(current_screen):
+		current_screen.queue_free()
+	current_screen = screen
+	add_child(current_screen)

--- a/components/main.tscn
+++ b/components/main.tscn
@@ -1,7 +1,6 @@
 [gd_scene load_steps=2 format=3 uid="uid://uminah6hxj5y"]
 
-[ext_resource type="PackedScene" uid="uid://c4tt0mgxvgw5g" path="res://components/ui/log_in_ui.tscn" id="1_6txqy"]
+[ext_resource type="Script" uid="uid://bpxx9rqgw7u6b" path="res://components/main.gd" id="1_lgkms"]
 
 [node name="Main" type="Node"]
-
-[node name="LogInUI" parent="." instance=ExtResource("1_6txqy")]
+script = ExtResource("1_lgkms")

--- a/project.godot
+++ b/project.godot
@@ -11,7 +11,7 @@ config_version=5
 [application]
 
 config/name="Sigma"
-run/main_scene="uid://c4tt0mgxvgw5g"
+run/main_scene="uid://uminah6hxj5y"
 config/features=PackedStringArray("4.4", "GL Compatibility")
 boot_splash/bg_color=Color(0.16283, 0.24604, 1, 1)
 boot_splash/fullsize=false


### PR DESCRIPTION
## Summary
- Add `Main` controller script to swap between login UI and desktop environment
- Update `GameManager` to delegate scene changes to the `Main` node
- Point project configuration at new `Main` scene

## Testing
- `godot3 --headless -s tests/test_runner.gd` *(fails: project uses newer engine version)*

------
https://chatgpt.com/codex/tasks/task_e_68a4ee6f95c8832581d770e918a0f393