### PR TITLE
Add slider-based shader controls for backgrounds

### DIFF
--- a/components/apps/app_scenes/settings.tscn
+++ b/components/apps/app_scenes/settings.tscn
@@ -164,28 +164,171 @@ size_flags_vertical = 3
 
 [node name="HBoxContainer" type="HBoxContainer" parent="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer"]
 layout_mode = 2
-
-[node name="VBoxContainer" type="VBoxContainer" parent="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer"]
+[node name="BlueWarpContainer" type="PanelContainer" parent="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer"]
 layout_mode = 2
 size_flags_horizontal = 6
 
-[node name="BlueWarpButton" type="CheckButton" parent="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer"]
+[node name="MarginContainer" type="MarginContainer" parent="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/BlueWarpContainer"]
+layout_mode = 2
+theme_override_constants/margin_left = 15
+theme_override_constants/margin_top = 15
+theme_override_constants/margin_right = 15
+theme_override_constants/margin_bottom = 15
+
+[node name="VBoxContainer" type="VBoxContainer" parent="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/BlueWarpContainer/MarginContainer"]
+layout_mode = 2
+
+[node name="BlueWarpButton" type="CheckButton" parent="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/BlueWarpContainer/MarginContainer/VBoxContainer"]
 unique_name_in_owner = true
 layout_mode = 2
+size_flags_horizontal = 4
 focus_mode = 0
 text = "Blue Warp"
 
-[node name="ComicDots1Button" type="CheckButton" parent="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer"]
+[node name="HBoxContainer" type="HBoxContainer" parent="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/BlueWarpContainer/MarginContainer/VBoxContainer"]
+layout_mode = 2
+
+[node name="Amplitude" type="Label" parent="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/BlueWarpContainer/MarginContainer/VBoxContainer/HBoxContainer"]
+layout_mode = 2
+text = "Stretch"
+
+[node name="BlueWarpStretchSlider" type="HSlider" parent="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/BlueWarpContainer/MarginContainer/VBoxContainer/HBoxContainer"]
 unique_name_in_owner = true
 layout_mode = 2
+min_value = 0.0
+max_value = 1.0
+step = 0.01
+value = 0.8
+
+[node name="HBoxContainer2" type="HBoxContainer" parent="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/BlueWarpContainer/MarginContainer/VBoxContainer"]
+layout_mode = 2
+
+[node name="Amplitude" type="Label" parent="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/BlueWarpContainer/MarginContainer/VBoxContainer/HBoxContainer2"]
+layout_mode = 2
+text = "Thing1"
+
+[node name="BlueWarpThing1Slider" type="HSlider" parent="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/BlueWarpContainer/MarginContainer/VBoxContainer/HBoxContainer2"]
+unique_name_in_owner = true
+layout_mode = 2
+min_value = 0.0
+max_value = 1.0
+step = 0.01
+value = 0.6
+
+[node name="HBoxContainer3" type="HBoxContainer" parent="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/BlueWarpContainer/MarginContainer/VBoxContainer"]
+layout_mode = 2
+
+[node name="Amplitude" type="Label" parent="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/BlueWarpContainer/MarginContainer/VBoxContainer/HBoxContainer3"]
+layout_mode = 2
+text = "Thing2"
+
+[node name="BlueWarpThing2Slider" type="HSlider" parent="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/BlueWarpContainer/MarginContainer/VBoxContainer/HBoxContainer3"]
+unique_name_in_owner = true
+layout_mode = 2
+min_value = 0.0
+max_value = 1.0
+step = 0.01
+value = 0.6
+
+[node name="HBoxContainer4" type="HBoxContainer" parent="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/BlueWarpContainer/MarginContainer/VBoxContainer"]
+layout_mode = 2
+
+[node name="Amplitude" type="Label" parent="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/BlueWarpContainer/MarginContainer/VBoxContainer/HBoxContainer4"]
+layout_mode = 2
+text = "Thing3"
+
+[node name="BlueWarpThing3Slider" type="HSlider" parent="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/BlueWarpContainer/MarginContainer/VBoxContainer/HBoxContainer4"]
+unique_name_in_owner = true
+layout_mode = 2
+min_value = 0.0
+max_value = 1.0
+step = 0.01
+value = 0.8
+
+[node name="HBoxContainer5" type="HBoxContainer" parent="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/BlueWarpContainer/MarginContainer/VBoxContainer"]
+layout_mode = 2
+
+[node name="Amplitude" type="Label" parent="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/BlueWarpContainer/MarginContainer/VBoxContainer/HBoxContainer5"]
+layout_mode = 2
+text = "Speed"
+
+[node name="BlueWarpSpeedSlider" type="HSlider" parent="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/BlueWarpContainer/MarginContainer/VBoxContainer/HBoxContainer5"]
+unique_name_in_owner = true
+layout_mode = 2
+min_value = 0.0
+max_value = 0.1
+step = 0.001
+value = 0.03
+
+[node name="ComicDotsContainer" type="PanelContainer" parent="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer"]
+layout_mode = 2
+size_flags_horizontal = 6
+
+[node name="MarginContainer" type="MarginContainer" parent="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/ComicDotsContainer"]
+layout_mode = 2
+theme_override_constants/margin_left = 15
+theme_override_constants/margin_top = 15
+theme_override_constants/margin_right = 15
+theme_override_constants/margin_bottom = 15
+
+[node name="VBoxContainer" type="VBoxContainer" parent="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/ComicDotsContainer/MarginContainer"]
+layout_mode = 2
+
+[node name="ComicDots1Button" type="CheckButton" parent="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/ComicDotsContainer/MarginContainer/VBoxContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 4
 focus_mode = 0
 text = "Comic Dots 1"
 
-[node name="ComicDots2Button" type="CheckButton" parent="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer"]
+[node name="ComicDots2Button" type="CheckButton" parent="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/ComicDotsContainer/MarginContainer/VBoxContainer"]
 unique_name_in_owner = true
 layout_mode = 2
+size_flags_horizontal = 4
 focus_mode = 0
 text = "Comic Dots 2"
+
+[node name="HBoxContainer" type="HBoxContainer" parent="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/ComicDotsContainer/MarginContainer/VBoxContainer"]
+layout_mode = 2
+
+[node name="Amplitude" type="Label" parent="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/ComicDotsContainer/MarginContainer/VBoxContainer/HBoxContainer"]
+layout_mode = 2
+text = "Color"
+
+[node name="ComicDotsColorPicker" type="ColorPickerButton" parent="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/ComicDotsContainer/MarginContainer/VBoxContainer/HBoxContainer"]
+unique_name_in_owner = true
+custom_minimum_size = Vector2(16, 16)
+layout_mode = 2
+
+[node name="HBoxContainer2" type="HBoxContainer" parent="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/ComicDotsContainer/MarginContainer/VBoxContainer"]
+layout_mode = 2
+
+[node name="Amplitude" type="Label" parent="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/ComicDotsContainer/MarginContainer/VBoxContainer/HBoxContainer2"]
+layout_mode = 2
+text = "Size"
+
+[node name="ComicDotsMultiplierSlider" type="HSlider" parent="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/ComicDotsContainer/MarginContainer/VBoxContainer/HBoxContainer2"]
+unique_name_in_owner = true
+layout_mode = 2
+min_value = 1.0
+max_value = 64.0
+step = 1.0
+value = 32.0
+
+[node name="HBoxContainer3" type="HBoxContainer" parent="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/ComicDotsContainer/MarginContainer/VBoxContainer"]
+layout_mode = 2
+
+[node name="Amplitude" type="Label" parent="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/ComicDotsContainer/MarginContainer/VBoxContainer/HBoxContainer3"]
+layout_mode = 2
+text = "Speed"
+
+[node name="ComicDotsSpeedSlider" type="HSlider" parent="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/ComicDotsContainer/MarginContainer/VBoxContainer/HBoxContainer3"]
+unique_name_in_owner = true
+layout_mode = 2
+min_value = 0.0
+max_value = 0.2
+step = 0.01
+value = 0.1
 
 [node name="WavesContainer" type="PanelContainer" parent="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer"]
 layout_mode = 2
@@ -232,7 +375,7 @@ layout_mode = 2
 layout_mode = 2
 text = "Amplitude"
 
-[node name="WaveAmpSpinBox" type="SpinBox" parent="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/WavesContainer/MarginContainer/VBoxContainer/HBoxContainer2"]
+[node name="WaveAmpSlider" type="HSlider" parent="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/WavesContainer/MarginContainer/VBoxContainer/HBoxContainer2"]
 unique_name_in_owner = true
 layout_mode = 2
 max_value = 0.5
@@ -246,7 +389,7 @@ layout_mode = 2
 layout_mode = 2
 text = "Frequency"
 
-[node name="WaveSizeSpinBox" type="SpinBox" parent="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/WavesContainer/MarginContainer/VBoxContainer/HBoxContainer3"]
+[node name="WaveSizeSlider" type="HSlider" parent="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/WavesContainer/MarginContainer/VBoxContainer/HBoxContainer3"]
 unique_name_in_owner = true
 layout_mode = 2
 min_value = 1.0
@@ -261,7 +404,7 @@ layout_mode = 2
 layout_mode = 2
 text = "Speed"
 
-[node name="WaveTimeMulSpinBox" type="SpinBox" parent="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/WavesContainer/MarginContainer/VBoxContainer/HBoxContainer4"]
+[node name="WaveTimeMulSlider" type="HSlider" parent="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/WavesContainer/MarginContainer/VBoxContainer/HBoxContainer4"]
 unique_name_in_owner = true
 layout_mode = 2
 min_value = 0.01
@@ -276,21 +419,30 @@ layout_mode = 2
 layout_mode = 2
 text = "Waves"
 
-[node name="TotalPhasesSpinBox" type="SpinBox" parent="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/WavesContainer/MarginContainer/VBoxContainer/HBoxContainer5"]
+[node name="TotalPhasesSlider" type="HSlider" parent="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/WavesContainer/MarginContainer/VBoxContainer/HBoxContainer5"]
 unique_name_in_owner = true
 layout_mode = 2
 min_value = 2.0
 max_value = 600.0
+step = 1.0
 value = 6.0
 
 [connection signal="toggled" from="Panel/MarginContainer/TabContainer/General/HBoxContainer/VBoxContainer2/SiggyButton" to="." method="_on_siggy_button_toggled"]
-[connection signal="toggled" from="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer/BlueWarpButton" to="." method="_on_blue_warp_button_toggled"]
-[connection signal="toggled" from="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer/ComicDots1Button" to="." method="_on_comic_dots_1_button_toggled"]
-[connection signal="toggled" from="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer/ComicDots2Button" to="." method="_on_comic_dots_2_button_toggled"]
+[connection signal="toggled" from="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/BlueWarpContainer/MarginContainer/VBoxContainer/BlueWarpButton" to="." method="_on_blue_warp_button_toggled"]
+[connection signal="toggled" from="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/ComicDotsContainer/MarginContainer/VBoxContainer/ComicDots1Button" to="." method="_on_comic_dots_1_button_toggled"]
+[connection signal="toggled" from="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/ComicDotsContainer/MarginContainer/VBoxContainer/ComicDots2Button" to="." method="_on_comic_dots_2_button_toggled"]
 [connection signal="toggled" from="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/WavesContainer/MarginContainer/VBoxContainer/WavesButton" to="." method="_on_waves_button_toggled"]
 [connection signal="color_changed" from="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/WavesContainer/MarginContainer/VBoxContainer/HBoxContainer/BottomColorPicker" to="." method="_on_bottom_color_picker_color_changed"]
 [connection signal="color_changed" from="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/WavesContainer/MarginContainer/VBoxContainer/HBoxContainer/TopColorPicker" to="." method="_on_top_color_picker_color_changed"]
-[connection signal="value_changed" from="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/WavesContainer/MarginContainer/VBoxContainer/HBoxContainer2/WaveAmpSpinBox" to="." method="_on_wave_amp_spin_box_value_changed"]
-[connection signal="value_changed" from="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/WavesContainer/MarginContainer/VBoxContainer/HBoxContainer3/WaveSizeSpinBox" to="." method="_on_wave_size_spin_box_value_changed"]
-[connection signal="value_changed" from="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/WavesContainer/MarginContainer/VBoxContainer/HBoxContainer4/WaveTimeMulSpinBox" to="." method="_on_wave_time_mul_spin_box_value_changed"]
-[connection signal="value_changed" from="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/WavesContainer/MarginContainer/VBoxContainer/HBoxContainer5/TotalPhasesSpinBox" to="." method="_on_total_phases_spin_box_value_changed"]
+[connection signal="value_changed" from="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/BlueWarpContainer/MarginContainer/VBoxContainer/HBoxContainer/BlueWarpStretchSlider" to="." method="_on_blue_warp_stretch_slider_value_changed"]
+[connection signal="value_changed" from="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/BlueWarpContainer/MarginContainer/VBoxContainer/HBoxContainer2/BlueWarpThing1Slider" to="." method="_on_blue_warp_thing1_slider_value_changed"]
+[connection signal="value_changed" from="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/BlueWarpContainer/MarginContainer/VBoxContainer/HBoxContainer3/BlueWarpThing2Slider" to="." method="_on_blue_warp_thing2_slider_value_changed"]
+[connection signal="value_changed" from="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/BlueWarpContainer/MarginContainer/VBoxContainer/HBoxContainer4/BlueWarpThing3Slider" to="." method="_on_blue_warp_thing3_slider_value_changed"]
+[connection signal="value_changed" from="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/BlueWarpContainer/MarginContainer/VBoxContainer/HBoxContainer5/BlueWarpSpeedSlider" to="." method="_on_blue_warp_speed_slider_value_changed"]
+[connection signal="color_changed" from="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/ComicDotsContainer/MarginContainer/VBoxContainer/HBoxContainer/ComicDotsColorPicker" to="." method="_on_comic_dots_color_picker_color_changed"]
+[connection signal="value_changed" from="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/ComicDotsContainer/MarginContainer/VBoxContainer/HBoxContainer2/ComicDotsMultiplierSlider" to="." method="_on_comic_dots_multiplier_slider_value_changed"]
+[connection signal="value_changed" from="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/ComicDotsContainer/MarginContainer/VBoxContainer/HBoxContainer3/ComicDotsSpeedSlider" to="." method="_on_comic_dots_speed_slider_value_changed"]
+[connection signal="value_changed" from="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/WavesContainer/MarginContainer/VBoxContainer/HBoxContainer2/WaveAmpSlider" to="." method="_on_wave_amp_slider_value_changed"]
+[connection signal="value_changed" from="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/WavesContainer/MarginContainer/VBoxContainer/HBoxContainer3/WaveSizeSlider" to="." method="_on_wave_size_slider_value_changed"]
+[connection signal="value_changed" from="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/WavesContainer/MarginContainer/VBoxContainer/HBoxContainer4/WaveTimeMulSlider" to="." method="_on_wave_time_mul_slider_value_changed"]
+[connection signal="value_changed" from="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/WavesContainer/MarginContainer/VBoxContainer/HBoxContainer5/TotalPhasesSlider" to="." method="_on_total_phases_slider_value_changed"]

--- a/components/settings_window.gd
+++ b/components/settings_window.gd
@@ -12,11 +12,22 @@ extends Pane
 @onready var waves_button: CheckButton = %WavesButton
 @onready var bottom_color_picker: ColorPickerButton = %BottomColorPicker
 @onready var top_color_picker: ColorPickerButton = %TopColorPicker
-@onready var wave_amp_spin_box: SpinBox = %WaveAmpSpinBox
-@onready var wave_size_spin_box: SpinBox = %WaveSizeSpinBox
-@onready var wave_time_mul_spin_box: SpinBox = %WaveTimeMulSpinBox
-@onready var total_phases_spin_box: SpinBox = %TotalPhasesSpinBox
+@onready var wave_amp_slider: HSlider = %WaveAmpSlider
+@onready var wave_size_slider: HSlider = %WaveSizeSlider
+@onready var wave_time_mul_slider: HSlider = %WaveTimeMulSlider
+@onready var total_phases_slider: HSlider = %TotalPhasesSlider
+@onready var blue_warp_stretch_slider: HSlider = %BlueWarpStretchSlider
+@onready var blue_warp_thing1_slider: HSlider = %BlueWarpThing1Slider
+@onready var blue_warp_thing2_slider: HSlider = %BlueWarpThing2Slider
+@onready var blue_warp_thing3_slider: HSlider = %BlueWarpThing3Slider
+@onready var blue_warp_speed_slider: HSlider = %BlueWarpSpeedSlider
+@onready var comic_dots_color_picker: ColorPickerButton = %ComicDotsColorPicker
+@onready var comic_dots_multiplier_slider: HSlider = %ComicDotsMultiplierSlider
+@onready var comic_dots_speed_slider: HSlider = %ComicDotsSpeedSlider
 @onready var waves_shader_material: ShaderMaterial = get_tree().root.get_node("Main/DesktopEnv/ShaderBackgroundsContainer/WavesShader").material
+@onready var blue_warp_shader_material: ShaderMaterial = get_tree().root.get_node("Main/DesktopEnv/ShaderBackgroundsContainer/BlueWarpShader").material
+@onready var comic_dots1_shader_material: ShaderMaterial = get_tree().root.get_node("Main/DesktopEnv/ShaderBackgroundsContainer/ComicDotsBlueVert").material
+@onready var comic_dots2_shader_material: ShaderMaterial = get_tree().root.get_node("Main/DesktopEnv/ShaderBackgroundsContainer/ComicDotsBlueHor").material
 
 
 func _ready() -> void:
@@ -34,12 +45,20 @@ func _ready() -> void:
 		comic_dots1_button.button_pressed = Events.is_desktop_background_visible("ComicDots1")
 		comic_dots2_button.button_pressed = Events.is_desktop_background_visible("ComicDots2")
 		waves_button.button_pressed = Events.is_desktop_background_visible("Waves")
-		bottom_color_picker.color = waves_shader_material.get_shader_parameter("bottom_color")
-		top_color_picker.color = waves_shader_material.get_shader_parameter("top_color")
-		wave_amp_spin_box.value = waves_shader_material.get_shader_parameter("wave_amp")
-		wave_size_spin_box.value = waves_shader_material.get_shader_parameter("wave_size")
-		wave_time_mul_spin_box.value = waves_shader_material.get_shader_parameter("wave_time_mul")
-		total_phases_spin_box.value = waves_shader_material.get_shader_parameter("total_phases")
+                bottom_color_picker.color = waves_shader_material.get_shader_parameter("bottom_color")
+                top_color_picker.color = waves_shader_material.get_shader_parameter("top_color")
+                wave_amp_slider.value = waves_shader_material.get_shader_parameter("wave_amp")
+                wave_size_slider.value = waves_shader_material.get_shader_parameter("wave_size")
+                wave_time_mul_slider.value = waves_shader_material.get_shader_parameter("wave_time_mul")
+                total_phases_slider.value = waves_shader_material.get_shader_parameter("total_phases")
+                blue_warp_stretch_slider.value = blue_warp_shader_material.get_shader_parameter("stretch")
+                blue_warp_thing1_slider.value = blue_warp_shader_material.get_shader_parameter("thing1")
+                blue_warp_thing2_slider.value = blue_warp_shader_material.get_shader_parameter("thing2")
+                blue_warp_thing3_slider.value = blue_warp_shader_material.get_shader_parameter("thing3")
+                blue_warp_speed_slider.value = blue_warp_shader_material.get_shader_parameter("speed")
+                comic_dots_color_picker.color = comic_dots1_shader_material.get_shader_parameter("circle_color")
+                comic_dots_multiplier_slider.value = comic_dots1_shader_material.get_shader_parameter("circle_multiplier")
+                comic_dots_speed_slider.value = comic_dots1_shader_material.get_shader_parameter("speed")
 
 func update_checked_mode() -> void:
 	var mode = DisplayServer.window_get_mode()
@@ -95,19 +114,46 @@ func _on_bottom_color_picker_color_changed(color: Color) -> void:
 	waves_shader_material.set_shader_parameter("bottom_color", color)
 
 func _on_top_color_picker_color_changed(color: Color) -> void:
-	waves_shader_material.set_shader_parameter("top_color", color)
+        waves_shader_material.set_shader_parameter("top_color", color)
 
-func _on_wave_amp_spin_box_value_changed(value: float) -> void:
-	waves_shader_material.set_shader_parameter("wave_amp", value)
+func _on_wave_amp_slider_value_changed(value: float) -> void:
+        waves_shader_material.set_shader_parameter("wave_amp", value)
 
-func _on_wave_size_spin_box_value_changed(value: float) -> void:
-	waves_shader_material.set_shader_parameter("wave_size", value)
+func _on_wave_size_slider_value_changed(value: float) -> void:
+        waves_shader_material.set_shader_parameter("wave_size", value)
 
-func _on_wave_time_mul_spin_box_value_changed(value: float) -> void:
-	waves_shader_material.set_shader_parameter("wave_time_mul", value)
+func _on_wave_time_mul_slider_value_changed(value: float) -> void:
+        waves_shader_material.set_shader_parameter("wave_time_mul", value)
 
-func _on_total_phases_spin_box_value_changed(value: float) -> void:
-	waves_shader_material.set_shader_parameter("total_phases", value)
+func _on_total_phases_slider_value_changed(value: float) -> void:
+        waves_shader_material.set_shader_parameter("total_phases", value)
+
+func _on_blue_warp_stretch_slider_value_changed(value: float) -> void:
+        blue_warp_shader_material.set_shader_parameter("stretch", value)
+
+func _on_blue_warp_thing1_slider_value_changed(value: float) -> void:
+        blue_warp_shader_material.set_shader_parameter("thing1", value)
+
+func _on_blue_warp_thing2_slider_value_changed(value: float) -> void:
+        blue_warp_shader_material.set_shader_parameter("thing2", value)
+
+func _on_blue_warp_thing3_slider_value_changed(value: float) -> void:
+        blue_warp_shader_material.set_shader_parameter("thing3", value)
+
+func _on_blue_warp_speed_slider_value_changed(value: float) -> void:
+        blue_warp_shader_material.set_shader_parameter("speed", value)
+
+func _on_comic_dots_color_picker_color_changed(color: Color) -> void:
+        comic_dots1_shader_material.set_shader_parameter("circle_color", color)
+        comic_dots2_shader_material.set_shader_parameter("circle_color", color)
+
+func _on_comic_dots_multiplier_slider_value_changed(value: float) -> void:
+        comic_dots1_shader_material.set_shader_parameter("circle_multiplier", value)
+        comic_dots2_shader_material.set_shader_parameter("circle_multiplier", value)
+
+func _on_comic_dots_speed_slider_value_changed(value: float) -> void:
+        comic_dots1_shader_material.set_shader_parameter("speed", value)
+        comic_dots2_shader_material.set_shader_parameter("speed", value)
 
 func _on_minute_passed(_total_minutes: int) -> void:
 		_update_autosave_timer_label()


### PR DESCRIPTION
## Summary
- replace wave spinboxes with sliders
- add Blue Warp shader panel
- add Comic Dots shader panel

## Testing
- `pytest`
- `pre-commit run --files components/settings_window.gd components/apps/app_scenes/settings.tscn` *(fails: .pre-commit-config.yaml is not a file)*

------
https://chatgpt.com/codex/tasks/task_e_68a55cec8ae883258bb2d1b41e2e9d96