### PR TITLE
Add centralized context menu system

### DIFF
--- a/autoloads/context_menu_manager.gd
+++ b/autoloads/context_menu_manager.gd
@@ -1,0 +1,32 @@
+extends Node
+class_name ContextMenuManager
+
+var _popup_menu: PopupMenu
+var _owner: Node
+var _actions: Dictionary = {}
+
+func _ready() -> void:
+	_popup_menu = PopupMenu.new()
+	get_tree().root.add_child(_popup_menu)
+	_popup_menu.hide()
+	_popup_menu.id_pressed.connect(_on_id_pressed)
+
+func open_for(owner: Node, screen_pos: Vector2, actions: Array) -> void:
+	_owner = owner
+	_actions.clear()
+	_popup_menu.clear()
+	for action in actions:
+		var ctx: ContextAction = action
+		_actions[ctx.id] = ctx
+		_popup_menu.add_item(ctx.label, ctx.id)
+		var idx: int = _popup_menu.get_item_count() - 1
+		_popup_menu.set_item_disabled(idx, not ctx.enabled)
+	_popup_menu.position = screen_pos
+	_popup_menu.reset_size()
+	_popup_menu.popup()
+
+func _on_id_pressed(id: int) -> void:
+	if _actions.has(id):
+		var action: ContextAction = _actions[id]
+		action.execute(_owner)
+	_popup_menu.hide()

--- a/components/desktop/folder_shortcut.gd
+++ b/components/desktop/folder_shortcut.gd
@@ -34,6 +34,24 @@ func _on_gui_input(event: InputEvent) -> void:
 				if is_dragging:
 					is_dragging = false
 					DesktopLayoutManager.move_item(item_id, global_position)
+		elif mb.button_index == MOUSE_BUTTON_RIGHT and mb.pressed:
+			var actions: Array = []
+			var action_open: ContextAction = ContextAction.new()
+			action_open.id = 0
+			action_open.label = "Open Folder"
+			action_open.method = "_open_folder"
+			actions.append(action_open)
+			var action_rename: ContextAction = ContextAction.new()
+			action_rename.id = 1
+			action_rename.label = "Rename Folder"
+			action_rename.method = "_ctx_rename"
+			actions.append(action_rename)
+			var action_delete: ContextAction = ContextAction.new()
+			action_delete.id = 2
+			action_delete.label = "Delete Folder"
+			action_delete.method = "_ctx_delete"
+			actions.append(action_delete)
+			ContextMenuManager.open_for(self, mb.global_position, actions)
 	elif event is InputEventMouseMotion:
 		if is_dragging:
 			global_position = get_global_mouse_position() - drag_offset
@@ -42,3 +60,21 @@ func _open_folder() -> void:
 	var scene: PackedScene = preload("res://components/desktop/folder_window.tscn")
 	var pane: Pane = scene.instantiate()
 	WindowManager.launch_pane_instance(pane, item_id)
+
+func _ctx_rename() -> void:
+	var dialog: AcceptDialog = AcceptDialog.new()
+	dialog.title = "Rename Folder"
+	var line_edit: LineEdit = LineEdit.new()
+	line_edit.text = title_label.text
+	dialog.add_child(line_edit)
+	dialog.confirmed.connect(Callable(self, "_on_rename_confirmed").bind(line_edit, dialog))
+	get_tree().root.add_child(dialog)
+	dialog.popup_centered()
+
+func _on_rename_confirmed(line_edit: LineEdit, dialog: AcceptDialog) -> void:
+	var new_title: String = line_edit.text
+	DesktopLayoutManager.rename_item(item_id, new_title)
+	dialog.queue_free()
+
+func _ctx_delete() -> void:
+	DesktopLayoutManager.delete_item(item_id)

--- a/components/desktop_background.gd
+++ b/components/desktop_background.gd
@@ -5,6 +5,23 @@ extends Control
 func _ready() -> void:
 	visible = Events.is_desktop_background_visible(background_name)
 	Events.connect("desktop_background_toggled", Callable(self, "_on_desktop_background_toggled"))
+	gui_input.connect(_on_gui_input)
+
+func _on_gui_input(event: InputEvent) -> void:
+	if event is InputEventMouseButton:
+		var mb: InputEventMouseButton = event
+		if mb.button_index == MOUSE_BUTTON_RIGHT and mb.pressed:
+			var actions: Array = []
+			var action: ContextAction = ContextAction.new()
+			action.id = 0
+			action.label = "New Folder"
+			action.method = "_ctx_new_folder"
+			action.args = [mb.global_position]
+			actions.append(action)
+			ContextMenuManager.open_for(self, mb.global_position, actions)
+
+func _ctx_new_folder(pos: Vector2) -> void:
+	DesktopLayoutManager.create_folder("unnamed folder", "res://assets/logos/folder.png", pos)
 
 func _on_desktop_background_toggled(name: String, visible_state: bool) -> void:
 	if name == background_name:

--- a/project.godot
+++ b/project.godot
@@ -21,6 +21,7 @@ config/icon="uid://xm8tdrmlmymx"
 boot_splash/minimum_display_time=240
 
 [autoload]
+ContextMenuManager="*res://autoloads/context_menu_manager.gd"
 
 WindowManager="*res://autoloads/window_manager.gd"
 PortfolioManager="*res://autoloads/portfolio_manager.gd"

--- a/resources/context_action.gd
+++ b/resources/context_action.gd
@@ -1,0 +1,14 @@
+extends Resource
+class_name ContextAction
+
+var id: int = 0
+var label: String = ""
+var enabled: bool = true
+var method: String = ""
+var args: Array = []
+
+func execute(owner: Node) -> void:
+	if not enabled:
+		return
+	if owner and owner.has_method(method):
+		owner.callv(method, args)


### PR DESCRIPTION
## Summary
- Add ContextAction resource and ContextMenuManager autoload to handle popup menus
- Enable folder shortcuts to show context menu with open, rename, and delete
- Allow desktop background right-click to create new folders

## Testing
- `godot3-server --headless --path . --script tests/test_runner.gd` *(fails: project requires newer Godot config version)*

------
https://chatgpt.com/codex/tasks/task_e_68a648402cbc8325abd969d136c5b39f