### PR TITLE
Add optional Apps folder generation

### DIFF
--- a/autoloads/desktop_layout_manager.gd
+++ b/autoloads/desktop_layout_manager.gd
@@ -14,38 +14,42 @@ func reset() -> void:
 	items.clear()
 	next_id = 1
 
-func create_app_shortcut(app_name: String, title: String, icon_path: String, position: Vector2) -> int:
-	var id: int = next_id
-	next_id += 1
-	var entry: Dictionary = {
-		"id": id,
-		"type": "app",
-		"app_name": app_name,
-		"title": title,
-		"icon_path": icon_path,
-		"desktop_position": position,
-		"parent_id": 0,
-		"child_ids": []
-	}
-	items[id] = entry
-	item_created.emit(id, entry)
-	return id
+func create_app_shortcut(app_name: String, title: String, icon_path: String, position: Vector2, parent_id: int = 0) -> int:
+    var id: int = next_id
+    next_id += 1
+    var entry: Dictionary = {
+        "id": id,
+        "type": "app",
+        "app_name": app_name,
+        "title": title,
+        "icon_path": icon_path,
+        "desktop_position": position,
+        "parent_id": parent_id,
+        "child_ids": []
+    }
+    items[id] = entry
+    if parent_id != 0 and items.has(parent_id):
+        items[parent_id]["child_ids"].append(id)
+    item_created.emit(id, entry)
+    return id
 
-func create_folder(title: String, icon_path: String, position: Vector2) -> int:
-	var id: int = next_id
-	next_id += 1
-	var entry: Dictionary = {
-		"id": id,
-		"type": "folder",
-		"title": title,
-		"icon_path": icon_path,
-		"desktop_position": position,
-		"parent_id": 0,
-		"child_ids": []
-	}
-	items[id] = entry
-	item_created.emit(id, entry)
-	return id
+func create_folder(title: String, icon_path: String, position: Vector2, parent_id: int = 0) -> int:
+    var id: int = next_id
+    next_id += 1
+    var entry: Dictionary = {
+        "id": id,
+        "type": "folder",
+        "title": title,
+        "icon_path": icon_path,
+        "desktop_position": position,
+        "parent_id": parent_id,
+        "child_ids": []
+    }
+    items[id] = entry
+    if parent_id != 0 and items.has(parent_id):
+        items[parent_id]["child_ids"].append(id)
+    item_created.emit(id, entry)
+    return id
 
 func move_item(id: int, position: Vector2) -> void:
 	if not items.has(id):
@@ -60,10 +64,13 @@ func rename_item(id: int, new_title: String) -> void:
 	item_renamed.emit(id, new_title)
 
 func delete_item(id: int) -> void:
-	if not items.has(id):
-		return
-	items.erase(id)
-	item_deleted.emit(id)
+    if not items.has(id):
+        return
+    var parent_id: int = int(items[id].get("parent_id", 0))
+    if parent_id != 0 and items.has(parent_id):
+        items[parent_id]["child_ids"].erase(id)
+    items.erase(id)
+    item_deleted.emit(id)
 
 func get_item(id: int) -> Dictionary:
 	return items.get(id, {})

--- a/scripts/desktop_env.gd
+++ b/scripts/desktop_env.gd
@@ -17,6 +17,7 @@ const FOLDER_SHORTCUT_SCENE: PackedScene = preload("res://components/desktop/fol
 
 
 @export var background_texture: Texture = preload("res://assets/backgrounds/Bliss_(Windows_XP) (2).png")
+@export var create_or_update_apps_folder: bool = false
 
 func _ready() -> void:
 	#SaveManager.save_to_slot(PlayerManager.get_slot_id())
@@ -135,17 +136,21 @@ func _on_load_button_pressed() -> void:
 	SaveManager.load_from_slot(SaveManager.current_slot_id)
 
 func _on_items_loaded() -> void:
-	for child in icons_layer.get_children():
-		if child is AppShortcut or child is FolderShortcut:
-			child.queue_free()
+        for child in icons_layer.get_children():
+                if child is AppShortcut or child is FolderShortcut:
+                        child.queue_free()
 
-	var items: Array = DesktopLayoutManager.get_children_of(0)
+        var items: Array = DesktopLayoutManager.get_children_of(0)
 
-	for entry in items:
-		_spawn_item(entry)
+        for entry in items:
+                _spawn_item(entry)
+        if create_or_update_apps_folder:
+                _create_or_update_apps_folder()
 
 func _on_item_created(item_id: int, data: Dictionary) -> void:
-	_spawn_item(data)
+        if int(data.get("parent_id", 0)) != 0:
+                return
+        _spawn_item(data)
 
 func _on_item_deleted(item_id: int) -> void:
 	for child in icons_layer.get_children():
@@ -169,5 +174,38 @@ func _spawn_item(data: Dictionary) -> void:
 		var tex: Texture2D = load(icon_path)
 		node.icon = tex
 	icons_layer.add_child(node)
-	var pos: Vector2 = data.get("desktop_position", Vector2.ZERO)
-	node.global_position = pos
+        var pos: Vector2 = data.get("desktop_position", Vector2.ZERO)
+        node.global_position = pos
+
+func _create_or_update_apps_folder() -> void:
+        var folder_id: int = 0
+        var root_items: Array = DesktopLayoutManager.get_children_of(0)
+        for entry in root_items:
+                if entry.get("type", "") == "folder" and entry.get("title", "") == "Apps":
+                        folder_id = int(entry.get("id", 0))
+                        DesktopLayoutManager.move_item(folder_id, Vector2.ZERO)
+                        break
+        if folder_id == 0:
+                folder_id = DesktopLayoutManager.create_folder("Apps", "res://assets/logos/folder.png", Vector2.ZERO)
+        var existing: Dictionary = {}
+        for entry in DesktopLayoutManager.get_children_of(folder_id):
+                if entry.get("type", "") == "app":
+                        existing[entry.get("app_name", "")] = true
+        for app_name in WindowManager.app_registry.keys():
+                if existing.has(app_name):
+                        continue
+                var meta: Dictionary = _get_app_meta(app_name)
+                DesktopLayoutManager.create_app_shortcut(app_name, meta.get("title", app_name), meta.get("icon_path", ""), Vector2.ZERO, folder_id)
+
+func _get_app_meta(app_name: String) -> Dictionary:
+        var scene: PackedScene = WindowManager.app_registry.get(app_name)
+        var title: String = app_name
+        var icon_path: String = ""
+        if scene:
+                var preview = scene.instantiate()
+                if preview is Pane:
+                        title = preview.window_title
+                        if preview.window_icon:
+                                icon_path = preview.window_icon.resource_path
+                preview.queue_free()
+        return {"title": title, "icon_path": icon_path}


### PR DESCRIPTION
## Summary
- add `create_or_update_apps_folder` export variable to desktop environment
- build/update an "Apps" folder with shortcuts for each registered app
- allow DesktopLayoutManager to create nested items via optional parent IDs

## Testing
- `godot -q --headless -s tests/test_runner.gd` *(fails: command not found)*
- `apt-get install -y godot4` *(fails: Unable to locate package godot4)*
- `apt-get install -y godot3` *(succeeds, but project uses a newer engine)*
- `godot3 -q --headless -s tests/test_runner.gd` *(fails: project requires Godot 4)*

------
https://chatgpt.com/codex/tasks/task_e_68a651e29d5c8325bcce33d0f8785697