### PR TITLE
Add Cyberstalk upgrade for fumble

### DIFF
--- a/components/apps/fumble/fumble_battle/battle_logic.gd
+++ b/components/apps/fumble/fumble_battle/battle_logic.gd
@@ -3,31 +3,36 @@ extends Resource
 
 var npc: NPC
 var stats = {}
+var move_count: int = 0
 
 
-func setup(npc_ref, stats_dict = {}):
-	npc = npc_ref
-	stats = stats_dict.duplicate()
+func setup(npc_ref, stats_dict = {}, move_count_in: int = 0):
+        npc = npc_ref
+        stats = stats_dict.duplicate()
+        move_count = move_count_in
 
 func resolve_move(move_type: String) -> Dictionary:
-	var chance = get_success_chance(move_type)
-	var success = RNGManager.get_rng().randf() < chance
-	var mod = get_move_type_modifier(npc.chat_battle_type, move_type)
-	var reaction = ""
-	if mod == 2.0:
-		reaction = "heart"
-	elif mod == 0.5:
-		reaction = "haha"
-	elif mod == 0.0:
-		reaction = "thumbs_down"
-	# Default: no reaction or normal (could add more)
-	var effects = apply_move_effects(move_type, success)
-	return {
-		"success": success,
-		"chance": chance,
-		"effects": effects,
-		"reaction": reaction
-	}
+        var chance = get_success_chance(move_type)
+        if move_count == 0 and move_type != "catch" and UpgradeManager.get_level("fumble_cyberstalk") > 0:
+                chance = clamp(chance + 0.1, 0.0, 1.0)
+        var success = RNGManager.get_rng().randf() < chance
+        var mod = get_move_type_modifier(npc.chat_battle_type, move_type)
+        var reaction = ""
+        if mod == 2.0:
+                reaction = "heart"
+        elif mod == 0.5:
+                reaction = "haha"
+        elif mod == 0.0:
+                reaction = "thumbs_down"
+        # Default: no reaction or normal (could add more)
+        var effects = apply_move_effects(move_type, success)
+        move_count += 1
+        return {
+                "success": success,
+                "chance": chance,
+                "effects": effects,
+                "reaction": reaction
+        }
 
 
 func get_success_chance(move_type: String) -> float:

--- a/components/apps/fumble/fumble_battle/battle_ui.gd
+++ b/components/apps/fumble/fumble_battle/battle_ui.gd
@@ -146,13 +146,17 @@ func load_battle(new_battle_id: String, new_npc: NPC, chatlog_in: Array = [], st
 	if is_new_battle and UpgradeManager.get_level("fumble_friend_pic") > 0:
 			battle_stats_to_use["apprehension"] = clamp(battle_stats_to_use.get("apprehension", 0) - 10, 0, 100)
 
-	# Set up logic
-	if battle_logic_resource:
-		logic = battle_logic_resource.duplicate()
-	else:
-		logic = BattleLogic.new()
-	logic.setup(npc, battle_stats_to_use)
-	battle_stats = logic.get_stats()
+        # Set up logic
+        if battle_logic_resource:
+                logic = battle_logic_resource.duplicate()
+        else:
+                logic = BattleLogic.new()
+        var player_move_count := 0
+        for msg in chatlog:
+                if msg.get("is_player", false) and msg.get("text", "") != "*ghosts*":
+                        player_move_count += 1
+        logic.setup(npc, battle_stats_to_use, player_move_count)
+        battle_stats = logic.get_stats()
 
 	_update_profiles()
 	for child in chat_container.get_children():

--- a/data/upgrades/fumble_cyberstalk.json
+++ b/data/upgrades/fumble_cyberstalk.json
@@ -1,0 +1,16 @@
+{
+  "id": "fumble_cyberstalk",
+  "name": "Cyberstalk",
+  "description": "+10% success chance on your first move in a chat battle (excluding CATCH).",
+  "effects": [],
+  "systems": [
+    "fumble"
+  ],
+  "dependencies": [],
+  "cost_per_level": {
+    "ex": 10
+  },
+  "max_level": 1,
+  "repeatable": false,
+  "scale_by_formula": false
+}


### PR DESCRIPTION
## Summary
- Add Cyberstalk upgrade with 10 EX cost
- Boost first-move success chance via move count tracking
- Pass prior player moves into battle logic for accurate bonus handling

## Testing
- `godot3 --headless --path . -s tests/test_runner.gd` *(fails: project requires newer Godot config version)*

------
https://chatgpt.com/codex/tasks/task_e_68a66e14c7e483259c4bcafbf3e1b58d