### PR TITLE
Add Friend Pic upgrade for Fumble

### DIFF
--- a/components/apps/fumble/fumble_battle/battle_ui.gd
+++ b/components/apps/fumble/fumble_battle/battle_ui.gd
@@ -130,6 +130,8 @@ func load_battle(new_battle_id: String, new_npc: NPC, chatlog_in: Array = [], st
 					move_usage_counts_in = data.get("move_usage_counts", {})
 	chatlog = chatlog_in.duplicate() if chatlog_in.size() > 0 else chatlog
 
+	var is_new_battle := chatlog.size() == 0 and stats_in.size() == 0 and move_usage_counts_in.size() == 0
+
 	# If stats_in is empty, pull stats from npc resource
 	var battle_stats_to_use: Dictionary = {}
 	if stats_in.size() > 0:
@@ -140,7 +142,10 @@ func load_battle(new_battle_id: String, new_npc: NPC, chatlog_in: Array = [], st
 					"chemistry": npc.chemistry,
 					"apprehension": npc.apprehension
 			}
-	
+
+	if is_new_battle and UpgradeManager.get_level("fumble_friend_pic") > 0:
+			battle_stats_to_use["apprehension"] = clamp(battle_stats_to_use.get("apprehension", 0) - 10, 0, 100)
+
 	# Set up logic
 	if battle_logic_resource:
 		logic = battle_logic_resource.duplicate()

--- a/data/upgrades/fumble_friend_pic.json
+++ b/data/upgrades/fumble_friend_pic.json
@@ -1,0 +1,16 @@
+{
+  "id": "fumble_friend_pic",
+  "name": "Friend Pic",
+  "description": "Start each chat battle by lowering the NPC's apprehension by 10.",
+  "effects": [],
+  "systems": [
+    "fumble"
+  ],
+  "dependencies": [],
+  "cost_per_level": {
+    "ex": 5
+  },
+  "max_level": 1,
+  "repeatable": false,
+  "scale_by_formula": false
+}


### PR DESCRIPTION
## Summary
- add Friend Pic upgrade that lowers NPC apprehension at chat battle start
- apply effect when loading new fumble chat battles

## Testing
- `godot4 --headless --script tests/test_runner.gd` *(fails: script doesn't inherit from SceneTree or MainLoop)*

------
https://chatgpt.com/codex/tasks/task_e_68a66ad504408325923622785c05944b