### PR TITLE
Introduce generic debt card UI and centralized debt management

### DIFF
--- a/autoloads/portfolio_manager.gd
+++ b/autoloads/portfolio_manager.gd
@@ -283,9 +283,10 @@ func _on_cash_changed(new_value: float) -> void:
 		emit_signal("resource_changed", "cash", new_value)
 
 func _on_credit_changed(_value: float) -> void:
-		emit_signal("credit_updated", get_credit_used(), get_credit_limit())
-		emit_signal("resource_changed", "debt", get_total_debt())
-		_recalculate_credit_score()
+                emit_signal("credit_updated", get_credit_used(), get_credit_limit())
+                emit_signal("resource_changed", "credit", get_credit_used())
+                emit_signal("resource_changed", "debt", get_total_debt())
+                _recalculate_credit_score()
 
 func _on_student_loans_changed(_value: float) -> void:
 		_update_student_loan_min_payment()

--- a/autoloads/save_manager.gd
+++ b/autoloads/save_manager.gd
@@ -72,11 +72,13 @@ func initialize_new_profile(slot_id: int, user_data: Dictionary) -> void:
 	if background != "":
 		PlayerManager.apply_background_effects(background)
 
-	var starting_debt = user_data.get("starting_student_debt", 0.0)
-	PortfolioManager.set_student_loans(starting_debt)
+        var starting_debt = user_data.get("starting_student_debt", 0.0)
+        PortfolioManager.set_student_loans(starting_debt)
 
-	var starting_credit_limit = user_data.get("starting_credit_limit", 0.0)
-	PortfolioManager.set_credit_limit(starting_credit_limit)
+        var starting_credit_limit = user_data.get("starting_credit_limit", 0.0)
+        PortfolioManager.set_credit_limit(starting_credit_limit)
+
+        BillManager._rebuild_debt_resources()
 
 	save_to_slot(slot_id)
 

--- a/components/apps/app_scenes/ower_view.tscn
+++ b/components/apps/app_scenes/ower_view.tscn
@@ -1,48 +1,6 @@
-[gd_scene load_steps=12 format=3 uid="uid://by7ye7kt412u3"]
+[gd_scene load_steps=2 format=3]
 
-[ext_resource type="Script" uid="uid://ce5ge1lmsdy7g" path="res://components/apps/ower_view/ower_view.gd" id="1_t43hg"]
-[ext_resource type="Texture2D" uid="uid://chka0bjnrrdmr" path="res://assets/ui/buttons/dark_purple_normal.png" id="3_aemln"]
-[ext_resource type="Texture2D" uid="uid://bsal74mys2v4b" path="res://assets/logos/owerview_logo.png" id="3_svf65"]
-[ext_resource type="Shader" uid="uid://dwdg8fcaxgjbp" path="res://assets/shaders/maroon_warp_shader.gdshader" id="4_6w1kr"]
-[ext_resource type="Texture2D" uid="uid://dpko7w8bh0pq1" path="res://assets/ui/buttons/english_violet_normal.png" id="4_svf65"]
-[ext_resource type="Texture2D" uid="uid://bu12v0yfad1ai" path="res://assets/ui/buttons/lilac_normal.png" id="5_6w1kr"]
-
-[sub_resource type="StyleBoxTexture" id="StyleBoxTexture_aemln"]
-texture = ExtResource("3_aemln")
-texture_margin_left = 2.0
-texture_margin_top = 2.0
-texture_margin_right = 2.0
-texture_margin_bottom = 2.0
-
-[sub_resource type="ShaderMaterial" id="ShaderMaterial_11odt"]
-shader = ExtResource("4_6w1kr")
-shader_parameter/stretch = 0.8
-shader_parameter/thing1 = 0.6
-shader_parameter/thing2 = 0.6
-shader_parameter/thing3 = 0.8
-shader_parameter/scale = 1.0
-shader_parameter/speed = 0.03
-
-[sub_resource type="StyleBoxTexture" id="StyleBoxTexture_njqv2"]
-texture = ExtResource("4_svf65")
-texture_margin_left = 2.0
-texture_margin_top = 2.0
-texture_margin_right = 2.0
-texture_margin_bottom = 2.0
-
-[sub_resource type="StyleBoxTexture" id="StyleBoxTexture_svf65"]
-texture = ExtResource("4_svf65")
-texture_margin_left = 2.0
-texture_margin_top = 2.0
-texture_margin_right = 2.0
-texture_margin_bottom = 2.0
-
-[sub_resource type="StyleBoxTexture" id="StyleBoxTexture_638yv"]
-texture = ExtResource("5_6w1kr")
-texture_margin_left = 2.0
-texture_margin_top = 2.0
-texture_margin_right = 2.0
-texture_margin_bottom = 2.0
+[ext_resource type="Script" path="res://components/apps/ower_view/ower_view.gd" id="1"]
 
 [node name="OwerView" type="PanelContainer"]
 anchors_preset = 15
@@ -50,19 +8,8 @@ anchor_right = 1.0
 anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
-size_flags_horizontal = 3
-size_flags_vertical = 3
-mouse_filter = 1
-theme_override_styles/panel = SubResource("StyleBoxTexture_aemln")
-script = ExtResource("1_t43hg")
+script = ExtResource("1")
 window_title = "OwerView"
-window_icon = ExtResource("3_svf65")
-default_window_size = Vector2(600, 500)
-default_position = "left"
-
-[node name="ColorRect" type="ColorRect" parent="."]
-material = SubResource("ShaderMaterial_11odt")
-layout_mode = 2
 
 [node name="MarginContainer" type="MarginContainer" parent="."]
 layout_mode = 2
@@ -71,199 +18,14 @@ theme_override_constants/margin_top = 15
 theme_override_constants/margin_right = 15
 theme_override_constants/margin_bottom = 15
 
-[node name="HBoxContainer" type="HBoxContainer" parent="MarginContainer"]
+[node name="VBoxContainer" type="VBoxContainer" parent="MarginContainer"]
 layout_mode = 2
 
-[node name="VBoxContainer" type="VBoxContainer" parent="MarginContainer/HBoxContainer"]
-layout_mode = 2
-
-[node name="ShortTerm" type="MarginContainer" parent="MarginContainer/HBoxContainer/VBoxContainer"]
-layout_mode = 2
-theme_override_constants/margin_left = 25
-theme_override_constants/margin_top = 25
-theme_override_constants/margin_right = 25
-theme_override_constants/margin_bottom = 25
-
-[node name="CreditCardSummary" type="PanelContainer" parent="MarginContainer/HBoxContainer/VBoxContainer/ShortTerm"]
-unique_name_in_owner = true
-custom_minimum_size = Vector2(300, 50)
-layout_mode = 2
-size_flags_horizontal = 0
-size_flags_vertical = 2
-mouse_filter = 1
-theme_override_styles/panel = SubResource("StyleBoxTexture_njqv2")
-
-[node name="MarginContainer" type="MarginContainer" parent="MarginContainer/HBoxContainer/VBoxContainer/ShortTerm/CreditCardSummary"]
-layout_mode = 2
-theme_override_constants/margin_left = 10
-theme_override_constants/margin_top = 10
-theme_override_constants/margin_right = 10
-theme_override_constants/margin_bottom = 10
-
-[node name="VBoxContainer" type="VBoxContainer" parent="MarginContainer/HBoxContainer/VBoxContainer/ShortTerm/CreditCardSummary/MarginContainer"]
-layout_mode = 2
-size_flags_vertical = 0
-
-[node name="Label" type="Label" parent="MarginContainer/HBoxContainer/VBoxContainer/ShortTerm/CreditCardSummary/MarginContainer/VBoxContainer"]
-layout_mode = 2
-text = "Credit Card"
-
-[node name="CreditLabel" type="Label" parent="MarginContainer/HBoxContainer/VBoxContainer/ShortTerm/CreditCardSummary/MarginContainer/VBoxContainer"]
-unique_name_in_owner = true
-layout_mode = 2
-size_flags_horizontal = 0
-text = "Credit Card"
-
-[node name="CreditInterestLabel" type="Label" parent="MarginContainer/HBoxContainer/VBoxContainer/ShortTerm/CreditCardSummary/MarginContainer/VBoxContainer"]
-unique_name_in_owner = true
-layout_mode = 2
-size_flags_horizontal = 0
-text = "Interest %
-"
-
-[node name="CreditProgressBar" type="ProgressBar" parent="MarginContainer/HBoxContainer/VBoxContainer/ShortTerm/CreditCardSummary/MarginContainer/VBoxContainer"]
+[node name="CardContainer" type="VBoxContainer" parent="MarginContainer/VBoxContainer"]
 unique_name_in_owner = true
 layout_mode = 2
 
-[node name="HBoxContainer" type="HBoxContainer" parent="MarginContainer/HBoxContainer/VBoxContainer/ShortTerm/CreditCardSummary/MarginContainer/VBoxContainer"]
-layout_mode = 2
-
-[node name="CreditSlider" type="HSlider" parent="MarginContainer/HBoxContainer/VBoxContainer/ShortTerm/CreditCardSummary/MarginContainer/VBoxContainer/HBoxContainer"]
+[node name="CreditScoreLabel" type="Label" parent="MarginContainer/VBoxContainer"]
 unique_name_in_owner = true
 layout_mode = 2
-size_flags_horizontal = 3
-
-[node name="CreditSliderLabel" type="Label" parent="MarginContainer/HBoxContainer/VBoxContainer/ShortTerm/CreditCardSummary/MarginContainer/VBoxContainer/HBoxContainer"]
-unique_name_in_owner = true
-layout_mode = 2
-size_flags_horizontal = 3
-size_flags_stretch_ratio = 0.46
-mouse_filter = 1
-text = "$0.00"
-
-[node name="PayCreditButton" type="Button" parent="MarginContainer/HBoxContainer/VBoxContainer/ShortTerm/CreditCardSummary/MarginContainer/VBoxContainer"]
-unique_name_in_owner = true
-layout_mode = 2
-size_flags_horizontal = 4
-size_flags_vertical = 0
-focus_mode = 0
-text = " Pay "
-
-[node name="LongTerm" type="MarginContainer" parent="MarginContainer/HBoxContainer/VBoxContainer"]
-layout_mode = 2
-theme_override_constants/margin_left = 25
-theme_override_constants/margin_top = 25
-theme_override_constants/margin_right = 25
-theme_override_constants/margin_bottom = 25
-
-[node name="StudentLoanSummary" type="PanelContainer" parent="MarginContainer/HBoxContainer/VBoxContainer/LongTerm"]
-unique_name_in_owner = true
-custom_minimum_size = Vector2(300, 50)
-layout_mode = 2
-size_flags_horizontal = 0
-size_flags_vertical = 0
-mouse_filter = 1
-theme_override_styles/panel = SubResource("StyleBoxTexture_svf65")
-
-[node name="MarginContainer" type="MarginContainer" parent="MarginContainer/HBoxContainer/VBoxContainer/LongTerm/StudentLoanSummary"]
-layout_mode = 2
-theme_override_constants/margin_left = 10
-theme_override_constants/margin_top = 10
-theme_override_constants/margin_right = 10
-theme_override_constants/margin_bottom = 10
-
-[node name="VBoxContainer2" type="VBoxContainer" parent="MarginContainer/HBoxContainer/VBoxContainer/LongTerm/StudentLoanSummary/MarginContainer"]
-layout_mode = 2
-
-[node name="Label" type="Label" parent="MarginContainer/HBoxContainer/VBoxContainer/LongTerm/StudentLoanSummary/MarginContainer/VBoxContainer2"]
-layout_mode = 2
-text = "Student Loans"
-
-[node name="StudentLoanLabel" type="Label" parent="MarginContainer/HBoxContainer/VBoxContainer/LongTerm/StudentLoanSummary/MarginContainer/VBoxContainer2"]
-unique_name_in_owner = true
-layout_mode = 2
-size_flags_horizontal = 0
-text = "Credit Card"
-
-[node name="HBoxContainer" type="HBoxContainer" parent="MarginContainer/HBoxContainer/VBoxContainer/LongTerm/StudentLoanSummary/MarginContainer/VBoxContainer2"]
-layout_mode = 2
-
-[node name="LoanSlider" type="HSlider" parent="MarginContainer/HBoxContainer/VBoxContainer/LongTerm/StudentLoanSummary/MarginContainer/VBoxContainer2/HBoxContainer"]
-unique_name_in_owner = true
-layout_mode = 2
-size_flags_horizontal = 3
-
-[node name="LoanSliderLabel" type="Label" parent="MarginContainer/HBoxContainer/VBoxContainer/LongTerm/StudentLoanSummary/MarginContainer/VBoxContainer2/HBoxContainer"]
-unique_name_in_owner = true
-layout_mode = 2
-size_flags_horizontal = 3
-size_flags_stretch_ratio = 0.46
-mouse_filter = 1
-text = "$0.00"
-
-[node name="PayStudentLoanButton" type="Button" parent="MarginContainer/HBoxContainer/VBoxContainer/LongTerm/StudentLoanSummary/MarginContainer/VBoxContainer2"]
-unique_name_in_owner = true
-layout_mode = 2
-size_flags_horizontal = 4
-focus_mode = 0
-text = " Pay "
-
-[node name="PanelContainer" type="PanelContainer" parent="MarginContainer/HBoxContainer"]
-layout_mode = 2
-mouse_filter = 1
-theme_override_styles/panel = SubResource("StyleBoxTexture_638yv")
-
-[node name="MarginContainer" type="MarginContainer" parent="MarginContainer/HBoxContainer/PanelContainer"]
-layout_mode = 2
-theme_override_constants/margin_left = 5
-theme_override_constants/margin_top = 10
-theme_override_constants/margin_right = 5
-theme_override_constants/margin_bottom = 25
-
-[node name="VBoxContainer" type="VBoxContainer" parent="MarginContainer/HBoxContainer/PanelContainer/MarginContainer"]
-layout_mode = 2
-
-[node name="CreditScore" type="Label" parent="MarginContainer/HBoxContainer/PanelContainer/MarginContainer/VBoxContainer"]
-layout_mode = 2
-size_flags_horizontal = 4
-theme_override_font_sizes/font_size = 12
-text = "Credit Score:"
-
-[node name="CreditScoreLabel" type="Label" parent="MarginContainer/HBoxContainer/PanelContainer/MarginContainer/VBoxContainer"]
-unique_name_in_owner = true
-layout_mode = 2
-size_flags_horizontal = 4
-theme_override_font_sizes/font_size = 17
-text = "Credit Score:"
-
-[node name="ProgressBar" type="ProgressBar" parent="MarginContainer/HBoxContainer/PanelContainer/MarginContainer/VBoxContainer"]
-custom_minimum_size = Vector2(15, 0)
-layout_mode = 2
-size_flags_horizontal = 4
-size_flags_vertical = 3
-min_value = 300.0
-max_value = 850.0
-value = 700.0
-fill_mode = 3
-show_percentage = false
-
-[node name="CenterContainer" type="CenterContainer" parent="MarginContainer/HBoxContainer"]
-layout_mode = 2
-size_flags_vertical = 0
-
-[node name="TextureRect" type="TextureRect" parent="MarginContainer/HBoxContainer/CenterContainer"]
-layout_mode = 2
-texture = ExtResource("3_svf65")
-stretch_mode = 3
-
-[node name="NOTELabel" type="Label" parent="MarginContainer/HBoxContainer/CenterContainer"]
-visible = false
-layout_mode = 2
-text = "+1 credit score per day
-and then mayvbe implement
-using cc -1 credit
-and you can upgrade 
-credit score recovery speed"
-
-[connection signal="pressed" from="MarginContainer/HBoxContainer/VBoxContainer/ShortTerm/CreditCardSummary/MarginContainer/VBoxContainer/PayCreditButton" to="." method="_on_pay_credit_button_pressed"]
-[connection signal="pressed" from="MarginContainer/HBoxContainer/VBoxContainer/LongTerm/StudentLoanSummary/MarginContainer/VBoxContainer2/PayStudentLoanButton" to="." method="_on_pay_student_loan_button_pressed"]
+text = "0"

--- a/components/apps/ower_view/ower_view.gd
+++ b/components/apps/ower_view/ower_view.gd
@@ -1,98 +1,30 @@
 extends Pane
 
-@onready var credit_label := %CreditLabel
-@onready var credit_interest_label: Label = %CreditInterestLabel
-@onready var credit_bar := %CreditProgressBar
-@onready var credit_pay_btn := %PayCreditButton
-@onready var credit_slider := %CreditSlider
-@onready var credit_slider_label := %CreditSliderLabel
-
-@onready var loan_label := %StudentLoanLabel
-@onready var loan_pay_btn := %PayStudentLoanButton
-@onready var loan_slider := %LoanSlider
-@onready var loan_slider_label := %LoanSliderLabel
-
-@onready var credit_score_label := %CreditScoreLabel
+@export var debt_card_scene: PackedScene = preload("res://components/ui/debt_card_ui.tscn")
+@onready var card_container: VBoxContainer = %CardContainer
+@onready var credit_score_label: Label = %CreditScoreLabel
 
 func _ready():
-	#app_title = "OwerView"
-	#emit_signal("title_updated", app_title)
+    BillManager.debt_resources_changed.connect(_refresh_cards)
+    PortfolioManager.resource_changed.connect(_on_resource_changed)
+    _refresh_cards()
+    _update_credit_score()
 
-	PortfolioManager.credit_updated.connect(update_credit)
-	PortfolioManager.resource_changed.connect(_on_resource_changed)
-	PortfolioManager.cash_updated.connect(_on_cash_updated)
+func _refresh_cards() -> void:
+    for c in card_container.get_children():
+        c.queue_free()
+    for debt in BillManager.get_debt_resources():
+        var card = debt_card_scene.instantiate() as DebtCardUI
+        card.setup(debt)
+        card_container.add_child(card)
 
-	credit_slider.value_changed.connect(_on_credit_slider_changed)
-	loan_slider.value_changed.connect(_on_loan_slider_changed)
+func _update_credit_score() -> void:
+    var score = PortfolioManager.get_credit_score()
+    credit_score_label.text = "%d" % score
 
-	update_credit(PortfolioManager.credit_used, PortfolioManager.credit_limit)
-	update_student_loans()
-	update_credit_score()
-	update_credit_interest_label()
-	update_sliders()
-
-func update_credit(used: float, limit: float):
-	credit_label.text = "Credit Used: " + NumberFormatter.format_commas(used) + "   Credit Limit: " + NumberFormatter.format_commas(limit)
-	credit_bar.value = (used / limit) * 100.0
-	update_credit_interest_label()
-	update_sliders()
-
-func update_student_loans():
-	var loans := PortfolioManager.get_student_loans()
-	loan_label.text = "Student Loans: " + NumberFormatter.format_commas(loans)
-	update_sliders()
-
-func update_credit_interest_label():
-	credit_interest_label.text = "Interest Rate: %.1f%% per 4 weeks" % (PortfolioManager.credit_interest_rate * 100.0)
-
-
-func update_credit_score():
-	var score = PortfolioManager.get_credit_score()
-	credit_score_label.text = "%d" % score
-
-func _on_resource_changed(resource_name: String, _value: float):
-	if resource_name == "student_loans":
-		update_student_loans()
-	elif resource_name == "debt":
-		update_credit_score()
-
-func _on_cash_updated(_cash: float):
-	update_sliders()
-
-func update_sliders():
-	var cash := PortfolioManager.cash
-
-	# Credit Slider
-	var credit_max = min(PortfolioManager.credit_used, cash)
-	credit_slider.max_value = credit_max
-	if credit_slider.value > credit_max:
-		credit_slider.value = credit_max
-	credit_slider_label.text = "$%.2f" % credit_slider.value
-
-	# Loan Slider
-	var loan_max = min(PortfolioManager.get_student_loans(), cash)
-	loan_slider.max_value = loan_max
-	if loan_slider.value > loan_max:
-		loan_slider.value = loan_max
-	loan_slider_label.text = "$%.2f" % loan_slider.value
-
-func _on_credit_slider_changed(value: float):
-	credit_slider_label.text = "$%.2f" % value
-
-func _on_loan_slider_changed(value: float):
-	loan_slider_label.text = "$%.2f" % value
-
-
-func _on_pay_credit_button_pressed() -> void:
-	var amount = credit_slider.value
-	PortfolioManager.pay_down_credit(amount)
-	update_sliders()
-
-
-func _on_pay_student_loan_button_pressed() -> void:
-	var amount = loan_slider.value
-	if PortfolioManager.pay_with_cash(amount):
-		var new_amt = max(PortfolioManager.get_student_loans() - amount, 0.0)
-		PortfolioManager.set_student_loans(new_amt)
-
-	update_sliders()
+func _on_resource_changed(resource_name: String, _value: float) -> void:
+    if resource_name in ["student_loans", "credit", "cash"]:
+        for card in card_container.get_children():
+            card.update_display()
+    if resource_name == "debt":
+        _update_credit_score()

--- a/components/ui/debt_card_ui.gd
+++ b/components/ui/debt_card_ui.gd
@@ -1,0 +1,48 @@
+extends PanelContainer
+class_name DebtCardUI
+
+var debt: DebtResource
+
+@onready var title_label: Label = %TitleLabel
+@onready var amount_label: Label = %AmountLabel
+@onready var slider: HSlider = %PaySlider
+@onready var slider_label: Label = %SliderLabel
+@onready var pay_button: Button = %PayButton
+
+func _ready():
+    slider.value_changed.connect(_on_slider_changed)
+    pay_button.pressed.connect(_on_pay_pressed)
+
+func setup(res: DebtResource) -> void:
+    debt = res
+    title_label.text = res.name
+    update_display()
+
+func update_display() -> void:
+    if debt == null:
+        return
+    var balance = debt.get_balance.call()
+    if debt.get_limit.is_valid():
+        var limit = debt.get_limit.call()
+        amount_label.text = "$%s / $%s" % [NumberFormatter.format_commas(balance), NumberFormatter.format_commas(limit)]
+    else:
+        amount_label.text = "Owed: $" + NumberFormatter.format_commas(balance)
+    var cash = PortfolioManager.cash
+    var max_val = min(balance, cash)
+    slider.max_value = max_val
+    if slider.value > max_val:
+        slider.value = max_val
+    slider_label.text = "$%.2f" % slider.value
+
+func _on_slider_changed(value: float) -> void:
+    slider_label.text = "$%.2f" % value
+
+func _on_pay_pressed() -> void:
+    if debt == null:
+        return
+    var amount = slider.value
+    if amount <= 0:
+        return
+    var success = debt.pay.call(amount)
+    if success:
+        update_display()

--- a/components/ui/debt_card_ui.tscn
+++ b/components/ui/debt_card_ui.tscn
@@ -1,0 +1,44 @@
+[gd_scene load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://components/ui/debt_card_ui.gd" id="1"]
+
+[node name="DebtCardUI" type="PanelContainer"]
+script = ExtResource("1")
+
+[node name="MarginContainer" type="MarginContainer" parent="."]
+layout_mode = 2
+theme_override_constants/margin_left = 10
+theme_override_constants/margin_top = 10
+theme_override_constants/margin_right = 10
+theme_override_constants/margin_bottom = 10
+
+[node name="VBox" type="VBoxContainer" parent="MarginContainer"]
+layout_mode = 2
+
+[node name="TitleLabel" type="Label" parent="MarginContainer/VBox"]
+unique_name_in_owner = true
+layout_mode = 2
+text = "Debt"
+
+[node name="AmountLabel" type="Label" parent="MarginContainer/VBox"]
+unique_name_in_owner = true
+layout_mode = 2
+text = "$0.00"
+
+[node name="HBox" type="HBoxContainer" parent="MarginContainer/VBox"]
+layout_mode = 2
+
+[node name="PaySlider" type="HSlider" parent="MarginContainer/VBox/HBox"]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 3
+
+[node name="SliderLabel" type="Label" parent="MarginContainer/VBox/HBox"]
+unique_name_in_owner = true
+layout_mode = 2
+text = "$0.00"
+
+[node name="PayButton" type="Button" parent="MarginContainer/VBox"]
+unique_name_in_owner = true
+layout_mode = 2
+text = "Pay"

--- a/resources/debt/debt_resource.gd
+++ b/resources/debt/debt_resource.gd
@@ -1,0 +1,7 @@
+extends Resource
+class_name DebtResource
+
+var name: String = ""
+var get_balance: Callable
+var pay: Callable
+var get_limit: Callable = Callable()


### PR DESCRIPTION
## Summary
- Expose optional debt limits for resources and show credit usage against limit
- Rebuild debt resources after profile setup and reset to include starting loans
- Update credit change signals so debt cards refresh properly

## Testing
- `godot --headless -s tests/test_runner.gd` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a6b25237608325adef150ef4dfbd2b