### PR TITLE
Add desktop background context menu actions

### DIFF
--- a/components/desktop_background.gd
+++ b/components/desktop_background.gd
@@ -8,20 +8,45 @@ func _ready() -> void:
 	gui_input.connect(_on_gui_input)
 
 func _on_gui_input(event: InputEvent) -> void:
-	if event is InputEventMouseButton:
-		var mb: InputEventMouseButton = event
-		if mb.button_index == MOUSE_BUTTON_RIGHT and mb.pressed:
-			var actions: Array = []
-			var action: ContextAction = ContextAction.new()
-			action.id = 0
-			action.label = "New Folder"
-			action.method = "_ctx_new_folder"
-			action.args = [mb.global_position]
-			actions.append(action)
-			ContextMenuManager.open_for(self, mb.global_position, actions)
+        if event is InputEventMouseButton:
+                var mb: InputEventMouseButton = event
+                if mb.button_index == MOUSE_BUTTON_RIGHT and mb.pressed:
+                        var actions: Array = []
+                        var action_new: ContextAction = ContextAction.new()
+                        action_new.id = 0
+                        action_new.label = "New Folder"
+                        action_new.method = "_ctx_new_folder"
+                        action_new.args = [mb.global_position]
+                        actions.append(action_new)
+                        var action_bg: ContextAction = ContextAction.new()
+                        action_bg.id = 1
+                        action_bg.label = "Change Desktop Background"
+                        action_bg.method = "_ctx_change_background"
+                        actions.append(action_bg)
+                        ContextMenuManager.open_for(self, mb.global_position, actions)
+                        accept_event()
 
 func _ctx_new_folder(pos: Vector2) -> void:
-	DesktopLayoutManager.create_folder("unnamed folder", "res://assets/logos/folder.png", pos)
+        var base_name := "Unnamed Folder"
+        var name := base_name
+        var counter := 1
+        while true:
+                var exists := false
+                for item in DesktopLayoutManager.items.values():
+                        if item.get("title", "") == name:
+                                exists = true
+                                break
+                if not exists:
+                        break
+                counter += 1
+                name = "%s %d" % [base_name, counter]
+        DesktopLayoutManager.create_folder(name, "res://assets/logos/folder.png", pos)
+
+func _ctx_change_background() -> void:
+        var scene: PackedScene = WindowManager.app_registry.get("Settings")
+        if scene:
+                var pane: Pane = scene.instantiate()
+                WindowManager.launch_pane_instance(pane, "Backgrounds")
 
 func _on_desktop_background_toggled(name: String, visible_state: bool) -> void:
 	if name == background_name:

--- a/components/desktop_env.tscn
+++ b/components/desktop_env.tscn
@@ -234,6 +234,8 @@ scale = Vector2(0.8673, 0.8673)
 texture = ExtResource("3_0utxc")
 expand_mode = 2
 stretch_mode = 5
+script = ExtResource("24_jkb4t")
+background_name = "Default"
 
 [node name="ShaderBackgroundsContainer" type="Control" parent="."]
 layout_mode = 1
@@ -242,6 +244,7 @@ anchor_right = 1.0
 anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
+script = ExtResource("24_jkb4t")
 
 [node name="BlueWarpShader" type="PanelContainer" parent="ShaderBackgroundsContainer"]
 visible = false
@@ -252,8 +255,7 @@ anchor_right = 1.0
 anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
-script = ExtResource("24_jkb4t")
-background_name = "BlueWarp"
+mouse_filter = 2
 
 [node name="PixelPlanet" type="PanelContainer" parent="ShaderBackgroundsContainer"]
 visible = false
@@ -264,6 +266,7 @@ anchor_right = 1.0
 anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
+mouse_filter = 2
 
 [node name="WavesShader" type="ColorRect" parent="ShaderBackgroundsContainer"]
 visible = false
@@ -274,8 +277,7 @@ anchor_right = 1.0
 anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
-script = ExtResource("24_jkb4t")
-background_name = "Waves"
+mouse_filter = 2
 
 [node name="ElectricShader" type="ColorRect" parent="ShaderBackgroundsContainer"]
 visible = false
@@ -286,8 +288,7 @@ anchor_right = 1.0
 anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
-script = ExtResource("24_jkb4t")
-background_name = "Electric"
+mouse_filter = 2
 
 [node name="ComicDotsBlueVert" type="ColorRect" parent="ShaderBackgroundsContainer"]
 visible = false
@@ -303,8 +304,7 @@ offset_bottom = 2733.0
 grow_horizontal = 2
 grow_vertical = 2
 rotation = -1.5708
-script = ExtResource("24_jkb4t")
-background_name = "ComicDots1"
+mouse_filter = 2
 
 [node name="ComicDotsBlueHor" type="ColorRect" parent="ShaderBackgroundsContainer"]
 visible = false
@@ -319,8 +319,7 @@ offset_right = 1008.0
 offset_bottom = -4.0
 grow_horizontal = 2
 grow_vertical = 2
-script = ExtResource("24_jkb4t")
-background_name = "ComicDots2"
+mouse_filter = 2
 
 [node name="TopBar" type="Control" parent="."]
 layout_mode = 1

--- a/components/settings_window.gd
+++ b/components/settings_window.gd
@@ -35,11 +35,18 @@ extends Pane
 @onready var electric_speed_slider: HSlider = %ElectricSpeedSlider
 @onready var electric_scale_x_slider: HSlider = %ElectricScaleXSlider
 @onready var electric_scale_y_slider: HSlider = %ElectricScaleYSlider
+@onready var tab_container: TabContainer = %TabContainer
 @onready var waves_shader_material: ShaderMaterial = get_tree().root.get_node("Main/DesktopEnv/ShaderBackgroundsContainer/WavesShader").material
 @onready var blue_warp_shader_material: ShaderMaterial = get_tree().root.get_node("Main/DesktopEnv/ShaderBackgroundsContainer/BlueWarpShader").material
 @onready var comic_dots1_shader_material: ShaderMaterial = get_tree().root.get_node("Main/DesktopEnv/ShaderBackgroundsContainer/ComicDotsBlueVert").material
 @onready var comic_dots2_shader_material: ShaderMaterial = get_tree().root.get_node("Main/DesktopEnv/ShaderBackgroundsContainer/ComicDotsBlueHor").material
 @onready var electric_shader_material: ShaderMaterial = get_tree().root.get_node("Main/DesktopEnv/ShaderBackgroundsContainer/ElectricShader").material
+
+func setup_custom(tab_name: String) -> void:
+        if tab_name == "Backgrounds":
+                var tab = tab_container.get_node_or_null("Backgrounds")
+                if tab:
+                        tab_container.current_tab = tab.get_index()
 
 
 func _ready() -> void:


### PR DESCRIPTION
## Summary
- add right-click menu on desktop background with options to create folders and change wallpaper
- support opening Settings directly to Backgrounds tab
- hook desktop background nodes to shared menu and ignore input on shader layers

## Testing
- `godot3-server --path . tests/test_runner.tscn` *(fails: config version from newer Godot)*

------
https://chatgpt.com/codex/tasks/task_e_68a650534afc832590bdb0996c8b3ab3