### PR TITLE
feat(settings): add apps folder creation button

### DIFF
--- a/components/apps/app_scenes/settings.tscn
+++ b/components/apps/app_scenes/settings.tscn
@@ -149,6 +149,11 @@ size_flags_horizontal = 4
 focus_mode = 0
 text = "Siggy?"
 
+[node name="CreateAppsFolderButton" type="Button" parent="Panel/MarginContainer/TabContainer/General/HBoxContainer/VBoxContainer2"]
+unique_name_in_owner = true
+layout_mode = 2
+text = "Create Apps Folder"
+
 [node name="Backgrounds" type="VBoxContainer" parent="Panel/MarginContainer/TabContainer"]
 layout_mode = 2
 metadata/_tab_index = 1
@@ -630,6 +635,7 @@ layout_mode = 2
 text = "Reset"
 
 [connection signal="toggled" from="Panel/MarginContainer/TabContainer/General/HBoxContainer/VBoxContainer2/SiggyButton" to="." method="_on_siggy_button_toggled"]
+[connection signal="pressed" from="Panel/MarginContainer/TabContainer/General/HBoxContainer/VBoxContainer2/CreateAppsFolderButton" to="." method="_on_create_apps_folder_button_pressed"]
 [connection signal="toggled" from="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/BlueWarpContainer/MarginContainer/VBoxContainer/BlueWarpButton" to="." method="_on_blue_warp_button_toggled"]
 [connection signal="value_changed" from="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/BlueWarpContainer/MarginContainer/VBoxContainer/HBoxContainer/BlueWarpStretchSlider" to="." method="_on_blue_warp_stretch_slider_value_changed"]
 [connection signal="value_changed" from="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/BlueWarpContainer/MarginContainer/VBoxContainer/HBoxContainer2/BlueWarpThing1Slider" to="." method="_on_blue_warp_thing1_slider_value_changed"]

--- a/components/settings_window.gd
+++ b/components/settings_window.gd
@@ -36,6 +36,7 @@ extends Pane
 @onready var electric_scale_x_slider: HSlider = %ElectricScaleXSlider
 @onready var electric_scale_y_slider: HSlider = %ElectricScaleYSlider
 @onready var tab_container: TabContainer = %TabContainer
+@onready var create_apps_folder_button: Button = %CreateAppsFolderButton
 @onready var waves_shader_material: ShaderMaterial = get_tree().root.get_node("Main/DesktopEnv/ShaderBackgroundsContainer/WavesShader").material
 @onready var blue_warp_shader_material: ShaderMaterial = get_tree().root.get_node("Main/DesktopEnv/ShaderBackgroundsContainer/BlueWarpShader").material
 @onready var comic_dots1_shader_material: ShaderMaterial = get_tree().root.get_node("Main/DesktopEnv/ShaderBackgroundsContainer/ComicDotsBlueVert").material
@@ -126,8 +127,13 @@ func _on_siggy_button_toggled(toggled_on: bool) -> void:
 		%SiggyButton.text = "Siggy. Please come back. I miss you"
 
 func _on_autosave_check_box_toggled(toggled_on: bool) -> void:
-		TimeManager.autosave_enabled = toggled_on
-		_update_autosave_timer_label()
+        TimeManager.autosave_enabled = toggled_on
+        _update_autosave_timer_label()
+
+func _on_create_apps_folder_button_pressed() -> void:
+        var desktop_env = get_tree().root.get_node("Main/DesktopEnv")
+        if desktop_env:
+                desktop_env._create_or_update_apps_folder()
 
 func _on_blue_warp_button_toggled(toggled_on: bool) -> void:
 	Events.set_desktop_background_visible("BlueWarp", toggled_on)


### PR DESCRIPTION
## Summary
- add "Create Apps Folder" button in Settings general tab
- allow regenerating the desktop apps folder on demand

## Testing
- `/tmp/godot/Godot_v4.2.2-stable_linux.x86_64 --headless --path . tests/test_runner.tscn`


------
https://chatgpt.com/codex/tasks/task_e_68a6a48842088325a0a9f56aebc76705