### PR TITLE
Avoid reloading card stack when adjusting fugly filter

### DIFF
--- a/components/apps/fumble/fumble.gd
+++ b/components/apps/fumble/fumble.gd
@@ -188,17 +188,17 @@ func _on_curiosity_h_slider_drag_ended(_changed) -> void:
 
 
 func _on_fugly_slider_drag_ended(_changed) -> void:
-				PlayerManager.set_var("fumble_fugly_filter_threshold", fugly_slider.value)
-				if card_stack:
-								await card_stack.refresh_swipe_pool_with_gender(preferred_gender, curiosity)
-				chats_tab.refresh_matches()
+                                PlayerManager.set_var("fumble_fugly_filter_threshold", fugly_slider.value)
+                                if card_stack:
+                                                                await card_stack.apply_fugly_filter()
+                                chats_tab.refresh_matches()
 
 
 func _on_fugly_filter_purchased(_level: int) -> void:
-				_update_fugly_filter_ui()
-				if card_stack:
-								await card_stack.refresh_swipe_pool_with_gender(preferred_gender, curiosity)
-				chats_tab.refresh_matches()
+                                _update_fugly_filter_ui()
+                                if card_stack:
+                                                                await card_stack.apply_fugly_filter()
+                                chats_tab.refresh_matches()
 
 
 func _update_fugly_filter_ui() -> void:


### PR DESCRIPTION
## Summary
- Remove low-attractiveness NPCs from existing swipe pool and card stack based on fugly filter
- Apply fugly filter without refreshing the entire stack when slider changes or filter purchased

## Testing
- `godot3 --headless --script tests/test_runner.gd` *(fails: Can't open project...)*

------
https://chatgpt.com/codex/tasks/task_e_68a68c30602883258dd98075119045c7