### PR TITLE
Persist background shader settings per profile

### DIFF
--- a/autoloads/save_manager.gd
+++ b/autoloads/save_manager.gd
@@ -65,7 +65,8 @@ func initialize_new_profile(slot_id: int, user_data: Dictionary) -> void:
 		seed_val = int(Time.get_unix_time_from_system())
 	user_data["global_rng_seed"] = seed_val
 	RNGManager.init_seed(int(user_data["global_rng_seed"]))
-	PlayerManager.user_data = user_data.duplicate(true)
+        PlayerManager.user_data = user_data.duplicate(true)
+        PlayerManager.ensure_default_stats()
 
 	var background = user_data.get("background", "")
 	if background != "":

--- a/components/apps/app_scenes/settings.tscn
+++ b/components/apps/app_scenes/settings.tscn
@@ -266,6 +266,10 @@ max_value = 0.1
 step = 0.001
 value = 0.03
 
+[node name="BlueWarpResetButton" type="Button" parent="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/BlueWarpContainer/MarginContainer/VBoxContainer"]
+layout_mode = 2
+text = "Reset"
+
 [node name="ComicDotsContainer" type="PanelContainer" parent="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer"]
 layout_mode = 2
 size_flags_horizontal = 6
@@ -335,6 +339,10 @@ size_flags_horizontal = 3
 max_value = 0.2
 step = 0.01
 value = 0.1
+
+[node name="ComicDotsResetButton" type="Button" parent="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/ComicDotsContainer/MarginContainer/VBoxContainer"]
+layout_mode = 2
+text = "Reset"
 
 [node name="WavesContainer" type="PanelContainer" parent="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer"]
 layout_mode = 2
@@ -435,6 +443,10 @@ size_flags_horizontal = 3
 min_value = 2.0
 max_value = 600.0
 value = 6.0
+
+[node name="WavesResetButton" type="Button" parent="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/WavesContainer/MarginContainer/VBoxContainer"]
+layout_mode = 2
+text = "Reset"
 
 [node name="ElectricContainer" type="PanelContainer" parent="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer"]
 layout_mode = 2
@@ -554,6 +566,10 @@ max_value = 30.0
 step = 0.01
 value = 15.43
 
+[node name="ElectricResetButton" type="Button" parent="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/ElectricContainer/MarginContainer/VBoxContainer"]
+layout_mode = 2
+text = "Reset"
+
 [connection signal="toggled" from="Panel/MarginContainer/TabContainer/General/HBoxContainer/VBoxContainer2/SiggyButton" to="." method="_on_siggy_button_toggled"]
 [connection signal="toggled" from="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/BlueWarpContainer/MarginContainer/VBoxContainer/BlueWarpButton" to="." method="_on_blue_warp_button_toggled"]
 [connection signal="value_changed" from="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/BlueWarpContainer/MarginContainer/VBoxContainer/HBoxContainer/BlueWarpStretchSlider" to="." method="_on_blue_warp_stretch_slider_value_changed"]
@@ -581,3 +597,7 @@ value = 15.43
 [connection signal="value_changed" from="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/ElectricContainer/MarginContainer/VBoxContainer/HBoxContainer4/ElectricSpeedSlider" to="." method="_on_electric_speed_slider_value_changed"]
 [connection signal="value_changed" from="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/ElectricContainer/MarginContainer/VBoxContainer/HBoxContainer5/ElectricScaleXSlider" to="." method="_on_electric_scale_x_slider_value_changed"]
 [connection signal="value_changed" from="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/ElectricContainer/MarginContainer/VBoxContainer/HBoxContainer6/ElectricScaleYSlider" to="." method="_on_electric_scale_y_slider_value_changed"]
+[connection signal="pressed" from="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/BlueWarpContainer/MarginContainer/VBoxContainer/BlueWarpResetButton" to="." method="_on_blue_warp_reset_button_pressed"]
+[connection signal="pressed" from="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/ComicDotsContainer/MarginContainer/VBoxContainer/ComicDotsResetButton" to="." method="_on_comic_dots_reset_button_pressed"]
+[connection signal="pressed" from="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/WavesContainer/MarginContainer/VBoxContainer/WavesResetButton" to="." method="_on_waves_reset_button_pressed"]
+[connection signal="pressed" from="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/ElectricContainer/MarginContainer/VBoxContainer/ElectricResetButton" to="." method="_on_electric_reset_button_pressed"]

--- a/components/settings_window.gd
+++ b/components/settings_window.gd
@@ -129,77 +129,163 @@ func _on_waves_button_toggled(toggled_on: bool) -> void:
 	Events.set_desktop_background_visible("Waves", toggled_on)
 
 func _on_bottom_color_picker_color_changed(color: Color) -> void:
-	waves_shader_material.set_shader_parameter("bottom_color", color)
+        waves_shader_material.set_shader_parameter("bottom_color", color)
+        PlayerManager.set_shader_param("Waves", "bottom_color", color)
 
 func _on_top_color_picker_color_changed(color: Color) -> void:
-		waves_shader_material.set_shader_parameter("top_color", color)
+        waves_shader_material.set_shader_parameter("top_color", color)
+        PlayerManager.set_shader_param("Waves", "top_color", color)
 
 func _on_wave_amp_slider_value_changed(value: float) -> void:
-		waves_shader_material.set_shader_parameter("wave_amp", value)
+                waves_shader_material.set_shader_parameter("wave_amp", value)
+                PlayerManager.set_shader_param("Waves", "wave_amp", value)
 
 func _on_wave_size_slider_value_changed(value: float) -> void:
-		waves_shader_material.set_shader_parameter("wave_size", value)
+                waves_shader_material.set_shader_parameter("wave_size", value)
+                PlayerManager.set_shader_param("Waves", "wave_size", value)
 
 func _on_wave_time_mul_slider_value_changed(value: float) -> void:
-		waves_shader_material.set_shader_parameter("wave_time_mul", value)
+                waves_shader_material.set_shader_parameter("wave_time_mul", value)
+                PlayerManager.set_shader_param("Waves", "wave_time_mul", value)
 
 func _on_total_phases_slider_value_changed(value: float) -> void:
-		waves_shader_material.set_shader_parameter("total_phases", value)
+                waves_shader_material.set_shader_parameter("total_phases", value)
+                PlayerManager.set_shader_param("Waves", "total_phases", value)
 
 func _on_blue_warp_stretch_slider_value_changed(value: float) -> void:
-		blue_warp_shader_material.set_shader_parameter("stretch", value)
+                blue_warp_shader_material.set_shader_parameter("stretch", value)
+                PlayerManager.set_shader_param("BlueWarp", "stretch", value)
 
 func _on_blue_warp_thing1_slider_value_changed(value: float) -> void:
-		blue_warp_shader_material.set_shader_parameter("thing1", value)
+                blue_warp_shader_material.set_shader_parameter("thing1", value)
+                PlayerManager.set_shader_param("BlueWarp", "thing1", value)
 
 func _on_blue_warp_thing2_slider_value_changed(value: float) -> void:
-		blue_warp_shader_material.set_shader_parameter("thing2", value)
+                blue_warp_shader_material.set_shader_parameter("thing2", value)
+                PlayerManager.set_shader_param("BlueWarp", "thing2", value)
 
 func _on_blue_warp_thing3_slider_value_changed(value: float) -> void:
-		blue_warp_shader_material.set_shader_parameter("thing3", value)
+                blue_warp_shader_material.set_shader_parameter("thing3", value)
+                PlayerManager.set_shader_param("BlueWarp", "thing3", value)
 
 func _on_blue_warp_speed_slider_value_changed(value: float) -> void:
-		blue_warp_shader_material.set_shader_parameter("speed", value)
+                blue_warp_shader_material.set_shader_parameter("speed", value)
+                PlayerManager.set_shader_param("BlueWarp", "speed", value)
 
 func _on_comic_dots_color_picker_color_changed(color: Color) -> void:
-		comic_dots1_shader_material.set_shader_parameter("circle_color", color)
-		comic_dots2_shader_material.set_shader_parameter("circle_color", color)
+                comic_dots1_shader_material.set_shader_parameter("circle_color", color)
+                comic_dots2_shader_material.set_shader_parameter("circle_color", color)
+                PlayerManager.set_shader_param("ComicDots", "circle_color", color)
 
 func _on_comic_dots_multiplier_slider_value_changed(value: float) -> void:
-		comic_dots1_shader_material.set_shader_parameter("circle_multiplier", value)
-		comic_dots2_shader_material.set_shader_parameter("circle_multiplier", value)
+                comic_dots1_shader_material.set_shader_parameter("circle_multiplier", value)
+                comic_dots2_shader_material.set_shader_parameter("circle_multiplier", value)
+                PlayerManager.set_shader_param("ComicDots", "circle_multiplier", value)
 
 func _on_comic_dots_speed_slider_value_changed(value: float) -> void:
-		comic_dots1_shader_material.set_shader_parameter("speed", value)
-		comic_dots2_shader_material.set_shader_parameter("speed", value)
+                comic_dots1_shader_material.set_shader_parameter("speed", value)
+                comic_dots2_shader_material.set_shader_parameter("speed", value)
+                PlayerManager.set_shader_param("ComicDots", "speed", value)
 
 func _on_electric_button_toggled(toggled_on: bool) -> void:
 		Events.set_desktop_background_visible("Electric", toggled_on)
 
 func _on_electric_bg_color_picker_color_changed(color: Color) -> void:
-		electric_shader_material.set_shader_parameter("background_color", color)
+                electric_shader_material.set_shader_parameter("background_color", color)
+                PlayerManager.set_shader_param("Electric", "background_color", color)
 
 func _on_electric_line_color_picker_color_changed(color: Color) -> void:
-		electric_shader_material.set_shader_parameter("line_color", color)
+                electric_shader_material.set_shader_parameter("line_color", color)
+                PlayerManager.set_shader_param("Electric", "line_color", color)
 
 func _on_electric_freq_slider_value_changed(value: float) -> void:
-		electric_shader_material.set_shader_parameter("line_freq", value)
+                electric_shader_material.set_shader_parameter("line_freq", value)
+                PlayerManager.set_shader_param("Electric", "line_freq", value)
 
 func _on_electric_height_slider_value_changed(value: float) -> void:
-		electric_shader_material.set_shader_parameter("height", value)
+                electric_shader_material.set_shader_parameter("height", value)
+                PlayerManager.set_shader_param("Electric", "height", value)
 
 func _on_electric_speed_slider_value_changed(value: float) -> void:
-		electric_shader_material.set_shader_parameter("speed", value)
+                electric_shader_material.set_shader_parameter("speed", value)
+                PlayerManager.set_shader_param("Electric", "speed", value)
 
 func _on_electric_scale_x_slider_value_changed(value: float) -> void:
-		var scale: Vector2 = electric_shader_material.get_shader_parameter("scale")
-		scale.x = value
-		electric_shader_material.set_shader_parameter("scale", scale)
+                var scale: Vector2 = electric_shader_material.get_shader_parameter("scale")
+                scale.x = value
+                electric_shader_material.set_shader_parameter("scale", scale)
+                PlayerManager.set_shader_param("Electric", "scale_x", value)
 
 func _on_electric_scale_y_slider_value_changed(value: float) -> void:
-		var scale: Vector2 = electric_shader_material.get_shader_parameter("scale")
-		scale.y = value
-		electric_shader_material.set_shader_parameter("scale", scale)
+                var scale: Vector2 = electric_shader_material.get_shader_parameter("scale")
+                scale.y = value
+                electric_shader_material.set_shader_parameter("scale", scale)
+                PlayerManager.set_shader_param("Electric", "scale_y", value)
+
+func _on_waves_reset_button_pressed() -> void:
+        PlayerManager.reset_shader("Waves")
+        var d = PlayerManager.DEFAULT_BACKGROUND_SHADERS["Waves"]
+        var bottom = PlayerManager.dict_to_color(d["bottom_color"])
+        var top = PlayerManager.dict_to_color(d["top_color"])
+        waves_shader_material.set_shader_parameter("bottom_color", bottom)
+        waves_shader_material.set_shader_parameter("top_color", top)
+        waves_shader_material.set_shader_parameter("wave_amp", d["wave_amp"])
+        waves_shader_material.set_shader_parameter("wave_size", d["wave_size"])
+        waves_shader_material.set_shader_parameter("wave_time_mul", d["wave_time_mul"])
+        waves_shader_material.set_shader_parameter("total_phases", d["total_phases"])
+        bottom_color_picker.color = bottom
+        top_color_picker.color = top
+        wave_amp_slider.value = d["wave_amp"]
+        wave_size_slider.value = d["wave_size"]
+        wave_time_mul_slider.value = d["wave_time_mul"]
+        total_phases_slider.value = d["total_phases"]
+
+func _on_blue_warp_reset_button_pressed() -> void:
+        PlayerManager.reset_shader("BlueWarp")
+        var d = PlayerManager.DEFAULT_BACKGROUND_SHADERS["BlueWarp"]
+        blue_warp_shader_material.set_shader_parameter("stretch", d["stretch"])
+        blue_warp_shader_material.set_shader_parameter("thing1", d["thing1"])
+        blue_warp_shader_material.set_shader_parameter("thing2", d["thing2"])
+        blue_warp_shader_material.set_shader_parameter("thing3", d["thing3"])
+        blue_warp_shader_material.set_shader_parameter("speed", d["speed"])
+        blue_warp_stretch_slider.value = d["stretch"]
+        blue_warp_thing1_slider.value = d["thing1"]
+        blue_warp_thing2_slider.value = d["thing2"]
+        blue_warp_thing3_slider.value = d["thing3"]
+        blue_warp_speed_slider.value = d["speed"]
+
+func _on_comic_dots_reset_button_pressed() -> void:
+        PlayerManager.reset_shader("ComicDots")
+        var d = PlayerManager.DEFAULT_BACKGROUND_SHADERS["ComicDots"]
+        var color = PlayerManager.dict_to_color(d["circle_color"])
+        comic_dots1_shader_material.set_shader_parameter("circle_color", color)
+        comic_dots2_shader_material.set_shader_parameter("circle_color", color)
+        comic_dots1_shader_material.set_shader_parameter("circle_multiplier", d["circle_multiplier"])
+        comic_dots2_shader_material.set_shader_parameter("circle_multiplier", d["circle_multiplier"])
+        comic_dots1_shader_material.set_shader_parameter("speed", d["speed"])
+        comic_dots2_shader_material.set_shader_parameter("speed", d["speed"])
+        comic_dots_color_picker.color = color
+        comic_dots_multiplier_slider.value = d["circle_multiplier"]
+        comic_dots_speed_slider.value = d["speed"]
+
+func _on_electric_reset_button_pressed() -> void:
+        PlayerManager.reset_shader("Electric")
+        var d = PlayerManager.DEFAULT_BACKGROUND_SHADERS["Electric"]
+        var bg = PlayerManager.dict_to_color(d["background_color"])
+        var line = PlayerManager.dict_to_color(d["line_color"])
+        electric_shader_material.set_shader_parameter("background_color", bg)
+        electric_shader_material.set_shader_parameter("line_color", line)
+        electric_shader_material.set_shader_parameter("line_freq", d["line_freq"])
+        electric_shader_material.set_shader_parameter("height", d["height"])
+        electric_shader_material.set_shader_parameter("speed", d["speed"])
+        electric_shader_material.set_shader_parameter("scale", Vector2(d["scale_x"], d["scale_y"]))
+        electric_bg_color_picker.color = bg
+        electric_line_color_picker.color = line
+        electric_freq_slider.value = d["line_freq"]
+        electric_height_slider.value = d["height"]
+        electric_speed_slider.value = d["speed"]
+        electric_scale_x_slider.value = d["scale_x"]
+        electric_scale_y_slider.value = d["scale_y"]
 
 func _on_minute_passed(_total_minutes: int) -> void:
 		_update_autosave_timer_label()

--- a/scripts/desktop_env.gd
+++ b/scripts/desktop_env.gd
@@ -5,6 +5,12 @@ extends Control
 @onready var trash_window: Pane = %TrashWindow
 @onready var background: TextureRect = %Background
 
+@onready var blue_warp_shader_material: ShaderMaterial = $ShaderBackgroundsContainer/BlueWarpShader.material
+@onready var comic_dots1_shader_material: ShaderMaterial = $ShaderBackgroundsContainer/ComicDotsBlueVert.material
+@onready var comic_dots2_shader_material: ShaderMaterial = $ShaderBackgroundsContainer/ComicDotsBlueHor.material
+@onready var waves_shader_material: ShaderMaterial = $ShaderBackgroundsContainer/WavesShader.material
+@onready var electric_shader_material: ShaderMaterial = $ShaderBackgroundsContainer/ElectricShader.material
+
 
 
 @export var background_texture: Texture = preload("res://assets/backgrounds/Bliss_(Windows_XP) (2).png")
@@ -27,16 +33,67 @@ func launch_startup_apps() -> void:
 
 
 func _deferred_load_save():
-	SaveManager.load_from_slot(SaveManager.current_slot_id)
-	var path = PlayerManager.user_data.get("background_path", "")
+        SaveManager.load_from_slot(SaveManager.current_slot_id)
+        _apply_shader_settings()
+        var path = PlayerManager.user_data.get("background_path", "")
 	if path != "":
 		var tex = load(path)
 		if tex is Texture2D:
 			background.texture = tex
 		else:
 			print("❌ Couldn't load texture from path: ", path)
-	else:
-		background.texture = background_texture  # fallback
+        else:
+                background.texture = background_texture  # fallback
+
+func _apply_shader_settings() -> void:
+        var defaults = PlayerManager.DEFAULT_BACKGROUND_SHADERS
+
+        var waves_def = defaults["Waves"]
+        var bottom = PlayerManager.get_shader_param("Waves", "bottom_color", PlayerManager.dict_to_color(waves_def["bottom_color"]))
+        var top = PlayerManager.get_shader_param("Waves", "top_color", PlayerManager.dict_to_color(waves_def["top_color"]))
+        var wave_amp = PlayerManager.get_shader_param("Waves", "wave_amp", waves_def["wave_amp"])
+        var wave_size = PlayerManager.get_shader_param("Waves", "wave_size", waves_def["wave_size"])
+        var wave_time_mul = PlayerManager.get_shader_param("Waves", "wave_time_mul", waves_def["wave_time_mul"])
+        var total_phases = PlayerManager.get_shader_param("Waves", "total_phases", waves_def["total_phases"])
+        waves_shader_material.set_shader_parameter("bottom_color", bottom)
+        waves_shader_material.set_shader_parameter("top_color", top)
+        waves_shader_material.set_shader_parameter("wave_amp", wave_amp)
+        waves_shader_material.set_shader_parameter("wave_size", wave_size)
+        waves_shader_material.set_shader_parameter("wave_time_mul", wave_time_mul)
+        waves_shader_material.set_shader_parameter("total_phases", total_phases)
+
+        var bw_def = defaults["BlueWarp"]
+        blue_warp_shader_material.set_shader_parameter("stretch", PlayerManager.get_shader_param("BlueWarp", "stretch", bw_def["stretch"]))
+        blue_warp_shader_material.set_shader_parameter("thing1", PlayerManager.get_shader_param("BlueWarp", "thing1", bw_def["thing1"]))
+        blue_warp_shader_material.set_shader_parameter("thing2", PlayerManager.get_shader_param("BlueWarp", "thing2", bw_def["thing2"]))
+        blue_warp_shader_material.set_shader_parameter("thing3", PlayerManager.get_shader_param("BlueWarp", "thing3", bw_def["thing3"]))
+        blue_warp_shader_material.set_shader_parameter("speed", PlayerManager.get_shader_param("BlueWarp", "speed", bw_def["speed"]))
+
+        var cd_def = defaults["ComicDots"]
+        var cd_color = PlayerManager.get_shader_param("ComicDots", "circle_color", PlayerManager.dict_to_color(cd_def["circle_color"]))
+        var cd_mult = PlayerManager.get_shader_param("ComicDots", "circle_multiplier", cd_def["circle_multiplier"])
+        var cd_speed = PlayerManager.get_shader_param("ComicDots", "speed", cd_def["speed"])
+        comic_dots1_shader_material.set_shader_parameter("circle_color", cd_color)
+        comic_dots2_shader_material.set_shader_parameter("circle_color", cd_color)
+        comic_dots1_shader_material.set_shader_parameter("circle_multiplier", cd_mult)
+        comic_dots2_shader_material.set_shader_parameter("circle_multiplier", cd_mult)
+        comic_dots1_shader_material.set_shader_parameter("speed", cd_speed)
+        comic_dots2_shader_material.set_shader_parameter("speed", cd_speed)
+
+        var e_def = defaults["Electric"]
+        var bg_color = PlayerManager.get_shader_param("Electric", "background_color", PlayerManager.dict_to_color(e_def["background_color"]))
+        var line_color = PlayerManager.get_shader_param("Electric", "line_color", PlayerManager.dict_to_color(e_def["line_color"]))
+        var line_freq = PlayerManager.get_shader_param("Electric", "line_freq", e_def["line_freq"])
+        var height = PlayerManager.get_shader_param("Electric", "height", e_def["height"])
+        var speed = PlayerManager.get_shader_param("Electric", "speed", e_def["speed"])
+        var scale_x = PlayerManager.get_shader_param("Electric", "scale_x", e_def["scale_x"])
+        var scale_y = PlayerManager.get_shader_param("Electric", "scale_y", e_def["scale_y"])
+        electric_shader_material.set_shader_parameter("background_color", bg_color)
+        electric_shader_material.set_shader_parameter("line_color", line_color)
+        electric_shader_material.set_shader_parameter("line_freq", line_freq)
+        electric_shader_material.set_shader_parameter("height", height)
+        electric_shader_material.set_shader_parameter("speed", speed)
+        electric_shader_material.set_shader_parameter("scale", Vector2(scale_x, scale_y))
 
 
 func hide_all_windows_and_panels() -> void:


### PR DESCRIPTION
## Summary
- store default background shader parameters per profile and persist changes
- apply saved shader settings on load and add reset buttons to restore defaults

## Testing
- `godot3 --headless --quit -s tests/test_runner.gd` *(fails: Can't open project, engine version mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_68a5dc6045b483259fa6ca708c8ebd7d