### PR TITLE
Ensure app icons have minimum size and responsive folder grid

### DIFF
--- a/components/desktop/app_shortcut.tscn
+++ b/components/desktop/app_shortcut.tscn
@@ -7,6 +7,7 @@ layout_mode = 3
 anchors_preset = 0
 offset_right = 64.0
 offset_bottom = 64.0
+custom_minimum_size = Vector2(64, 87)
 script = ExtResource("1")
 
 [node name="Icon" type="TextureRect" parent="."]

--- a/components/desktop/folder_shortcut.tscn
+++ b/components/desktop/folder_shortcut.tscn
@@ -7,6 +7,7 @@ layout_mode = 3
 anchors_preset = 0
 offset_right = 64.0
 offset_bottom = 64.0
+custom_minimum_size = Vector2(64, 87)
 script = ExtResource("1")
 
 [node name="Icon" type="TextureRect" parent="."]

--- a/components/desktop/folder_window.gd
+++ b/components/desktop/folder_window.gd
@@ -4,6 +4,14 @@ class_name FolderWindow
 @export var folder_id: int = 0
 
 @onready var grid: GridContainer = %Grid
+@onready var scroll: ScrollContainer = %Scroll
+
+func _ready() -> void:
+        call_deferred("_update_grid_columns")
+
+func _notification(what: int) -> void:
+        if what == NOTIFICATION_RESIZED:
+                _update_grid_columns()
 
 
 func setup_custom(id: int) -> void:
@@ -24,26 +32,35 @@ func _populate() -> void:
 
 	var items: Array = DesktopLayoutManager.get_children_of(folder_id)
 
-	for entry in items:
-		if entry.get("type", "") == "app":
-			var ps: PackedScene = load("res://components/desktop/app_shortcut.tscn")
-			var node: AppShortcut = ps.instantiate()
-			node.item_id = entry.get("id", 0)
-			node.title = entry.get("title", "")
-			node.app_name = entry.get("app_name", "")
-			_set_icon(node, entry)
-			grid.add_child(node)
-		else:
-			var ps: PackedScene = load("res://components/desktop/folder_shortcut.tscn")
-			var node: FolderShortcut = ps.instantiate()
-			node.item_id = entry.get("id", 0)
-			node.title = entry.get("title", "")
-			_set_icon(node, entry)
-			grid.add_child(node)
+        for entry in items:
+                if entry.get("type", "") == "app":
+                        var ps: PackedScene = load("res://components/desktop/app_shortcut.tscn")
+                        var node: AppShortcut = ps.instantiate()
+                        node.item_id = entry.get("id", 0)
+                        node.title = entry.get("title", "")
+                        node.app_name = entry.get("app_name", "")
+                        _set_icon(node, entry)
+                        grid.add_child(node)
+                else:
+                        var ps: PackedScene = load("res://components/desktop/folder_shortcut.tscn")
+                        var node: FolderShortcut = ps.instantiate()
+                        node.item_id = entry.get("id", 0)
+                        node.title = entry.get("title", "")
+                        _set_icon(node, entry)
+                        grid.add_child(node)
+        _update_grid_columns()
 
 func _set_icon(node: Control, entry: Dictionary) -> void:
 	var icon_path: String = entry.get("icon_path", "")
-	if icon_path != "":
-		var tex: Texture2D = load(icon_path)
-		if tex != null:
-			node.icon = tex
+        if icon_path != "":
+                var tex: Texture2D = load(icon_path)
+                if tex != null:
+                        node.icon = tex
+
+func _update_grid_columns() -> void:
+        if not is_node_ready():
+                return
+        var available_width: float = scroll.size.x
+        var cols: int = max(1, int(available_width / 64.0))
+        grid.columns = cols
+        grid.custom_minimum_size = Vector2(available_width, 0)

--- a/components/desktop/folder_window.tscn
+++ b/components/desktop/folder_window.tscn
@@ -16,6 +16,7 @@ script = ExtResource("1")
 window_icon = ExtResource("2_4k5vl")
 
 [node name="Scroll" type="ScrollContainer" parent="."]
+unique_name_in_owner = true
 layout_mode = 1
 anchors_preset = 15
 anchor_right = 1.0


### PR DESCRIPTION
## Summary
- enforce a minimum 64x64 size for app and folder shortcut icons
- update folder window grid to resize columns based on available width

## Testing
- `godot --headless --path . --script tests/test_runner.gd` *(command not found: godot)*

------
https://chatgpt.com/codex/tasks/task_e_68a682fa238c832593c32d18a0ea4f1d