### PR TITLE
Add breakup confirmation popup and dynamic action costs

### DIFF
--- a/components/popups/suitor_popup.tscn
+++ b/components/popups/suitor_popup.tscn
@@ -126,3 +126,37 @@ text = "Date"
 unique_name_in_owner = true
 layout_mode = 2
 text = "Breakup"
+
+[node name="BreakupConfirm" type="CenterContainer" parent="."]
+unique_name_in_owner = true
+visible = false
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="Panel" type="PanelContainer" parent="BreakupConfirm"]
+
+[node name="VBox" type="VBoxContainer" parent="BreakupConfirm/Panel"]
+layout_mode = 2
+theme_override_constants/separation = 8
+
+[node name="BreakupConfirmLabel" type="Label" parent="BreakupConfirm/Panel/VBox"]
+unique_name_in_owner = true
+layout_mode = 2
+autowrap_mode = 3
+
+[node name="Buttons" type="HBoxContainer" parent="BreakupConfirm/Panel/VBox"]
+layout_mode = 2
+theme_override_constants/separation = 8
+
+[node name="BreakupConfirmYesButton" type="Button" parent="BreakupConfirm/Panel/VBox/Buttons"]
+unique_name_in_owner = true
+layout_mode = 2
+text = "Yes"
+
+[node name="BreakupConfirmNoButton" type="Button" parent="BreakupConfirm/Panel/VBox/Buttons"]
+unique_name_in_owner = true
+layout_mode = 2
+text = "No"


### PR DESCRIPTION
## Summary
- add in-scene confirmation panel for breaking up with suitors, warning about asset loss when married
- show running EX cost on Gift and Date buttons and double cost after each use

## Testing
- `godot3-server --headless -s tests/test_runner.gd` *(fails: project uses Godot 4 engine)*

------
https://chatgpt.com/codex/tasks/task_e_68a4efa2c84c8325984f9fb7519985ab