### PR TITLE
Avoid duplicate NewYou panels for an NPC

### DIFF
--- a/autoloads/window_manager.gd
+++ b/autoloads/window_manager.gd
@@ -176,14 +176,19 @@ func launch_pane(scene: PackedScene) -> void:
 
 func launch_pane_instance(pane: Pane, setup_args: Variant = null) -> void:
 	print("launch pane instance : " + str(pane))
+	if pane.unique_popup_key != "":
+		var existing_window = find_popup_by_key(pane.unique_popup_key)
+		if existing_window:
+			focus_window(existing_window)
+			pane.queue_free()
+			return
 	var window := WindowFrame.instantiate_for_pane(pane)
 	register_window(window, pane.show_in_taskbar)
-	
+
 	if setup_args != null and pane.has_method("setup_custom"):
 		pane.call_deferred("setup_custom", setup_args)
 
 	call_deferred("autoposition_window", window)
-
 
 func launch_popup(popup_scene: PackedScene, unique_key: String, setup_args: Variant = null) -> void:
 	if popup_scene == null:

--- a/components/portrait/portrait_view.gd
+++ b/components/portrait/portrait_view.gd
@@ -83,6 +83,10 @@ func _on_mouse_exited() -> void:
 func _on_new_you_pressed() -> void:
 	var scene = preload("res://components/apps/new_you/new_you.tscn")
 	var pane = scene.instantiate()
+	if subject_is_player:
+		pane.unique_popup_key = "new_you_player"
+	elif subject_npc_idx != -1:
+		pane.unique_popup_key = "new_you_npc_%s" % subject_npc_idx
 	var args: Dictionary = {"portrait_view": self}
 	if subject_is_player:
 			args["type"] = "player"


### PR DESCRIPTION
## Summary
- Prevent multiple NewYou windows by checking for existing panels via unique_popup_key
- Assign unique_popup_key per player or NPC before launching NewYou pane

## Testing
- `godot3 --headless -s tests/test_runner.gd` *(fails: project requires a newer Godot version)*

------
https://chatgpt.com/codex/tasks/task_e_68a523969778832597f9ceaf0650d6da