### PR TITLE
feat: improve stat progress bar formatting

### DIFF
--- a/components/apps/fumble/fumble.tscn
+++ b/components/apps/fumble/fumble.tscn
@@ -479,6 +479,9 @@ show_percentage = false
 script = ExtResource("10_jh1fk")
 tooltip_name = "Confidence"
 duration = 0.4
+stat_name = "confidence"
+auto_update = false
+fractional = false
 
 [node name="Label" type="Label" parent="MarginContainer/VBoxContainer/MenuTabContainer/ConfidenceProgressBar"]
 layout_mode = 1
@@ -562,6 +565,9 @@ script = ExtResource("10_jh1fk")
 stat_name = "ex"
 duration = 0.4
 reset_on_overflow = true
+show_value_before = true
+fractional = false
+value_decimals = 0
 
 [node name="ExLabel" type="Label" parent="MarginContainer/VBoxContainer/MenuTabContainer/ExProgressBar"]
 unique_name_in_owner = true

--- a/components/apps/fumble/stat_progress_bar.gd
+++ b/components/apps/fumble/stat_progress_bar.gd
@@ -9,28 +9,46 @@ extends ProgressBar
 @export var transition := Tween.TRANS_CUBIC
 @export var fractional := true
 @export var reset_on_overflow := false
+@export var show_value_before := false
+@export var value_decimals: int = 2
+@export var auto_update: bool = true
 
 var _tween: Tween = null
 var _actual_value: float = 0.0
+var _label: Label = null
+var _label_base_text: String = ""
+
+func _find_label() -> Label:
+        for child in get_children():
+                if child is Label:
+                        return child
+        return null
 
 func _ready():
-		if stat_name != "":
-				StatManager.connect_to_stat(stat_name, self, "_on_stat_updated")
-		if tooltip_name == "":
-				tooltip_name = stat_name
-		_actual_value = value
-		update_tooltip(value)
+                _label = _find_label()
+                if _label:
+                                _label_base_text = _label.text
+                if stat_name != "":
+                                StatManager.connect_to_stat(stat_name, self, "_on_stat_updated")
+                if tooltip_name == "":
+                                tooltip_name = stat_name
+                _actual_value = value
+                update_tooltip(value)
 
 func _exit_tree():
-		if stat_name != "":
-				StatManager.disconnect_from_stat(stat_name, self, "_on_stat_updated")
+                if stat_name != "":
+                                StatManager.disconnect_from_stat(stat_name, self, "_on_stat_updated")
 
 func _on_stat_updated(value: float) -> void:
-	update_value(value)
+        if auto_update:
+                update_value(value)
+        else:
+                _actual_value = value
+                update_tooltip(_actual_value)
 
 func update_value(new_value: float) -> void:
-	_actual_value = new_value
-	var display_value = new_value
+        _actual_value = new_value
+        var display_value = new_value
 	if reset_on_overflow:
 		display_value = fmod(new_value, max_value)
 		if display_value < 0:
@@ -41,25 +59,36 @@ func update_value(new_value: float) -> void:
 			display_value = int(new_value)
 		# Otherwise just use the float value (including > max_value if overflows)
 
-	if animate:
-		set_value_animated(display_value, _actual_value)
-	else:
-		value = clamp(display_value, min_value, max_value)
-		update_tooltip(_actual_value)
+        if animate:
+                set_value_animated(display_value, _actual_value)
+        else:
+                value = clamp(display_value, min_value, max_value)
+                update_tooltip(_actual_value)
 
 func set_value_animated(target_value: float, tooltip_value: float) -> void:
 	if _tween:
 		_tween.kill()
-	_tween = get_tree().create_tween()
-	_tween.tween_property(
-		self, "value", clamp(target_value, min_value, max_value), duration
-	).set_trans(transition).set_ease(easing)
-	_tween.tween_callback(Callable(self, "update_tooltip").bind(tooltip_value))
+        _tween = get_tree().create_tween()
+        _tween.tween_property(
+                self, "value", clamp(target_value, min_value, max_value), duration
+        ).set_trans(transition).set_ease(easing)
+        _tween.tween_callback(Callable(self, "update_tooltip").bind(tooltip_value))
 
 func update_tooltip(val: float) -> void:
-	var str_val: String
-	if fractional:
-		str_val = "%.2f" % val
-	else:
-		str_val = str(int(val))
-		tooltip_text = "%s: %s" % [tooltip_name, str_val]
+        var str_val := _format_value(val)
+        tooltip_text = "%s: %s" % [tooltip_name, str_val]
+        _update_label()
+
+func _format_value(val: float) -> String:
+        if fractional:
+                var format_str := "%." + str(value_decimals) + "f"
+                return format_str % val
+        return str(int(val))
+
+func _update_label() -> void:
+        if not _label:
+                return
+        if show_value_before:
+                _label.text = "%s %s" % [_format_value(_actual_value), _label_base_text]
+        else:
+                _label.text = _label_base_text


### PR DESCRIPTION
## Summary
- show values before StatProgressBar labels and control decimal places
- allow StatProgressBar to defer automatic stat updates
- configure Fumble bars for confidence tracking and XP value display

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a51a19a520832587015d5c8ca4ea7e