### PR TITLE
Allow dragging shortcuts between folders and desktop

### DIFF
--- a/autoloads/desktop_layout_manager.gd
+++ b/autoloads/desktop_layout_manager.gd
@@ -6,6 +6,7 @@ signal item_created(item_id: int, data: Dictionary)
 signal item_moved(item_id: int, position: Vector2)
 signal item_deleted(item_id: int)
 signal item_renamed(item_id: int, new_title: String)
+signal item_parent_changed(item_id: int, old_parent: int, new_parent: int)
 
 var items: Dictionary = {}
 var next_id: int = 1
@@ -51,11 +52,21 @@ func create_folder(title: String, icon_path: String, position: Vector2, parent_i
 	item_created.emit(id, entry)
 	return id
 
-func move_item(id: int, position: Vector2) -> void:
-	if not items.has(id):
-		return
-	items[id]["desktop_position"] = position
-	item_moved.emit(id, position)
+func move_item(id: int, position: Vector2, new_parent_id: int = -1) -> void:
+       if not items.has(id):
+               return
+       var old_parent: int = int(items[id].get("parent_id", 0))
+       items[id]["desktop_position"] = position
+
+       if new_parent_id != -1 and new_parent_id != old_parent:
+               if old_parent != 0 and items.has(old_parent):
+                       items[old_parent]["child_ids"].erase(id)
+               items[id]["parent_id"] = new_parent_id
+               if new_parent_id != 0 and items.has(new_parent_id):
+                       items[new_parent_id]["child_ids"].append(id)
+               item_parent_changed.emit(id, old_parent, new_parent_id)
+
+       item_moved.emit(id, position)
 
 func rename_item(id: int, new_title: String) -> void:
 	if not items.has(id):

--- a/components/desktop/app_shortcut.gd
+++ b/components/desktop/app_shortcut.gd
@@ -11,6 +11,7 @@ class_name AppShortcut
 
 var is_dragging: bool = false
 var drag_offset: Vector2
+var original_parent: Node
 
 func _ready() -> void:
 	icon_rect.texture = icon
@@ -23,13 +24,32 @@ func _on_gui_input(event: InputEvent) -> void:
 		if mb.button_index == MOUSE_BUTTON_LEFT:
 			if mb.double_click and mb.pressed:
 				WindowManager.launch_app_by_name(app_name)
-			elif mb.pressed:
-				is_dragging = true
-				drag_offset = mb.position
-			else:
-				if is_dragging:
-					is_dragging = false
-					DesktopLayoutManager.move_item(item_id, global_position)
-	elif event is InputEventMouseMotion:
-		if is_dragging:
-			global_position = get_global_mouse_position() - drag_offset
+                       elif mb.pressed:
+                               is_dragging = true
+                               drag_offset = mb.position
+                               original_parent = get_parent()
+                               var global_pos: Vector2 = global_position
+                               get_tree().root.add_child(self)
+                               global_position = global_pos
+                       else:
+                               if is_dragging:
+                                       is_dragging = false
+                                       var new_parent_id: int = _get_drop_parent_id()
+                                       var old_parent_id: int = int(DesktopLayoutManager.get_item(item_id).get("parent_id", 0))
+                                       DesktopLayoutManager.move_item(item_id, global_position, new_parent_id)
+                                       if new_parent_id == old_parent_id:
+                                               original_parent.add_child(self)
+                                               global_position = get_global_mouse_position() - drag_offset
+                                       else:
+                                               queue_free()
+       elif event is InputEventMouseMotion:
+               if is_dragging:
+                       global_position = get_global_mouse_position() - drag_offset
+
+func _get_drop_parent_id() -> int:
+       var node: Node = get_viewport().gui_pick(get_global_mouse_position())
+       while node and not (node is FolderWindow):
+               node = node.get_parent()
+       if node and node is FolderWindow:
+               return (node as FolderWindow).folder_id
+       return 0

--- a/components/desktop/folder_shortcut.gd
+++ b/components/desktop/folder_shortcut.gd
@@ -10,6 +10,7 @@ class_name FolderShortcut
 
 var is_dragging: bool = false
 var drag_offset: Vector2
+var original_parent: Node
 
 func _ready() -> void:
 	icon_rect.texture = icon
@@ -27,13 +28,24 @@ func _on_gui_input(event: InputEvent) -> void:
 		if mb.button_index == MOUSE_BUTTON_LEFT:
 			if mb.double_click and mb.pressed:
 				_open_folder()
-			elif mb.pressed:
-				is_dragging = true
-				drag_offset = mb.position
-			else:
-				if is_dragging:
-					is_dragging = false
-					DesktopLayoutManager.move_item(item_id, global_position)
+                       elif mb.pressed:
+                               is_dragging = true
+                               drag_offset = mb.position
+                               original_parent = get_parent()
+                               var global_pos: Vector2 = global_position
+                               get_tree().root.add_child(self)
+                               global_position = global_pos
+                       else:
+                               if is_dragging:
+                                       is_dragging = false
+                                       var new_parent_id: int = _get_drop_parent_id()
+                                       var old_parent_id: int = int(DesktopLayoutManager.get_item(item_id).get("parent_id", 0))
+                                       DesktopLayoutManager.move_item(item_id, global_position, new_parent_id)
+                                       if new_parent_id == old_parent_id:
+                                               original_parent.add_child(self)
+                                               global_position = get_global_mouse_position() - drag_offset
+                                       else:
+                                               queue_free()
 		elif mb.button_index == MOUSE_BUTTON_RIGHT and mb.pressed:
 			var actions: Array = []
 			var action_open: ContextAction = ContextAction.new()
@@ -52,9 +64,17 @@ func _on_gui_input(event: InputEvent) -> void:
 			action_delete.method = "_ctx_delete"
 			actions.append(action_delete)
 			ContextMenuManager.open_for(self, mb.global_position, actions)
-	elif event is InputEventMouseMotion:
-		if is_dragging:
-			global_position = get_global_mouse_position() - drag_offset
+       elif event is InputEventMouseMotion:
+               if is_dragging:
+                       global_position = get_global_mouse_position() - drag_offset
+
+func _get_drop_parent_id() -> int:
+       var node: Node = get_viewport().gui_pick(get_global_mouse_position())
+       while node and not (node is FolderWindow):
+               node = node.get_parent()
+       if node and node is FolderWindow:
+               return (node as FolderWindow).folder_id
+       return 0
 
 func _open_folder() -> void:
 	var scene: PackedScene = preload("res://components/desktop/folder_window.tscn")

--- a/components/desktop/folder_window.gd
+++ b/components/desktop/folder_window.gd
@@ -7,7 +7,10 @@ class_name FolderWindow
 @onready var scroll: ScrollContainer = %Scroll
 
 func _ready() -> void:
-		call_deferred("_update_grid_columns")
+               call_deferred("_update_grid_columns")
+               DesktopLayoutManager.item_created.connect(_on_item_created)
+               DesktopLayoutManager.item_deleted.connect(_on_item_deleted)
+               DesktopLayoutManager.item_parent_changed.connect(_on_item_parent_changed)
 
 func _notification(what: int) -> void:
 		if what == NOTIFICATION_RESIZED:
@@ -48,7 +51,18 @@ func _populate() -> void:
 					node.title = entry.get("title", "")
 					_set_icon(node, entry)
 					grid.add_child(node)
-	_update_grid_columns()
+        _update_grid_columns()
+
+func _on_item_created(item_id: int, data: Dictionary) -> void:
+       if int(data.get("parent_id", 0)) == folder_id:
+               _populate()
+
+func _on_item_deleted(item_id: int) -> void:
+       _populate()
+
+func _on_item_parent_changed(item_id: int, old_parent: int, new_parent: int) -> void:
+       if old_parent == folder_id or new_parent == folder_id:
+               _populate()
 
 func _set_icon(node: Control, entry: Dictionary) -> void:
 	var icon_path: String = entry.get("icon_path", "")

--- a/scripts/desktop_env.gd
+++ b/scripts/desktop_env.gd
@@ -28,9 +28,10 @@ func _ready() -> void:
 	#hide_all_windows_and_panels()
 	WindowManager.taskbar_container = taskbar
 	WindowManager.start_panel = start_panel
-	DesktopLayoutManager.items_loaded.connect(_on_items_loaded)
-	DesktopLayoutManager.item_created.connect(_on_item_created)
-	DesktopLayoutManager.item_deleted.connect(_on_item_deleted)
+       DesktopLayoutManager.items_loaded.connect(_on_items_loaded)
+       DesktopLayoutManager.item_created.connect(_on_item_created)
+       DesktopLayoutManager.item_deleted.connect(_on_item_deleted)
+       DesktopLayoutManager.item_parent_changed.connect(_on_item_parent_changed)
 	
 	call_deferred("_deferred_load_save")
 	launch_startup_apps()
@@ -158,10 +159,21 @@ func _on_item_created(item_id: int, data: Dictionary) -> void:
 
 
 func _on_item_deleted(item_id: int) -> void:
-	for child in icons_layer.get_children():
-		if (child is AppShortcut or child is FolderShortcut) and child.item_id == item_id:
-			child.queue_free()
-			break
+        for child in icons_layer.get_children():
+                if (child is AppShortcut or child is FolderShortcut) and child.item_id == item_id:
+                        child.queue_free()
+                        break
+
+func _on_item_parent_changed(item_id: int, old_parent: int, new_parent: int) -> void:
+       if old_parent == 0:
+               for child in icons_layer.get_children():
+                       if (child is AppShortcut or child is FolderShortcut) and child.item_id == item_id:
+                               child.queue_free()
+                               break
+       if new_parent == 0:
+               var data: Dictionary = DesktopLayoutManager.get_item(item_id)
+               if data:
+                       _spawn_item(data)
 
 
 func _spawn_item(data: Dictionary) -> void:


### PR DESCRIPTION
## Summary
- Enable desktop layout manager to handle parent changes when moving items
- Allow app and folder shortcuts to be dragged between folders and desktop
- Refresh folder and desktop views when shortcuts change parents

## Testing
- `/tmp/godot/Godot_v4.2.1-stable_linux.x86_64 --headless --path . tests/test_runner.tscn` *(fails: Failed to instantiate an autoload, script 'res://autoloads/window_manager.gd' does not inherit from 'Node')*


------
https://chatgpt.com/codex/tasks/task_e_68a6a67b8e2883258ebedb40479fbf2f