### PR TITLE
Add electric desktop background controls

### DIFF
--- a/autoloads/events.gd
+++ b/autoloads/events.gd
@@ -8,6 +8,7 @@ var desktop_backgrounds: Dictionary = {
 	"ComicDots1": false,
 	"ComicDots2": false,
 	"Waves": false,
+	"Electric": false,
 }
 
 func set_desktop_background_visible(name: String, visible: bool) -> void:

--- a/components/apps/app_scenes/settings.tscn
+++ b/components/apps/app_scenes/settings.tscn
@@ -436,6 +436,124 @@ min_value = 2.0
 max_value = 600.0
 value = 6.0
 
+[node name="ElectricContainer" type="PanelContainer" parent="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer"]
+layout_mode = 2
+size_flags_horizontal = 6
+
+[node name="MarginContainer" type="MarginContainer" parent="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/ElectricContainer"]
+layout_mode = 2
+theme_override_constants/margin_left = 15
+theme_override_constants/margin_top = 15
+theme_override_constants/margin_right = 15
+theme_override_constants/margin_bottom = 15
+
+[node name="VBoxContainer" type="VBoxContainer" parent="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/ElectricContainer/MarginContainer"]
+layout_mode = 2
+
+[node name="ElectricButton" type="CheckButton" parent="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/ElectricContainer/MarginContainer/VBoxContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 4
+focus_mode = 0
+theme_override_fonts/font = ExtResource("4_a82ne")
+theme_override_font_sizes/font_size = 24
+theme_override_styles/normal = SubResource("StyleBoxFlat_dij2h")
+text = " Electric"
+
+[node name="HBoxContainer" type="HBoxContainer" parent="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/ElectricContainer/MarginContainer/VBoxContainer"]
+layout_mode = 2
+
+[node name="ElectricBGColorPicker" type="ColorPickerButton" parent="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/ElectricContainer/MarginContainer/VBoxContainer/HBoxContainer"]
+unique_name_in_owner = true
+custom_minimum_size = Vector2(16, 16)
+layout_mode = 2
+
+[node name="ElectricLineColorPicker" type="ColorPickerButton" parent="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/ElectricContainer/MarginContainer/VBoxContainer/HBoxContainer"]
+unique_name_in_owner = true
+custom_minimum_size = Vector2(16, 16)
+layout_mode = 2
+color = Color(0, 1, 1, 1)
+
+[node name="HBoxContainer2" type="HBoxContainer" parent="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/ElectricContainer/MarginContainer/VBoxContainer"]
+layout_mode = 2
+
+[node name="Label" type="Label" parent="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/ElectricContainer/MarginContainer/VBoxContainer/HBoxContainer2"]
+layout_mode = 2
+text = "Freq"
+
+[node name="ElectricFreqSlider" type="HSlider" parent="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/ElectricContainer/MarginContainer/VBoxContainer/HBoxContainer2"]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 3
+min_value = 0.0
+max_value = 20.0
+step = 0.01
+value = 5.085
+
+[node name="HBoxContainer3" type="HBoxContainer" parent="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/ElectricContainer/MarginContainer/VBoxContainer"]
+layout_mode = 2
+
+[node name="Label" type="Label" parent="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/ElectricContainer/MarginContainer/VBoxContainer/HBoxContainer3"]
+layout_mode = 2
+text = "Height"
+
+[node name="ElectricHeightSlider" type="HSlider" parent="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/ElectricContainer/MarginContainer/VBoxContainer/HBoxContainer3"]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 3
+min_value = 0.0
+max_value = 1.0
+step = 0.01
+value = 0.6
+
+[node name="HBoxContainer4" type="HBoxContainer" parent="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/ElectricContainer/MarginContainer/VBoxContainer"]
+layout_mode = 2
+
+[node name="Label" type="Label" parent="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/ElectricContainer/MarginContainer/VBoxContainer/HBoxContainer4"]
+layout_mode = 2
+text = "Speed"
+
+[node name="ElectricSpeedSlider" type="HSlider" parent="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/ElectricContainer/MarginContainer/VBoxContainer/HBoxContainer4"]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 3
+min_value = 0.0
+max_value = 10.0
+step = 0.01
+value = 2.555
+
+[node name="HBoxContainer5" type="HBoxContainer" parent="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/ElectricContainer/MarginContainer/VBoxContainer"]
+layout_mode = 2
+
+[node name="Label" type="Label" parent="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/ElectricContainer/MarginContainer/VBoxContainer/HBoxContainer5"]
+layout_mode = 2
+text = "Scale X"
+
+[node name="ElectricScaleXSlider" type="HSlider" parent="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/ElectricContainer/MarginContainer/VBoxContainer/HBoxContainer5"]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 3
+min_value = 1.0
+max_value = 10.0
+step = 0.01
+value = 3.25
+
+[node name="HBoxContainer6" type="HBoxContainer" parent="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/ElectricContainer/MarginContainer/VBoxContainer"]
+layout_mode = 2
+
+[node name="Label" type="Label" parent="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/ElectricContainer/MarginContainer/VBoxContainer/HBoxContainer6"]
+layout_mode = 2
+text = "Scale Y"
+
+[node name="ElectricScaleYSlider" type="HSlider" parent="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/ElectricContainer/MarginContainer/VBoxContainer/HBoxContainer6"]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 3
+min_value = 1.0
+max_value = 30.0
+step = 0.01
+value = 15.43
+
 [connection signal="toggled" from="Panel/MarginContainer/TabContainer/General/HBoxContainer/VBoxContainer2/SiggyButton" to="." method="_on_siggy_button_toggled"]
 [connection signal="toggled" from="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/BlueWarpContainer/MarginContainer/VBoxContainer/BlueWarpButton" to="." method="_on_blue_warp_button_toggled"]
 [connection signal="value_changed" from="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/BlueWarpContainer/MarginContainer/VBoxContainer/HBoxContainer/BlueWarpStretchSlider" to="." method="_on_blue_warp_stretch_slider_value_changed"]
@@ -455,3 +573,11 @@ value = 6.0
 [connection signal="value_changed" from="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/WavesContainer/MarginContainer/VBoxContainer/HBoxContainer3/WaveSizeSlider" to="." method="_on_wave_size_slider_value_changed"]
 [connection signal="value_changed" from="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/WavesContainer/MarginContainer/VBoxContainer/HBoxContainer4/WaveTimeMulSlider" to="." method="_on_wave_time_mul_slider_value_changed"]
 [connection signal="value_changed" from="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/WavesContainer/MarginContainer/VBoxContainer/HBoxContainer5/TotalPhasesSlider" to="." method="_on_total_phases_slider_value_changed"]
+[connection signal="toggled" from="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/ElectricContainer/MarginContainer/VBoxContainer/ElectricButton" to="." method="_on_electric_button_toggled"]
+[connection signal="color_changed" from="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/ElectricContainer/MarginContainer/VBoxContainer/HBoxContainer/ElectricBGColorPicker" to="." method="_on_electric_bg_color_picker_color_changed"]
+[connection signal="color_changed" from="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/ElectricContainer/MarginContainer/VBoxContainer/HBoxContainer/ElectricLineColorPicker" to="." method="_on_electric_line_color_picker_color_changed"]
+[connection signal="value_changed" from="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/ElectricContainer/MarginContainer/VBoxContainer/HBoxContainer2/ElectricFreqSlider" to="." method="_on_electric_freq_slider_value_changed"]
+[connection signal="value_changed" from="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/ElectricContainer/MarginContainer/VBoxContainer/HBoxContainer3/ElectricHeightSlider" to="." method="_on_electric_height_slider_value_changed"]
+[connection signal="value_changed" from="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/ElectricContainer/MarginContainer/VBoxContainer/HBoxContainer4/ElectricSpeedSlider" to="." method="_on_electric_speed_slider_value_changed"]
+[connection signal="value_changed" from="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/ElectricContainer/MarginContainer/VBoxContainer/HBoxContainer5/ElectricScaleXSlider" to="." method="_on_electric_scale_x_slider_value_changed"]
+[connection signal="value_changed" from="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/ElectricContainer/MarginContainer/VBoxContainer/HBoxContainer6/ElectricScaleYSlider" to="." method="_on_electric_scale_y_slider_value_changed"]

--- a/components/desktop_env.tscn
+++ b/components/desktop_env.tscn
@@ -317,6 +317,8 @@ anchor_right = 1.0
 anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
+script = ExtResource("24_jkb4t")
+background_name = "Electric"
 
 [node name="TopBar" type="Control" parent="."]
 layout_mode = 1

--- a/components/settings_window.gd
+++ b/components/settings_window.gd
@@ -24,10 +24,19 @@ extends Pane
 @onready var comic_dots_color_picker: ColorPickerButton = %ComicDotsColorPicker
 @onready var comic_dots_multiplier_slider: HSlider = %ComicDotsMultiplierSlider
 @onready var comic_dots_speed_slider: HSlider = %ComicDotsSpeedSlider
+@onready var electric_button: CheckButton = %ElectricButton
+@onready var electric_bg_color_picker: ColorPickerButton = %ElectricBGColorPicker
+@onready var electric_line_color_picker: ColorPickerButton = %ElectricLineColorPicker
+@onready var electric_freq_slider: HSlider = %ElectricFreqSlider
+@onready var electric_height_slider: HSlider = %ElectricHeightSlider
+@onready var electric_speed_slider: HSlider = %ElectricSpeedSlider
+@onready var electric_scale_x_slider: HSlider = %ElectricScaleXSlider
+@onready var electric_scale_y_slider: HSlider = %ElectricScaleYSlider
 @onready var waves_shader_material: ShaderMaterial = get_tree().root.get_node("Main/DesktopEnv/ShaderBackgroundsContainer/WavesShader").material
 @onready var blue_warp_shader_material: ShaderMaterial = get_tree().root.get_node("Main/DesktopEnv/ShaderBackgroundsContainer/BlueWarpShader").material
 @onready var comic_dots1_shader_material: ShaderMaterial = get_tree().root.get_node("Main/DesktopEnv/ShaderBackgroundsContainer/ComicDotsBlueVert").material
 @onready var comic_dots2_shader_material: ShaderMaterial = get_tree().root.get_node("Main/DesktopEnv/ShaderBackgroundsContainer/ComicDotsBlueHor").material
+@onready var electric_shader_material: ShaderMaterial = get_tree().root.get_node("Main/DesktopEnv/ShaderBackgroundsContainer/ElectricShader").material
 
 
 func _ready() -> void:
@@ -59,6 +68,15 @@ func _ready() -> void:
 		comic_dots_color_picker.color = comic_dots1_shader_material.get_shader_parameter("circle_color")
 		comic_dots_multiplier_slider.value = comic_dots1_shader_material.get_shader_parameter("circle_multiplier")
 		comic_dots_speed_slider.value = comic_dots1_shader_material.get_shader_parameter("speed")
+		electric_button.button_pressed = Events.is_desktop_background_visible("Electric")
+		electric_bg_color_picker.color = electric_shader_material.get_shader_parameter("background_color")
+		electric_line_color_picker.color = electric_shader_material.get_shader_parameter("line_color")
+		electric_freq_slider.value = electric_shader_material.get_shader_parameter("line_freq")
+		electric_height_slider.value = electric_shader_material.get_shader_parameter("height")
+		electric_speed_slider.value = electric_shader_material.get_shader_parameter("speed")
+		var electric_scale: Vector2 = electric_shader_material.get_shader_parameter("scale")
+		electric_scale_x_slider.value = electric_scale.x
+		electric_scale_y_slider.value = electric_scale.y
 
 func update_checked_mode() -> void:
 	var mode = DisplayServer.window_get_mode()
@@ -154,6 +172,34 @@ func _on_comic_dots_multiplier_slider_value_changed(value: float) -> void:
 func _on_comic_dots_speed_slider_value_changed(value: float) -> void:
 		comic_dots1_shader_material.set_shader_parameter("speed", value)
 		comic_dots2_shader_material.set_shader_parameter("speed", value)
+
+func _on_electric_button_toggled(toggled_on: bool) -> void:
+		Events.set_desktop_background_visible("Electric", toggled_on)
+
+func _on_electric_bg_color_picker_color_changed(color: Color) -> void:
+		electric_shader_material.set_shader_parameter("background_color", color)
+
+func _on_electric_line_color_picker_color_changed(color: Color) -> void:
+		electric_shader_material.set_shader_parameter("line_color", color)
+
+func _on_electric_freq_slider_value_changed(value: float) -> void:
+		electric_shader_material.set_shader_parameter("line_freq", value)
+
+func _on_electric_height_slider_value_changed(value: float) -> void:
+		electric_shader_material.set_shader_parameter("height", value)
+
+func _on_electric_speed_slider_value_changed(value: float) -> void:
+		electric_shader_material.set_shader_parameter("speed", value)
+
+func _on_electric_scale_x_slider_value_changed(value: float) -> void:
+		var scale: Vector2 = electric_shader_material.get_shader_parameter("scale")
+		scale.x = value
+		electric_shader_material.set_shader_parameter("scale", scale)
+
+func _on_electric_scale_y_slider_value_changed(value: float) -> void:
+		var scale: Vector2 = electric_shader_material.get_shader_parameter("scale")
+		scale.y = value
+		electric_shader_material.set_shader_parameter("scale", scale)
 
 func _on_minute_passed(_total_minutes: int) -> void:
 		_update_autosave_timer_label()


### PR DESCRIPTION
## Summary
- make electric shader togglable via Settings UI and Events
- add UI controls for electric background colors, frequency, height, speed, and scale
- register electric background in desktop scene and events dictionary

## Testing
- `godot --headless --path . tests/test_runner.tscn` *(fails: missing resources and parse errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a5ceccee7c832589500e1aaa622ccf