### PR TITLE
Refresh Daterbase portraits when NPC configs change

### DIFF
--- a/components/apps/daterbase/daterbase.gd
+++ b/components/apps/daterbase/daterbase.gd
@@ -17,7 +17,7 @@ var results_tree: Tree
 
 # --- Table state ---
 var current_headers: Array[String] = []
-var current_rows: Array = []        # Array[Dictionary]
+var current_rows: Array = []	    # Array[Dictionary]
 var sort_column_index: int = -1
 var sort_ascending: bool = true
 
@@ -39,6 +39,8 @@ var column_user_min_widths: Array[int] = []  # per-column min widths from user d
 var _active_tab: StringName = &"Daterbase"
 var _ran_initial_show_all: bool = false
 
+var _portrait_views_by_npc: Dictionary = {}
+
 const PORTRAIT_SCENE: PackedScene = preload("res://components/portrait/portrait_view.tscn")
 const SUITOR_POPUP_SCENE: PackedScene = preload("res://components/popups/suitor_popup.tscn")
 const STAGE_NAMES: Array[String] = ["STRANGER", "TALKING", "DATING", "SERIOUS", "ENGAGED", "MARRIED", "DIVORCED", "EX"]
@@ -49,6 +51,8 @@ func _ready() -> void:
 	show_all_button.pressed.connect(_on_show_all_pressed)
 	daterbase_tab_button.pressed.connect(_on_daterbase_tab_pressed)
 	sql_tab_button.pressed.connect(_on_sql_tab_pressed)
+
+	NPCManager.portrait_changed.connect(_on_npc_portrait_changed)
 
 	numeric_regex = RegEx.new()
 	numeric_regex.compile("^[-+]?\\d*(?:\\.\\d+)?(?:[eE][-+]?\\d+)?$")
@@ -165,6 +169,7 @@ func _is_safe_select(query_text: String) -> bool:
 func _load_default_entries() -> void:
 	for child in results_container_daterbase.get_children():
 		child.queue_free()
+	_portrait_views_by_npc.clear()
 	
 	var header := HBoxContainer.new()
 	header.mouse_filter = Control.MOUSE_FILTER_IGNORE
@@ -202,6 +207,7 @@ func _load_default_entries() -> void:
 			portrait.mouse_filter = Control.MOUSE_FILTER_IGNORE
 			if npc_object.portrait_config != null:
 					portrait.apply_config(npc_object.portrait_config)
+			_portrait_views_by_npc[entry_dictionary.npc_id] = portrait
 			row.add_child(portrait)
 			var name_label := Label.new()
 			name_label.text = npc_object.full_name
@@ -256,6 +262,11 @@ func _open_suitor_popup(npc: NPC) -> void:
 	var popup: SuitorPopup = SUITOR_POPUP_SCENE.instantiate()
 	WindowManager.launch_pane_instance(popup)
 	popup.call_deferred("setup", npc)
+
+func _on_npc_portrait_changed(idx: int, cfg: PortraitConfig) -> void:
+	if _portrait_views_by_npc.has(idx):
+		var portrait: PortraitView = _portrait_views_by_npc[idx]
+		portrait.apply_config(cfg)
 
 func _display_generic_rows(result_rows: Array) -> void:
 	if result_rows.size() == 0:

--- a/components/npc/npc_manager.gd
+++ b/components/npc/npc_manager.gd
@@ -1,6 +1,9 @@
 extends Node
 # Autoload: NPCManager
 
+signal portrait_changed(idx, cfg)
+
+
 var encounter_count: int = 0
 var encountered_npcs: Array[int] = []
 var encountered_npcs_by_app: Dictionary = {}
@@ -69,6 +72,9 @@ func set_npc_field(idx: int, field: String, value) -> void:
 		if not npc_overrides.has(idx):
 			npc_overrides[idx] = {}
 		npc_overrides[idx][field] = value
+
+	if field == "portrait_config":
+		emit_signal("portrait_changed", idx, value)
 
 func promote_to_persistent(idx: int) -> void:
 	if not persistent_npcs.has(idx):


### PR DESCRIPTION
## Summary
- add portrait_changed signal to NPCManager and emit when portrait_config updates
- track Daterbase portrait views and update when NPC portrait changes

## Testing
- `/tmp/godot4/Godot_v4.2.2-stable_linux.x86_64 --headless tests/test_runner.tscn`


------
https://chatgpt.com/codex/tasks/task_e_68a51a61d9108325aec9ea2afb8917f0