### PR TITLE
Fix EarlyBird autopilot window offset bug

### DIFF
--- a/components/apps/early_bird/early_bird_autopilot.gd
+++ b/components/apps/early_bird/early_bird_autopilot.gd
@@ -13,25 +13,25 @@ func _process(delta: float) -> void:
 		printerr("Autopilot cannot find pipe manager")
 		return
 
-	var pipes = pipe_manager.get_active_pipe_pairs()
-	if pipes.is_empty():
-		if player.global_position.y > 300:
-			player.flap()
-		return
+        var pipes = pipe_manager.get_active_pipe_pairs()
+        if pipes.is_empty():
+                if player.position.y > 300:
+                        player.flap()
+                return
 
-	# Find the first pipe ahead of the player
-	var next_pipe = null
-	for pipe in pipes:
-		if pipe.global_position.x > player.global_position.x - 40: # Adjust magic number for fine tuning
-			next_pipe = pipe
-			break
-	
-	if player.global_position.y > 550:
-			player.flap()
-	
-	if next_pipe:
-		var target_y = next_pipe.get_gap_center_y() #- 51 # Adjust magic number for fine tuning
-		if player.global_position.y > target_y:
-			player.flap()
+        # Find the first pipe ahead of the player
+        var next_pipe = null
+        for pipe in pipes:
+                if pipe.position.x > player.position.x - 40: # Adjust magic number for fine tuning
+                        next_pipe = pipe
+                        break
+
+        if player.position.y > 550:
+                        player.flap()
+
+        if next_pipe:
+                var target_y = next_pipe.get_gap_center_y() #- 51 # Adjust magic number for fine tuning
+                if player.position.y > target_y:
+                        player.flap()
 			
 	#print(player.global_position)

--- a/components/apps/early_bird/pipe_pair.gd
+++ b/components/apps/early_bird/pipe_pair.gd
@@ -41,4 +41,4 @@ func randomize_gap_position() -> void:
 
 
 func get_gap_center_y() -> float:
-	return global_position.y
+        return position.y


### PR DESCRIPTION
## Summary
- Prevent autopilot from using screen-relative coordinates by comparing player and pipe positions locally
- Report pipe gap center in local space

## Testing
- `apt-get install -y godot4` *(fails: Unable to locate package godot4)*
- `apt-get install -y godot` *(fails: Unable to locate package godot)*
- `godot --headless -s tests/test_runner.gd` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a561c562308325a1381ebe6e7a58d7