### PR TITLE
Add Fugly Filter upgrade for Fumble

### DIFF
--- a/autoloads/player_manager.gd
+++ b/autoloads/player_manager.gd
@@ -79,10 +79,11 @@ var default_user_data: Dictionary = {
 		"mbti": "",
 
 	# Fumble preferences
-	"fumble_pref_x": 0.0,
-	"fumble_pref_y": 0.0,
-	"fumble_pref_z": 0.0,
-	"fumble_curiosity": 50.0,
+        "fumble_pref_x": 0.0,
+        "fumble_pref_y": 0.0,
+        "fumble_pref_z": 0.0,
+        "fumble_curiosity": 50.0,
+        "fumble_fugly_filter_threshold": 0,
 
 		# Flags and progression
 "unlocked_perks": [],

--- a/components/apps/fumble/chats_tab.gd
+++ b/components/apps/fumble/chats_tab.gd
@@ -49,9 +49,10 @@ func refresh_matches(time_budget_msec := 8) -> void:
 		var battles: Array = FumbleManager.get_active_battles()
 		var battle_npc_indices := battles.map(func(b): return b.npc_idx)
 
-		var total_attractiveness := 0
-		var filtered_count := 0
-		var data := []
+               var total_attractiveness := 0
+               var match_count := 0
+               var data := []
+               var min_att := PlayerManager.get_var("fumble_fugly_filter_threshold", 0) * 10
 
 		var start_time = Time.get_ticks_msec()
 
@@ -59,10 +60,12 @@ func refresh_matches(time_budget_msec := 8) -> void:
 				var idx: int = row.npc_id
 				if battle_npc_indices.has(idx):
 						continue
-				var npc = NPCManager.get_npc_by_index(idx)
-				total_attractiveness += npc.attractiveness
-				filtered_count += 1
-				data.append({"npc": npc, "idx": idx, "created_at": row.created_at})
+                               var npc = NPCManager.get_npc_by_index(idx)
+                               if npc.attractiveness < min_att:
+                                               continue
+                               total_attractiveness += npc.attractiveness
+                               match_count += 1
+                               data.append({"npc": npc, "idx": idx, "created_at": row.created_at})
 				if Time.get_ticks_msec() - start_time > time_budget_msec:
 						await get_tree().process_frame
 						start_time = Time.get_ticks_msec()
@@ -93,7 +96,7 @@ func refresh_matches(time_budget_msec := 8) -> void:
 				if Time.get_ticks_msec() - start_time > time_budget_msec:
 						await get_tree().process_frame
 						start_time = Time.get_ticks_msec()
-		var total_count := filtered_count + battles.size()
+               var total_count := match_count + battles.size()
 		matches_label.text = "Matches: %d" % total_count
 
 		var avg_att := 0.0

--- a/components/apps/fumble/fumble.gd
+++ b/components/apps/fumble/fumble.gd
@@ -34,6 +34,8 @@ var pride_material = preload("res://components/apps/fumble/fumble_label_pride_mo
 @onready var y_slider: HSlider = %YHSlider
 @onready var z_slider: HSlider = %ZHSlider
 @onready var curiosity_slider: HSlider = %CuriosityHSlider
+@onready var fugly_container: HBoxContainer = %FuglyFilterContainer
+@onready var fugly_slider: HSlider = %FuglyFilterSlider
 
 
 func _ready():
@@ -71,15 +73,20 @@ func _setup_over_frames() -> void:
 
 	x_slider.drag_ended.connect(_on_gender_slider_drag_ended)
 	y_slider.drag_ended.connect(_on_gender_slider_drag_ended)
-	z_slider.drag_ended.connect(_on_gender_slider_drag_ended)
-	curiosity_slider.value_changed.connect(_on_curiosity_h_slider_value_changed)
-	curiosity_slider.drag_ended.connect(_on_curiosity_h_slider_drag_ended)
+        z_slider.drag_ended.connect(_on_gender_slider_drag_ended)
+        curiosity_slider.value_changed.connect(_on_curiosity_h_slider_value_changed)
+        curiosity_slider.drag_ended.connect(_on_curiosity_h_slider_drag_ended)
+        fugly_slider.drag_ended.connect(_on_fugly_slider_drag_ended)
+        if Events.has_signal("fumble_fugly_filter_purchased"):
+                Events.connect("fumble_fugly_filter_purchased", _on_fugly_filter_purchased)
 
 	await get_tree().process_frame
 
-	_load_preferences()
-	bio_text_edit.text = PlayerManager.get_var("bio", "")
-	bio_text_edit.text_changed.connect(_on_bio_text_edit_text_changed)
+        _load_preferences()
+        bio_text_edit.text = PlayerManager.get_var("bio", "")
+        bio_text_edit.text_changed.connect(_on_bio_text_edit_text_changed)
+
+        _update_fugly_filter_ui()
 
 	confidence_progress_bar.update_value(StatManager.get_stat("confidence"))
 	ex_progress_bar.update_value(StatManager.get_stat("ex"))
@@ -174,17 +181,40 @@ func _on_curiosity_h_slider_value_changed(value: float) -> void:
 
 
 func _on_curiosity_h_slider_drag_ended(_changed) -> void:
-		if card_stack:
-				card_stack.set_curiosity(curiosity)
-				card_stack.refresh_pool_under_top_with_gender(preferred_gender, curiosity)
-		PlayerManager.set_var("fumble_curiosity", curiosity_slider.value)
+                if card_stack:
+                                card_stack.set_curiosity(curiosity)
+                                card_stack.refresh_pool_under_top_with_gender(preferred_gender, curiosity)
+                PlayerManager.set_var("fumble_curiosity", curiosity_slider.value)
+
+
+func _on_fugly_slider_drag_ended(_changed) -> void:
+                PlayerManager.set_var("fumble_fugly_filter_threshold", fugly_slider.value)
+                if card_stack:
+                                await card_stack.refresh_swipe_pool_with_gender(preferred_gender, curiosity)
+                chats_tab.refresh_matches()
+
+
+func _on_fugly_filter_purchased(_level: int) -> void:
+                _update_fugly_filter_ui()
+                if card_stack:
+                                await card_stack.refresh_swipe_pool_with_gender(preferred_gender, curiosity)
+                chats_tab.refresh_matches()
+
+
+func _update_fugly_filter_ui() -> void:
+                var level := UpgradeManager.get_level("fumble_fugly_filter")
+                fugly_container.visible = level > 0
+                fugly_slider.max_value = level
+                var current = PlayerManager.get_var("fumble_fugly_filter_threshold", fugly_slider.value)
+                fugly_slider.value = clamp(current, 0, fugly_slider.max_value)
 
 
 func _load_preferences() -> void:
-		x_slider.value = PlayerManager.get_var("fumble_pref_x", x_slider.value)
-		y_slider.value = PlayerManager.get_var("fumble_pref_y", y_slider.value)
-		z_slider.value = PlayerManager.get_var("fumble_pref_z", z_slider.value)
-		curiosity_slider.value = PlayerManager.get_var("fumble_curiosity", curiosity_slider.value)
+                x_slider.value = PlayerManager.get_var("fumble_pref_x", x_slider.value)
+                y_slider.value = PlayerManager.get_var("fumble_pref_y", y_slider.value)
+                z_slider.value = PlayerManager.get_var("fumble_pref_z", z_slider.value)
+                curiosity_slider.value = PlayerManager.get_var("fumble_curiosity", curiosity_slider.value)
+                fugly_slider.value = PlayerManager.get_var("fumble_fugly_filter_threshold", fugly_slider.value)
 
 
 func _on_resize_x_requested(pixels):
@@ -204,13 +234,14 @@ func _on_bio_text_edit_text_changed() -> void:
 
 
 func _on_visibility_changed() -> void:
-		if not visible:
-				return
-		_load_preferences()
-		_on_gender_slider_changed(0)
-		_on_curiosity_h_slider_value_changed(curiosity_slider.value)
-		if card_stack and card_stack.cards.is_empty():
-				await card_stack.refresh_swipe_pool_with_gender(preferred_gender, curiosity)
+                if not visible:
+                                return
+                _load_preferences()
+                _update_fugly_filter_ui()
+                _on_gender_slider_changed(0)
+                _on_curiosity_h_slider_value_changed(curiosity_slider.value)
+                if card_stack and card_stack.cards.is_empty():
+                                await card_stack.refresh_swipe_pool_with_gender(preferred_gender, curiosity)
 
 
 func _on_confidence_changed(value: float) -> void:

--- a/components/apps/fumble/fumble.tscn
+++ b/components/apps/fumble/fumble.tscn
@@ -283,6 +283,26 @@ size_flags_horizontal = 3
 custom_minimum_size = Vector2(25, 0)
 layout_mode = 2
 
+[node name="FuglyFilterContainer" type="HBoxContainer" parent="MarginContainer/VBoxContainer/SelfTab/MarginContainer/ScrollContainer/VBoxContainer2/VBoxContainer/FumbleSearchCriteriaContainer"]
+visible = false
+layout_mode = 2
+
+[node name="Label" type="Label" parent="MarginContainer/VBoxContainer/SelfTab/MarginContainer/ScrollContainer/VBoxContainer2/VBoxContainer/FumbleSearchCriteriaContainer/FuglyFilterContainer"]
+layout_mode = 2
+text = "Min 🔥"
+
+[node name="FuglyFilterSlider" type="HSlider" parent="MarginContainer/VBoxContainer/SelfTab/MarginContainer/ScrollContainer/VBoxContainer2/VBoxContainer/FumbleSearchCriteriaContainer/FuglyFilterContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 3
+min_value = 0.0
+max_value = 1.0
+step = 1.0
+
+[node name="Control8" type="Control" parent="MarginContainer/VBoxContainer/SelfTab/MarginContainer/ScrollContainer/VBoxContainer2/VBoxContainer/FumbleSearchCriteriaContainer/FuglyFilterContainer"]
+custom_minimum_size = Vector2(25, 0)
+layout_mode = 2
+
 [node name="10px7" type="Control" parent="MarginContainer/VBoxContainer/SelfTab/MarginContainer/ScrollContainer/VBoxContainer2"]
 custom_minimum_size = Vector2(10, 0)
 layout_mode = 2

--- a/components/apps/fumble/profile_card_stack.gd
+++ b/components/apps/fumble/profile_card_stack.gd
@@ -167,22 +167,23 @@ func _populate_cards_over_frames(count: int, add_at_top: bool = true) -> void:
 		await get_tree().process_frame  # Spread out the work
 
 func _refill_swipe_pool_async(time_budget_msec := 8) -> void:
-	var start_time = Time.get_ticks_msec()
-	var seen = NPCManager.encounter_count
-	var t = clamp(float(seen) / float(max_recycled_cap_index), 0.0, 1.0)
-	var percent = lerp(min_recycled_percent, max_recycled_percent, t)
-	var num_recycled = int(round(swipe_pool_size * percent))
-	var num_new = swipe_pool_size - num_recycled
-	var pool: Array[int] = []
+        var start_time = Time.get_ticks_msec()
+        var seen = NPCManager.encounter_count
+        var t = clamp(float(seen) / float(max_recycled_cap_index), 0.0, 1.0)
+        var percent = lerp(min_recycled_percent, max_recycled_percent, t)
+        var num_recycled = int(round(swipe_pool_size * percent))
+        var num_new = swipe_pool_size - num_recycled
+        var pool: Array[int] = []
 
-	var exclude = npc_indices + swipe_pool
+        var exclude = npc_indices + swipe_pool
+        var min_att := PlayerManager.get_var("fumble_fugly_filter_threshold", 0) * 10
 
 	var new_indices: Array[int] = []
-	for idx in NPCManager.get_batch_of_new_npc_indices(app_name, num_new * 3):
-		if not exclude.has(idx):
-			var npc = NPCManager.get_npc_by_index(idx)
-			if gender_dot_similarity(preferred_gender, npc.gender_vector) >= gender_similarity_threshold:
-				new_indices.append(idx)
+       for idx in NPCManager.get_batch_of_new_npc_indices(app_name, num_new * 3):
+               if not exclude.has(idx):
+                       var npc = NPCManager.get_npc_by_index(idx)
+                       if npc.attractiveness >= min_att and gender_dot_similarity(preferred_gender, npc.gender_vector) >= gender_similarity_threshold:
+                               new_indices.append(idx)
 		if new_indices.size() >= num_new:
 			break
 		# ---- Time budget yield ----
@@ -191,11 +192,11 @@ func _refill_swipe_pool_async(time_budget_msec := 8) -> void:
 			start_time = Time.get_ticks_msec()
 
 	var recycled_indices: Array[int] = []
-	for idx in NPCManager.get_batch_of_recycled_npc_indices(app_name, num_recycled * 3):
-		if not exclude.has(idx):
-			var npc = NPCManager.get_npc_by_index(idx)
-			if gender_dot_similarity(preferred_gender, npc.gender_vector) >= gender_similarity_threshold:
-				recycled_indices.append(idx)
+       for idx in NPCManager.get_batch_of_recycled_npc_indices(app_name, num_recycled * 3):
+               if not exclude.has(idx):
+                       var npc = NPCManager.get_npc_by_index(idx)
+                       if npc.attractiveness >= min_att and gender_dot_similarity(preferred_gender, npc.gender_vector) >= gender_similarity_threshold:
+                               recycled_indices.append(idx)
 		if recycled_indices.size() >= num_recycled:
 			break
 		# ---- Time budget yield ----

--- a/data/upgrades/fumble_fugly_filter.json
+++ b/data/upgrades/fumble_fugly_filter.json
@@ -1,0 +1,18 @@
+{
+  "id": "fumble_fugly_filter",
+  "name": "Fugly Filter",
+  "description": "Adds a minimum attractiveness filter to Fumble matches. Each level raises the maximum threshold by 1.",
+  "effects": [],
+  "systems": [
+    "fumble"
+  ],
+  "dependencies": [],
+  "cost_per_level": {
+    "ex": 1
+  },
+  "scale_by_formula": true,
+  "cost_formula": {
+    "ex": "base_cost[\\\"ex\\\"] * pow(1.1, level-1)"
+  },
+  "max_level": 10
+}


### PR DESCRIPTION
## Summary
- add Fugly Filter upgrade that hides low-attractiveness matches and scales cost by 10%
- store player-selected filter threshold and expose a slider in Fumble's You tab once unlocked
- apply attractiveness threshold when building swipe pools and listing matches

## Testing
- `godot --headless -s tests/test_runner.gd` *(fails: command not found)*
- `apt-get install -y godot4` *(fails: Unable to locate package godot4)*

------
https://chatgpt.com/codex/tasks/task_e_68a66f22b880832580147f140e3df4a8