### PR TITLE
Add instant winnings upgrade for Early Bird

### DIFF
--- a/components/apps/early_bird/early_bird.gd
+++ b/components/apps/early_bird/early_bird.gd
@@ -152,6 +152,8 @@ func _on_player_died() -> void:
 
 func _on_player_scored() -> void:
 	winnings += cash_per_score
+	if UpgradeManager.get_level("earlybird_instant_winnings") > 0:
+		PortfolioManager.add_cash(cash_per_score)
 	hud.update_score(player.score)
 	hud.update_winnings(winnings)
 

--- a/data/upgrades/instant_winnings.json
+++ b/data/upgrades/instant_winnings.json
@@ -1,0 +1,15 @@
+{
+  "id": "earlybird_instant_winnings",
+  "name": "Instant Gratification",
+  "description": "Earn cash immediately with each point scored, on top of the normal payout at game over.",
+  "effects": [],
+  "systems": [
+    "earlybird"
+  ],
+  "dependencies": [],
+  "cost_per_level": {
+    "cash": 25
+  },
+  "max_level": 1,
+  "repeatable": false
+}


### PR DESCRIPTION
## Summary
- Add Instant Gratification upgrade for Early Bird to pay out cash on each scored point
- Award cash immediately on score when the upgrade is owned

## Testing
- `godot4 --headless --path . tests/test_runner.tscn`

------
https://chatgpt.com/codex/tasks/task_e_68a6c652dca48325a0b1fc5867292d76