### PR TITLE
feat: implement sigma mail inbox ui

### DIFF
--- a/components/apps/app_scenes/sigma_mail.tscn
+++ b/components/apps/app_scenes/sigma_mail.tscn
@@ -51,6 +51,7 @@ layout_mode = 2
 size_flags_horizontal = 3
 mouse_filter = 1
 
+
 [node name="MarginContainer" type="MarginContainer" parent="HBoxContainer/Panel"]
 layout_mode = 2
 size_flags_horizontal = 3
@@ -59,53 +60,48 @@ theme_override_constants/margin_top = 10
 theme_override_constants/margin_right = 10
 theme_override_constants/margin_bottom = 10
 
-[node name="ScrollContainer" type="ScrollContainer" parent="HBoxContainer/Panel/MarginContainer"]
-layout_mode = 2
-
-[node name="Inbox" type="VBoxContainer" parent="HBoxContainer/Panel/MarginContainer/ScrollContainer"]
+[node name="VBox" type="VBoxContainer" parent="HBoxContainer/Panel/MarginContainer"]
 layout_mode = 2
 size_flags_horizontal = 3
-size_flags_vertical = 2
-size_flags_stretch_ratio = 4.0
-alignment = 2
+size_flags_vertical = 3
 
-[node name="Button" type="Button" parent="HBoxContainer/Panel/MarginContainer/ScrollContainer/Inbox"]
+[node name="Controls" type="HBoxContainer" parent="HBoxContainer/Panel/MarginContainer/VBox"]
 layout_mode = 2
-size_flags_vertical = 8
-text = " from: jamie95@horizon.net Subject: "
-alignment = 0
+size_flags_horizontal = 3
 
-[node name="Button2" type="Button" parent="HBoxContainer/Panel/MarginContainer/ScrollContainer/Inbox"]
+[node name="SearchBar" type="LineEdit" parent="HBoxContainer/Panel/MarginContainer/VBox/Controls"]
 layout_mode = 2
-text = " from: jamie95@horizon.net Subject: "
-alignment = 0
+size_flags_horizontal = 3
+placeholder_text = "Search"
 
-[node name="Button3" type="Button" parent="HBoxContainer/Panel/MarginContainer/ScrollContainer/Inbox"]
+[node name="LimitSpin" type="SpinBox" parent="HBoxContainer/Panel/MarginContainer/VBox/Controls"]
 layout_mode = 2
-text = " from: jamie95@horizon.net Subject: "
-alignment = 0
+min_value = 1.0
+max_value = 100.0
+step = 1.0
+value = 10.0
 
-[node name="Button4" type="Button" parent="HBoxContainer/Panel/MarginContainer/ScrollContainer/Inbox"]
+[node name="ScrollContainer" type="ScrollContainer" parent="HBoxContainer/Panel/MarginContainer/VBox"]
 layout_mode = 2
-text = " from: jamie95@horizon.net Subject: "
-alignment = 0
+size_flags_horizontal = 3
+size_flags_vertical = 3
 
-[node name="Button5" type="Button" parent="HBoxContainer/Panel/MarginContainer/ScrollContainer/Inbox"]
+[node name="Inbox" type="VBoxContainer" parent="HBoxContainer/Panel/MarginContainer/VBox/ScrollContainer"]
 layout_mode = 2
-text = " from: jamie95@horizon.net Subject: "
-alignment = 0
+size_flags_horizontal = 3
 
-[node name="Button6" type="Button" parent="HBoxContainer/Panel/MarginContainer/ScrollContainer/Inbox"]
+[node name="Pagination" type="HBoxContainer" parent="HBoxContainer/Panel/MarginContainer/VBox"]
 layout_mode = 2
-text = " from: jamie95@horizon.net Subject: "
-alignment = 0
+size_flags_horizontal = 3
 
-[node name="Button7" type="Button" parent="HBoxContainer/Panel/MarginContainer/ScrollContainer/Inbox"]
+[node name="PrevButton" type="Button" parent="HBoxContainer/Panel/MarginContainer/VBox/Pagination"]
 layout_mode = 2
-text = " from: jamie95@horizon.net Subject: "
-alignment = 0
+text = "Prev"
 
-[node name="Button8" type="Button" parent="HBoxContainer/Panel/MarginContainer/ScrollContainer/Inbox"]
+[node name="PageLabel" type="Label" parent="HBoxContainer/Panel/MarginContainer/VBox/Pagination"]
 layout_mode = 2
-text = " from: jamie95@horizon.net Subject: "
-alignment = 0
+text = "Page 1/1"
+
+[node name="NextButton" type="Button" parent="HBoxContainer/Panel/MarginContainer/VBox/Pagination"]
+layout_mode = 2
+text = "Next"

--- a/components/apps/sigma_mail/sigma_mail.gd
+++ b/components/apps/sigma_mail/sigma_mail.gd
@@ -1,10 +1,76 @@
 extends Pane
 class_name SigmaMail
 
+@onready var search_bar: LineEdit = %SearchBar
+@onready var limit_spin: SpinBox = %LimitSpin
+@onready var inbox: VBoxContainer = %Inbox
+@onready var page_label: Label = %PageLabel
+@onready var prev_button: Button = %PrevButton
+@onready var next_button: Button = %NextButton
 
+var emails: Array = []
+var filtered_emails: Array = []
+var current_page: int = 0
+var emails_per_page: int = 10
 
 func _ready() -> void:
-	#app_title = "Sigma Mail"
-	#app_icon = preload("res://assets/AlphaOnline.png")
-#	emit_signal("title_updated", app_title)
-	pass
+        _generate_dummy_emails()
+        limit_spin.value = emails_per_page
+        search_bar.text_changed.connect(_on_search_changed)
+        limit_spin.value_changed.connect(_on_limit_changed)
+        prev_button.pressed.connect(_on_prev_page)
+        next_button.pressed.connect(_on_next_page)
+        _apply_filter()
+
+func _generate_dummy_emails() -> void:
+        emails.clear()
+        for i in range(1, 51):
+                emails.append({
+                        "from": "user%d@example.com" % i,
+                        "subject": "Subject %d" % i,
+                })
+
+func _on_search_changed(_new_text: String) -> void:
+        _apply_filter()
+
+func _on_limit_changed(value: float) -> void:
+        emails_per_page = int(value)
+        current_page = 0
+        _render_emails()
+
+func _on_prev_page() -> void:
+        if current_page > 0:
+                current_page -= 1
+                _render_emails()
+
+func _on_next_page() -> void:
+        if (current_page + 1) * emails_per_page < filtered_emails.size():
+                current_page += 1
+                _render_emails()
+
+func _apply_filter() -> void:
+        var query = search_bar.text.to_lower()
+        filtered_emails.clear()
+        for email in emails:
+                if query == "" or email["from"].to_lower().find(query) != -1 or email["subject"].to_lower().find(query) != -1:
+                        filtered_emails.append(email)
+        current_page = 0
+        _render_emails()
+
+func _render_emails() -> void:
+        for child in inbox.get_children():
+                child.queue_free()
+        var start = current_page * emails_per_page
+        var end = min(start + emails_per_page, filtered_emails.size())
+        for i in range(start, end):
+                var email = filtered_emails[i]
+                var btn = Button.new()
+                btn.text = "From: %s  Subject: %s" % [email["from"], email["subject"]]
+                btn.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+                btn.alignment = HORIZONTAL_ALIGNMENT_LEFT
+                inbox.add_child(btn)
+        var total_pages = max(1, int(ceil(filtered_emails.size() / float(emails_per_page))))
+        page_label.text = "Page %d/%d" % [current_page + 1, total_pages]
+        prev_button.disabled = current_page == 0
+        next_button.disabled = current_page >= total_pages - 1
+


### PR DESCRIPTION
## Summary
- add inbox UI with search and pagination controls
- allow adjusting number of emails shown per page
- render sample email list with navigation between pages

## Testing
- `godot4 --headless --run tests/test_runner.tscn` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a571afcd208325ae158528fd50d397