### PR TITLE
Allow independent comic dots shader settings

### DIFF
--- a/autoloads/player_manager.gd
+++ b/autoloads/player_manager.gd
@@ -9,7 +9,12 @@ const DEFAULT_BACKGROUND_SHADERS := {
 "thing3": 0.8,
 "speed": 0.03,
 },
-"ComicDots": {
+"ComicDots1": {
+"circle_color": {"r": 0.00000481308, "g": 0.665883, "b": 0.95733, "a": 1.0},
+"circle_multiplier": 32.0,
+"speed": 0.01,
+},
+"ComicDots2": {
 "circle_color": {"r": 0.00000481308, "g": 0.665883, "b": 0.95733, "a": 1.0},
 "circle_multiplier": 32.0,
 "speed": 0.01,

--- a/components/apps/app_scenes/settings.tscn
+++ b/components/apps/app_scenes/settings.tscn
@@ -527,7 +527,7 @@ layout_mode = 2
 layout_mode = 2
 text = "Color"
 
-[node name="ComicDotsColorPicker" type="ColorPickerButton" parent="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer2/ComicDotsContainer/MarginContainer/HBoxContainer4/VBoxContainer/HBoxContainer"]
+[node name="ComicDots1ColorPicker" type="ColorPickerButton" parent="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer2/ComicDotsContainer/MarginContainer/HBoxContainer4/VBoxContainer/HBoxContainer"]
 unique_name_in_owner = true
 custom_minimum_size = Vector2(16, 16)
 layout_mode = 2
@@ -539,7 +539,7 @@ layout_mode = 2
 layout_mode = 2
 text = "Size"
 
-[node name="ComicDotsMultiplierSlider" type="HSlider" parent="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer2/ComicDotsContainer/MarginContainer/HBoxContainer4/VBoxContainer/HBoxContainer2"]
+[node name="ComicDots1MultiplierSlider" type="HSlider" parent="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer2/ComicDotsContainer/MarginContainer/HBoxContainer4/VBoxContainer/HBoxContainer2"]
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 3
@@ -554,7 +554,7 @@ layout_mode = 2
 layout_mode = 2
 text = "Speed"
 
-[node name="ComicDotsSpeedSlider" type="HSlider" parent="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer2/ComicDotsContainer/MarginContainer/HBoxContainer4/VBoxContainer/HBoxContainer3"]
+[node name="ComicDots1SpeedSlider" type="HSlider" parent="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer2/ComicDotsContainer/MarginContainer/HBoxContainer4/VBoxContainer/HBoxContainer3"]
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 3
@@ -562,7 +562,8 @@ max_value = 0.2
 step = 0.01
 value = 0.1
 
-[node name="ComicDotsResetButton" type="Button" parent="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer2/ComicDotsContainer/MarginContainer/HBoxContainer4/VBoxContainer"]
+[node name="ComicDots1ResetButton" type="Button" parent="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer2/ComicDotsContainer/MarginContainer/HBoxContainer4/VBoxContainer"]
+unique_name_in_owner = true
 layout_mode = 2
 text = "Reset"
 
@@ -583,7 +584,8 @@ layout_mode = 2
 layout_mode = 2
 text = "Color"
 
-[node name="ComicDotsColorPicker" type="ColorPickerButton" parent="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer2/ComicDotsContainer/MarginContainer/HBoxContainer4/VBoxContainer2/HBoxContainer"]
+[node name="ComicDots2ColorPicker" type="ColorPickerButton" parent="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer2/ComicDotsContainer/MarginContainer/HBoxContainer4/VBoxContainer2/HBoxContainer"]
+unique_name_in_owner = true
 custom_minimum_size = Vector2(16, 16)
 layout_mode = 2
 
@@ -594,7 +596,8 @@ layout_mode = 2
 layout_mode = 2
 text = "Size"
 
-[node name="ComicDotsMultiplierSlider" type="HSlider" parent="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer2/ComicDotsContainer/MarginContainer/HBoxContainer4/VBoxContainer2/HBoxContainer2"]
+[node name="ComicDots2MultiplierSlider" type="HSlider" parent="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer2/ComicDotsContainer/MarginContainer/HBoxContainer4/VBoxContainer2/HBoxContainer2"]
+unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 3
 min_value = 1.0
@@ -608,14 +611,16 @@ layout_mode = 2
 layout_mode = 2
 text = "Speed"
 
-[node name="ComicDotsSpeedSlider" type="HSlider" parent="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer2/ComicDotsContainer/MarginContainer/HBoxContainer4/VBoxContainer2/HBoxContainer3"]
+[node name="ComicDots2SpeedSlider" type="HSlider" parent="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer2/ComicDotsContainer/MarginContainer/HBoxContainer4/VBoxContainer2/HBoxContainer3"]
+unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 3
 max_value = 0.2
 step = 0.01
 value = 0.1
 
-[node name="ComicDotsResetButton" type="Button" parent="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer2/ComicDotsContainer/MarginContainer/HBoxContainer4/VBoxContainer2"]
+[node name="ComicDots2ResetButton" type="Button" parent="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer2/ComicDotsContainer/MarginContainer/HBoxContainer4/VBoxContainer2"]
+unique_name_in_owner = true
 layout_mode = 2
 text = "Reset"
 
@@ -645,12 +650,12 @@ text = "Reset"
 [connection signal="value_changed" from="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/ElectricContainer/MarginContainer/VBoxContainer/HBoxContainer6/ElectricScaleYSlider" to="." method="_on_electric_scale_y_slider_value_changed"]
 [connection signal="pressed" from="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/ElectricContainer/MarginContainer/VBoxContainer/ElectricResetButton" to="." method="_on_electric_reset_button_pressed"]
 [connection signal="toggled" from="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer2/ComicDotsContainer/MarginContainer/HBoxContainer4/VBoxContainer/ComicDots1Button" to="." method="_on_comic_dots_1_button_toggled"]
-[connection signal="color_changed" from="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer2/ComicDotsContainer/MarginContainer/HBoxContainer4/VBoxContainer/HBoxContainer/ComicDotsColorPicker" to="." method="_on_comic_dots_color_picker_color_changed"]
-[connection signal="value_changed" from="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer2/ComicDotsContainer/MarginContainer/HBoxContainer4/VBoxContainer/HBoxContainer2/ComicDotsMultiplierSlider" to="." method="_on_comic_dots_multiplier_slider_value_changed"]
-[connection signal="value_changed" from="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer2/ComicDotsContainer/MarginContainer/HBoxContainer4/VBoxContainer/HBoxContainer3/ComicDotsSpeedSlider" to="." method="_on_comic_dots_speed_slider_value_changed"]
-[connection signal="pressed" from="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer2/ComicDotsContainer/MarginContainer/HBoxContainer4/VBoxContainer/ComicDotsResetButton" to="." method="_on_comic_dots_reset_button_pressed"]
+[connection signal="color_changed" from="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer2/ComicDotsContainer/MarginContainer/HBoxContainer4/VBoxContainer/HBoxContainer/ComicDots1ColorPicker" to="." method="_on_comic_dots_1_color_picker_color_changed"]
+[connection signal="value_changed" from="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer2/ComicDotsContainer/MarginContainer/HBoxContainer4/VBoxContainer/HBoxContainer2/ComicDots1MultiplierSlider" to="." method="_on_comic_dots_1_multiplier_slider_value_changed"]
+[connection signal="value_changed" from="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer2/ComicDotsContainer/MarginContainer/HBoxContainer4/VBoxContainer/HBoxContainer3/ComicDots1SpeedSlider" to="." method="_on_comic_dots_1_speed_slider_value_changed"]
+[connection signal="pressed" from="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer2/ComicDotsContainer/MarginContainer/HBoxContainer4/VBoxContainer/ComicDots1ResetButton" to="." method="_on_comic_dots_1_reset_button_pressed"]
 [connection signal="toggled" from="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer2/ComicDotsContainer/MarginContainer/HBoxContainer4/VBoxContainer2/ComicDots2Button" to="." method="_on_comic_dots_2_button_toggled"]
-[connection signal="color_changed" from="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer2/ComicDotsContainer/MarginContainer/HBoxContainer4/VBoxContainer2/HBoxContainer/ComicDotsColorPicker" to="." method="_on_comic_dots_color_picker_color_changed"]
-[connection signal="value_changed" from="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer2/ComicDotsContainer/MarginContainer/HBoxContainer4/VBoxContainer2/HBoxContainer2/ComicDotsMultiplierSlider" to="." method="_on_comic_dots_multiplier_slider_value_changed"]
-[connection signal="value_changed" from="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer2/ComicDotsContainer/MarginContainer/HBoxContainer4/VBoxContainer2/HBoxContainer3/ComicDotsSpeedSlider" to="." method="_on_comic_dots_speed_slider_value_changed"]
-[connection signal="pressed" from="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer2/ComicDotsContainer/MarginContainer/HBoxContainer4/VBoxContainer2/ComicDotsResetButton" to="." method="_on_comic_dots_reset_button_pressed"]
+[connection signal="color_changed" from="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer2/ComicDotsContainer/MarginContainer/HBoxContainer4/VBoxContainer2/HBoxContainer/ComicDots2ColorPicker" to="." method="_on_comic_dots_2_color_picker_color_changed"]
+[connection signal="value_changed" from="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer2/ComicDotsContainer/MarginContainer/HBoxContainer4/VBoxContainer2/HBoxContainer2/ComicDots2MultiplierSlider" to="." method="_on_comic_dots_2_multiplier_slider_value_changed"]
+[connection signal="value_changed" from="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer2/ComicDotsContainer/MarginContainer/HBoxContainer4/VBoxContainer2/HBoxContainer3/ComicDots2SpeedSlider" to="." method="_on_comic_dots_2_speed_slider_value_changed"]
+[connection signal="pressed" from="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer2/ComicDotsContainer/MarginContainer/HBoxContainer4/VBoxContainer2/ComicDots2ResetButton" to="." method="_on_comic_dots_2_reset_button_pressed"]

--- a/components/settings_window.gd
+++ b/components/settings_window.gd
@@ -21,9 +21,12 @@ extends Pane
 @onready var blue_warp_thing2_slider: HSlider = %BlueWarpThing2Slider
 @onready var blue_warp_thing3_slider: HSlider = %BlueWarpThing3Slider
 @onready var blue_warp_speed_slider: HSlider = %BlueWarpSpeedSlider
-@onready var comic_dots_color_picker: ColorPickerButton = %ComicDotsColorPicker
-@onready var comic_dots_multiplier_slider: HSlider = %ComicDotsMultiplierSlider
-@onready var comic_dots_speed_slider: HSlider = %ComicDotsSpeedSlider
+@onready var comic_dots1_color_picker: ColorPickerButton = %ComicDots1ColorPicker
+@onready var comic_dots1_multiplier_slider: HSlider = %ComicDots1MultiplierSlider
+@onready var comic_dots1_speed_slider: HSlider = %ComicDots1SpeedSlider
+@onready var comic_dots2_color_picker: ColorPickerButton = %ComicDots2ColorPicker
+@onready var comic_dots2_multiplier_slider: HSlider = %ComicDots2MultiplierSlider
+@onready var comic_dots2_speed_slider: HSlider = %ComicDots2SpeedSlider
 @onready var electric_button: CheckButton = %ElectricButton
 @onready var electric_bg_color_picker: ColorPickerButton = %ElectricBGColorPicker
 @onready var electric_line_color_picker: ColorPickerButton = %ElectricLineColorPicker
@@ -64,11 +67,14 @@ func _ready() -> void:
 		blue_warp_thing1_slider.value = blue_warp_shader_material.get_shader_parameter("thing1")
 		blue_warp_thing2_slider.value = blue_warp_shader_material.get_shader_parameter("thing2")
 		blue_warp_thing3_slider.value = blue_warp_shader_material.get_shader_parameter("thing3")
-		blue_warp_speed_slider.value = blue_warp_shader_material.get_shader_parameter("speed")
-		comic_dots_color_picker.color = comic_dots1_shader_material.get_shader_parameter("circle_color")
-		comic_dots_multiplier_slider.value = comic_dots1_shader_material.get_shader_parameter("circle_multiplier")
-		comic_dots_speed_slider.value = comic_dots1_shader_material.get_shader_parameter("speed")
-		electric_button.button_pressed = Events.is_desktop_background_visible("Electric")
+                blue_warp_speed_slider.value = blue_warp_shader_material.get_shader_parameter("speed")
+                comic_dots1_color_picker.color = comic_dots1_shader_material.get_shader_parameter("circle_color")
+                comic_dots1_multiplier_slider.value = comic_dots1_shader_material.get_shader_parameter("circle_multiplier")
+                comic_dots1_speed_slider.value = comic_dots1_shader_material.get_shader_parameter("speed")
+                comic_dots2_color_picker.color = comic_dots2_shader_material.get_shader_parameter("circle_color")
+                comic_dots2_multiplier_slider.value = comic_dots2_shader_material.get_shader_parameter("circle_multiplier")
+                comic_dots2_speed_slider.value = comic_dots2_shader_material.get_shader_parameter("speed")
+                electric_button.button_pressed = Events.is_desktop_background_visible("Electric")
 		electric_bg_color_picker.color = electric_shader_material.get_shader_parameter("background_color")
 		electric_line_color_picker.color = electric_shader_material.get_shader_parameter("line_color")
 		electric_freq_slider.value = electric_shader_material.get_shader_parameter("line_freq")
@@ -172,20 +178,29 @@ func _on_blue_warp_speed_slider_value_changed(value: float) -> void:
 				blue_warp_shader_material.set_shader_parameter("speed", value)
 				PlayerManager.set_shader_param("BlueWarp", "speed", value)
 
-func _on_comic_dots_color_picker_color_changed(color: Color) -> void:
-				comic_dots1_shader_material.set_shader_parameter("circle_color", color)
-				comic_dots2_shader_material.set_shader_parameter("circle_color", color)
-				PlayerManager.set_shader_param("ComicDots", "circle_color", color)
+func _on_comic_dots_1_color_picker_color_changed(color: Color) -> void:
+                                comic_dots1_shader_material.set_shader_parameter("circle_color", color)
+                                PlayerManager.set_shader_param("ComicDots1", "circle_color", color)
 
-func _on_comic_dots_multiplier_slider_value_changed(value: float) -> void:
-				comic_dots1_shader_material.set_shader_parameter("circle_multiplier", value)
-				comic_dots2_shader_material.set_shader_parameter("circle_multiplier", value)
-				PlayerManager.set_shader_param("ComicDots", "circle_multiplier", value)
+func _on_comic_dots_1_multiplier_slider_value_changed(value: float) -> void:
+                                comic_dots1_shader_material.set_shader_parameter("circle_multiplier", value)
+                                PlayerManager.set_shader_param("ComicDots1", "circle_multiplier", value)
 
-func _on_comic_dots_speed_slider_value_changed(value: float) -> void:
-				comic_dots1_shader_material.set_shader_parameter("speed", value)
-				comic_dots2_shader_material.set_shader_parameter("speed", value)
-				PlayerManager.set_shader_param("ComicDots", "speed", value)
+func _on_comic_dots_1_speed_slider_value_changed(value: float) -> void:
+                                comic_dots1_shader_material.set_shader_parameter("speed", value)
+                                PlayerManager.set_shader_param("ComicDots1", "speed", value)
+
+func _on_comic_dots_2_color_picker_color_changed(color: Color) -> void:
+                                comic_dots2_shader_material.set_shader_parameter("circle_color", color)
+                                PlayerManager.set_shader_param("ComicDots2", "circle_color", color)
+
+func _on_comic_dots_2_multiplier_slider_value_changed(value: float) -> void:
+                                comic_dots2_shader_material.set_shader_parameter("circle_multiplier", value)
+                                PlayerManager.set_shader_param("ComicDots2", "circle_multiplier", value)
+
+func _on_comic_dots_2_speed_slider_value_changed(value: float) -> void:
+                                comic_dots2_shader_material.set_shader_parameter("speed", value)
+                                PlayerManager.set_shader_param("ComicDots2", "speed", value)
 
 func _on_electric_button_toggled(toggled_on: bool) -> void:
 		Events.set_desktop_background_visible("Electric", toggled_on)
@@ -254,19 +269,27 @@ func _on_blue_warp_reset_button_pressed() -> void:
 		blue_warp_thing3_slider.value = d["thing3"]
 		blue_warp_speed_slider.value = d["speed"]
 
-func _on_comic_dots_reset_button_pressed() -> void:
-		PlayerManager.reset_shader("ComicDots")
-		var d = PlayerManager.DEFAULT_BACKGROUND_SHADERS["ComicDots"]
-		var color = PlayerManager.dict_to_color(d["circle_color"])
-		comic_dots1_shader_material.set_shader_parameter("circle_color", color)
-		comic_dots2_shader_material.set_shader_parameter("circle_color", color)
-		comic_dots1_shader_material.set_shader_parameter("circle_multiplier", d["circle_multiplier"])
-		comic_dots2_shader_material.set_shader_parameter("circle_multiplier", d["circle_multiplier"])
-		comic_dots1_shader_material.set_shader_parameter("speed", d["speed"])
-		comic_dots2_shader_material.set_shader_parameter("speed", d["speed"])
-		comic_dots_color_picker.color = color
-		comic_dots_multiplier_slider.value = d["circle_multiplier"]
-		comic_dots_speed_slider.value = d["speed"]
+func _on_comic_dots_1_reset_button_pressed() -> void:
+                PlayerManager.reset_shader("ComicDots1")
+                var d = PlayerManager.DEFAULT_BACKGROUND_SHADERS["ComicDots1"]
+                var color = PlayerManager.dict_to_color(d["circle_color"])
+                comic_dots1_shader_material.set_shader_parameter("circle_color", color)
+                comic_dots1_shader_material.set_shader_parameter("circle_multiplier", d["circle_multiplier"])
+                comic_dots1_shader_material.set_shader_parameter("speed", d["speed"])
+                comic_dots1_color_picker.color = color
+                comic_dots1_multiplier_slider.value = d["circle_multiplier"]
+                comic_dots1_speed_slider.value = d["speed"]
+
+func _on_comic_dots_2_reset_button_pressed() -> void:
+                PlayerManager.reset_shader("ComicDots2")
+                var d = PlayerManager.DEFAULT_BACKGROUND_SHADERS["ComicDots2"]
+                var color = PlayerManager.dict_to_color(d["circle_color"])
+                comic_dots2_shader_material.set_shader_parameter("circle_color", color)
+                comic_dots2_shader_material.set_shader_parameter("circle_multiplier", d["circle_multiplier"])
+                comic_dots2_shader_material.set_shader_parameter("speed", d["speed"])
+                comic_dots2_color_picker.color = color
+                comic_dots2_multiplier_slider.value = d["circle_multiplier"]
+                comic_dots2_speed_slider.value = d["speed"]
 
 func _on_electric_reset_button_pressed() -> void:
 		PlayerManager.reset_shader("Electric")

--- a/scripts/desktop_env.gd
+++ b/scripts/desktop_env.gd
@@ -69,16 +69,21 @@ func _apply_shader_settings() -> void:
 		blue_warp_shader_material.set_shader_parameter("thing3", PlayerManager.get_shader_param("BlueWarp", "thing3", bw_def["thing3"]))
 		blue_warp_shader_material.set_shader_parameter("speed", PlayerManager.get_shader_param("BlueWarp", "speed", bw_def["speed"]))
 
-		var cd_def = defaults["ComicDots"]
-		var cd_color = PlayerManager.get_shader_param("ComicDots", "circle_color", PlayerManager.dict_to_color(cd_def["circle_color"]))
-		var cd_mult = PlayerManager.get_shader_param("ComicDots", "circle_multiplier", cd_def["circle_multiplier"])
-		var cd_speed = PlayerManager.get_shader_param("ComicDots", "speed", cd_def["speed"])
-		comic_dots1_shader_material.set_shader_parameter("circle_color", cd_color)
-		comic_dots2_shader_material.set_shader_parameter("circle_color", cd_color)
-		comic_dots1_shader_material.set_shader_parameter("circle_multiplier", cd_mult)
-		comic_dots2_shader_material.set_shader_parameter("circle_multiplier", cd_mult)
-		comic_dots1_shader_material.set_shader_parameter("speed", cd_speed)
-		comic_dots2_shader_material.set_shader_parameter("speed", cd_speed)
+                var cd1_def = defaults["ComicDots1"]
+                var cd1_color = PlayerManager.get_shader_param("ComicDots1", "circle_color", PlayerManager.dict_to_color(cd1_def["circle_color"]))
+                var cd1_mult = PlayerManager.get_shader_param("ComicDots1", "circle_multiplier", cd1_def["circle_multiplier"])
+                var cd1_speed = PlayerManager.get_shader_param("ComicDots1", "speed", cd1_def["speed"])
+                comic_dots1_shader_material.set_shader_parameter("circle_color", cd1_color)
+                comic_dots1_shader_material.set_shader_parameter("circle_multiplier", cd1_mult)
+                comic_dots1_shader_material.set_shader_parameter("speed", cd1_speed)
+
+                var cd2_def = defaults["ComicDots2"]
+                var cd2_color = PlayerManager.get_shader_param("ComicDots2", "circle_color", PlayerManager.dict_to_color(cd2_def["circle_color"]))
+                var cd2_mult = PlayerManager.get_shader_param("ComicDots2", "circle_multiplier", cd2_def["circle_multiplier"])
+                var cd2_speed = PlayerManager.get_shader_param("ComicDots2", "speed", cd2_def["speed"])
+                comic_dots2_shader_material.set_shader_parameter("circle_color", cd2_color)
+                comic_dots2_shader_material.set_shader_parameter("circle_multiplier", cd2_mult)
+                comic_dots2_shader_material.set_shader_parameter("speed", cd2_speed)
 
 		var e_def = defaults["Electric"]
 		var bg_color = PlayerManager.get_shader_param("Electric", "background_color", PlayerManager.dict_to_color(e_def["background_color"]))


### PR DESCRIPTION
## Summary
- manage ComicDots1 and ComicDots2 shader defaults separately
- add per-shader controls in settings for color, size, speed, and reset
- load and apply each comic dots shader's parameters independently

## Testing
- `/tmp/godot4/Godot_v4.2.2-stable_linux.x86_64 --headless tests/test_runner.tscn >/tmp/test.log 2>&1 && tail -n 20 /tmp/test.log`


------
https://chatgpt.com/codex/tasks/task_e_68a636dd39c88325ac53dd4e371aba67