### PR TITLE
Add configurable waves background

### DIFF
--- a/autoloads/events.gd
+++ b/autoloads/events.gd
@@ -7,6 +7,7 @@ var desktop_backgrounds: Dictionary = {
 	"BlueWarp": true,
 	"ComicDots1": false,
 	"ComicDots2": false,
+	"Waves": false,
 }
 
 func set_desktop_background_visible(name: String, visible: bool) -> void:

--- a/components/apps/app_scenes/settings.tscn
+++ b/components/apps/app_scenes/settings.tscn
@@ -164,7 +164,62 @@ layout_mode = 2
 focus_mode = 0
 text = "Comic Dots 2"
 
+[node name="WavesButton" type="CheckButton" parent="Panel/MarginContainer/TabContainer/DesktopBackground"]
+unique_name_in_owner = true
+layout_mode = 2
+focus_mode = 0
+text = "Waves"
+
+[node name="BottomColorPicker" type="ColorPickerButton" parent="Panel/MarginContainer/TabContainer/DesktopBackground"]
+unique_name_in_owner = true
+layout_mode = 2
+color = Color(0, 0, 0, 1)
+
+[node name="TopColorPicker" type="ColorPickerButton" parent="Panel/MarginContainer/TabContainer/DesktopBackground"]
+unique_name_in_owner = true
+layout_mode = 2
+color = Color(0.868811, 5.77569e-07, 0.459911, 1)
+
+[node name="WaveAmpSpinBox" type="SpinBox" parent="Panel/MarginContainer/TabContainer/DesktopBackground"]
+unique_name_in_owner = true
+layout_mode = 2
+min_value = 0.0
+max_value = 0.5
+step = 0.01
+value = 0.082
+
+[node name="WaveSizeSpinBox" type="SpinBox" parent="Panel/MarginContainer/TabContainer/DesktopBackground"]
+unique_name_in_owner = true
+layout_mode = 2
+min_value = 1.0
+max_value = 10.0
+step = 0.01
+value = 2.253
+
+[node name="WaveTimeMulSpinBox" type="SpinBox" parent="Panel/MarginContainer/TabContainer/DesktopBackground"]
+unique_name_in_owner = true
+layout_mode = 2
+min_value = 0.01
+max_value = 2.0
+step = 0.01
+value = 0.01
+
+[node name="TotalPhasesSpinBox" type="SpinBox" parent="Panel/MarginContainer/TabContainer/DesktopBackground"]
+unique_name_in_owner = true
+layout_mode = 2
+min_value = 2.0
+max_value = 600.0
+step = 1.0
+value = 6.0
+
 [connection signal="toggled" from="Panel/MarginContainer/TabContainer/General/HBoxContainer/VBoxContainer2/SiggyButton" to="." method="_on_siggy_button_toggled"]
 [connection signal="toggled" from="Panel/MarginContainer/TabContainer/DesktopBackground/BlueWarpButton" to="." method="_on_blue_warp_button_toggled"]
 [connection signal="toggled" from="Panel/MarginContainer/TabContainer/DesktopBackground/ComicDots1Button" to="." method="_on_comic_dots_1_button_toggled"]
 [connection signal="toggled" from="Panel/MarginContainer/TabContainer/DesktopBackground/ComicDots2Button" to="." method="_on_comic_dots_2_button_toggled"]
+[connection signal="toggled" from="Panel/MarginContainer/TabContainer/DesktopBackground/WavesButton" to="." method="_on_waves_button_toggled"]
+[connection signal="color_changed" from="Panel/MarginContainer/TabContainer/DesktopBackground/BottomColorPicker" to="." method="_on_bottom_color_picker_color_changed"]
+[connection signal="color_changed" from="Panel/MarginContainer/TabContainer/DesktopBackground/TopColorPicker" to="." method="_on_top_color_picker_color_changed"]
+[connection signal="value_changed" from="Panel/MarginContainer/TabContainer/DesktopBackground/WaveAmpSpinBox" to="." method="_on_wave_amp_spin_box_value_changed"]
+[connection signal="value_changed" from="Panel/MarginContainer/TabContainer/DesktopBackground/WaveSizeSpinBox" to="." method="_on_wave_size_spin_box_value_changed"]
+[connection signal="value_changed" from="Panel/MarginContainer/TabContainer/DesktopBackground/WaveTimeMulSpinBox" to="." method="_on_wave_time_mul_spin_box_value_changed"]
+[connection signal="value_changed" from="Panel/MarginContainer/TabContainer/DesktopBackground/TotalPhasesSpinBox" to="." method="_on_total_phases_spin_box_value_changed"]

--- a/components/desktop_env.tscn
+++ b/components/desktop_env.tscn
@@ -287,6 +287,7 @@ grow_horizontal = 2
 grow_vertical = 2
 
 [node name="WavesShader" type="ColorRect" parent="ShaderBackgroundsContainer"]
+visible = false
 material = SubResource("ShaderMaterial_668nl")
 layout_mode = 1
 anchors_preset = 15
@@ -294,6 +295,8 @@ anchor_right = 1.0
 anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
+script = ExtResource("24_jkb4t")
+background_name = "Waves"
 
 [node name="TopBar" type="Control" parent="."]
 layout_mode = 1

--- a/components/settings_window.gd
+++ b/components/settings_window.gd
@@ -9,6 +9,14 @@ extends Pane
 @onready var blue_warp_button: CheckButton = %BlueWarpButton
 @onready var comic_dots1_button: CheckButton = %ComicDots1Button
 @onready var comic_dots2_button: CheckButton = %ComicDots2Button
+@onready var waves_button: CheckButton = %WavesButton
+@onready var bottom_color_picker: ColorPickerButton = %BottomColorPicker
+@onready var top_color_picker: ColorPickerButton = %TopColorPicker
+@onready var wave_amp_spin_box: SpinBox = %WaveAmpSpinBox
+@onready var wave_size_spin_box: SpinBox = %WaveSizeSpinBox
+@onready var wave_time_mul_spin_box: SpinBox = %WaveTimeMulSpinBox
+@onready var total_phases_spin_box: SpinBox = %TotalPhasesSpinBox
+@onready var waves_shader_material: ShaderMaterial = get_tree().root.get_node("Main/DesktopEnv/ShaderBackgroundsContainer/WavesShader").material
 
 
 func _ready() -> void:
@@ -25,6 +33,13 @@ func _ready() -> void:
 		blue_warp_button.button_pressed = Events.is_desktop_background_visible("BlueWarp")
 		comic_dots1_button.button_pressed = Events.is_desktop_background_visible("ComicDots1")
 		comic_dots2_button.button_pressed = Events.is_desktop_background_visible("ComicDots2")
+		waves_button.button_pressed = Events.is_desktop_background_visible("Waves")
+		bottom_color_picker.color = waves_shader_material.get_shader_parameter("bottom_color")
+		top_color_picker.color = waves_shader_material.get_shader_parameter("top_color")
+		wave_amp_spin_box.value = waves_shader_material.get_shader_parameter("wave_amp")
+		wave_size_spin_box.value = waves_shader_material.get_shader_parameter("wave_size")
+		wave_time_mul_spin_box.value = waves_shader_material.get_shader_parameter("wave_time_mul")
+		total_phases_spin_box.value = waves_shader_material.get_shader_parameter("total_phases")
 
 func update_checked_mode() -> void:
 	var mode = DisplayServer.window_get_mode()
@@ -71,7 +86,28 @@ func _on_comic_dots_1_button_toggled(toggled_on: bool) -> void:
 	Events.set_desktop_background_visible("ComicDots1", toggled_on)
 
 func _on_comic_dots_2_button_toggled(toggled_on: bool) -> void:
-		Events.set_desktop_background_visible("ComicDots2", toggled_on)
+	Events.set_desktop_background_visible("ComicDots2", toggled_on)
+
+func _on_waves_button_toggled(toggled_on: bool) -> void:
+	Events.set_desktop_background_visible("Waves", toggled_on)
+
+func _on_bottom_color_picker_color_changed(color: Color) -> void:
+	waves_shader_material.set_shader_parameter("bottom_color", color)
+
+func _on_top_color_picker_color_changed(color: Color) -> void:
+	waves_shader_material.set_shader_parameter("top_color", color)
+
+func _on_wave_amp_spin_box_value_changed(value: float) -> void:
+	waves_shader_material.set_shader_parameter("wave_amp", value)
+
+func _on_wave_size_spin_box_value_changed(value: float) -> void:
+	waves_shader_material.set_shader_parameter("wave_size", value)
+
+func _on_wave_time_mul_spin_box_value_changed(value: float) -> void:
+	waves_shader_material.set_shader_parameter("wave_time_mul", value)
+
+func _on_total_phases_spin_box_value_changed(value: float) -> void:
+	waves_shader_material.set_shader_parameter("total_phases", value)
 
 func _on_minute_passed(_total_minutes: int) -> void:
 		_update_autosave_timer_label()


### PR DESCRIPTION
## Summary
- allow toggling the Waves shader background
- expose Waves shader colors and animation controls in Settings

## Testing
- `godot4 --headless -s tests/test_runner.gd` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a552c7e0308325a75d61393f9189f4