### PR TITLE
Persist suitor gift and date costs

### DIFF
--- a/autoloads/db_manager.gd
+++ b/autoloads/db_manager.gd
@@ -22,6 +22,8 @@ const SCHEMA: Dictionary = {
 		"rizz": {"data_type": "int"},
 				"attractiveness": {"data_type": "int"},
 				"dates_paid": {"data_type": "int"},
+				"gift_cost": {"data_type": "real"},
+				"date_cost": {"data_type": "real"},
 				"income": {"data_type": "int"},
 		"wealth": {"data_type": "int"},
 		"preferred_pet_names": {"data_type": "text"},

--- a/components/npc/npc.gd
+++ b/components/npc/npc.gd
@@ -25,6 +25,8 @@ enum RelationshipStage { STRANGER, TALKING, DATING, SERIOUS, ENGAGED, MARRIED, D
 @export_range(0, 100, 0.1) var rizz: int
 @export_range(0, 100, 1) var attractiveness: int
 @export var dates_paid: int = 0
+@export var gift_cost: float = 25.0
+@export var date_cost: float = 200.0
 
 # === Economics ===
 var income: int
@@ -132,9 +134,11 @@ func to_dict() -> Dictionary:
 "rizz": rizz,
 "attractiveness": attractiveness,
 "dates_paid": dates_paid,
+"gift_cost": gift_cost,
+"date_cost": date_cost,
 "income": income,
-		"wealth": wealth,
-		"preferred_pet_names": preferred_pet_names.duplicate(),
+"wealth": wealth,
+"preferred_pet_names": preferred_pet_names.duplicate(),
 		"player_pet_names": player_pet_names.duplicate(),
 		"alpha": alpha,
 		"beta": beta,
@@ -181,11 +185,13 @@ static func from_dict(data: Dictionary) -> NPC:
 	npc.relationship_progress = _safe_float(data.get("relationship_progress"))
 	npc.affinity = _safe_float(data.get("affinity"), 0.0)
 	npc.affinity_equilibrium = _safe_float(data.get("affinity_equilibrium"), 50.0)
-	npc.rizz  = _safe_int(data.get("rizz"), 0)
-	npc.attractiveness = _safe_int(data.get("attractiveness"), 0)
-	npc.dates_paid = _safe_int(data.get("dates_paid"), 0)
-	npc.income= _safe_int(data.get("income"), 0)
-	npc.wealth= _safe_int(data.get("wealth"), 0)
+npc.rizz  = _safe_int(data.get("rizz"), 0)
+npc.attractiveness = _safe_int(data.get("attractiveness"), 0)
+npc.dates_paid = _safe_int(data.get("dates_paid"), 0)
+npc.gift_cost = _safe_float(data.get("gift_cost"), 25.0)
+npc.date_cost = _safe_float(data.get("date_cost"), 200.0)
+npc.income= _safe_int(data.get("income"), 0)
+npc.wealth= _safe_int(data.get("wealth"), 0)
 
 	_assign_string_array(npc.preferred_pet_names, data.get("preferred_pet_names"))
 	_assign_string_array(npc.player_pet_names, data.get("player_pet_names"))

--- a/components/popups/suitor_view.gd
+++ b/components/popups/suitor_view.gd
@@ -35,11 +35,11 @@ func setup_custom(data: Dictionary) -> void:
 		portrait_view.subject_npc_idx = idx
 	if portrait_view.has_method("apply_config") and npc.portrait_config:
 		portrait_view.apply_config(npc.portrait_config)
-	gift_cost = 25.0
-	date_cost = 200.0
-	breakup_reward = 0.0
-	apologize_cost = 10
-	_update_all()
+gift_cost = npc.gift_cost
+date_cost = npc.date_cost
+breakup_reward = 0.0
+apologize_cost = 10
+_update_all()
 
 
 func _ready() -> void:
@@ -126,6 +126,7 @@ func _on_gift_pressed() -> void:
 	if PortfolioManager.attempt_spend(gift_cost):
 		npc.affinity = min(npc.affinity + 5.0, 100.0)
 		gift_cost *= 2.0
+		npc.gift_cost = gift_cost
 		_update_affinity_bar()
 		_update_action_buttons_text()
 
@@ -146,6 +147,7 @@ func _on_date_pressed() -> void:
 	_update_relationship_bar()
 	_update_breakup_button_text()
 	date_cost *= 2.0
+	npc.date_cost = date_cost
 	_update_action_buttons_text()
 func _on_breakup_pressed() -> void:
 	var bounds: Vector2 = SuitorLogic.get_stage_bounds(npc.relationship_stage, npc.relationship_progress)

--- a/tests/suitor_cost_persistence_test.gd
+++ b/tests/suitor_cost_persistence_test.gd
@@ -1,0 +1,20 @@
+extends SceneTree
+
+func _ready() -> void:
+	var pm: Node = Engine.get_singleton("PortfolioManager")
+	pm.add_cash(1000.0)
+	var npc: NPC = NPC.new()
+	npc.full_name = "Test NPC"
+	npc.first_name = "Test"
+	var scene: PackedScene = load("res://components/popups/suitor_popup.tscn")
+	var sv: SuitorView = scene.instantiate()
+	add_child(sv)
+	await get_tree().process_frame
+	sv.setup_custom({"npc": npc})
+	sv._on_gift_pressed()
+	sv._on_date_pressed()
+	sv.setup_custom({"npc": npc})
+	assert(sv.gift_cost == 50.0)
+	assert(sv.date_cost == 400.0)
+	print("suitor_cost_persistence_test passed")
+	quit()


### PR DESCRIPTION
## Summary
- store gift and date prices on each NPC and include them in save data
- load and update these costs in the suitor view so they no longer reset
- add regression test confirming gift/date price persistence

## Testing
- `godot --headless -s tests/test_runner.gd` *(fails: command not found)*
- `apt-get install -y godot4` *(fails: Unable to locate package)*
- `wget https://downloads.tuxfamily.org/godotengine/4.2.1/Godot_v4.2.1-stable_linux.x86_64.zip` *(fails: 503 Service Unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68a6d66da7008325ad314e63a8b3a10e