### PR TITLE
Refactor debt handling with card UI

### DIFF
--- a/autoloads/save_manager.gd
+++ b/autoloads/save_manager.gd
@@ -78,6 +78,20 @@ func initialize_new_profile(slot_id: int, user_data: Dictionary) -> void:
 	var starting_credit_limit = user_data.get("starting_credit_limit", 0.0)
 	PortfolioManager.set_credit_limit(starting_credit_limit)
 
+	BillManager.add_debt_resource({
+		"name": "Credit Card",
+		"balance": 0.0,
+		"has_credit_limit": true,
+		"credit_limit": starting_credit_limit
+	})
+	if starting_debt > 0.0:
+		BillManager.add_debt_resource({
+			"name": "Student Loan",
+			"balance": starting_debt,
+			"has_credit_limit": false,
+			"credit_limit": 0.0
+		})
+
 	save_to_slot(slot_id)
 
 

--- a/components/apps/app_scenes/ower_view.tscn
+++ b/components/apps/app_scenes/ower_view.tscn
@@ -1,48 +1,7 @@
-[gd_scene load_steps=12 format=3 uid="uid://by7ye7kt412u3"]
+[gd_scene load_steps=2 format=3]
 
-[ext_resource type="Script" uid="uid://ce5ge1lmsdy7g" path="res://components/apps/ower_view/ower_view.gd" id="1_t43hg"]
-[ext_resource type="Texture2D" uid="uid://chka0bjnrrdmr" path="res://assets/ui/buttons/dark_purple_normal.png" id="3_aemln"]
-[ext_resource type="Texture2D" uid="uid://bsal74mys2v4b" path="res://assets/logos/owerview_logo.png" id="3_svf65"]
-[ext_resource type="Shader" uid="uid://dwdg8fcaxgjbp" path="res://assets/shaders/maroon_warp_shader.gdshader" id="4_6w1kr"]
-[ext_resource type="Texture2D" uid="uid://dpko7w8bh0pq1" path="res://assets/ui/buttons/english_violet_normal.png" id="4_svf65"]
-[ext_resource type="Texture2D" uid="uid://bu12v0yfad1ai" path="res://assets/ui/buttons/lilac_normal.png" id="5_6w1kr"]
-
-[sub_resource type="StyleBoxTexture" id="StyleBoxTexture_aemln"]
-texture = ExtResource("3_aemln")
-texture_margin_left = 2.0
-texture_margin_top = 2.0
-texture_margin_right = 2.0
-texture_margin_bottom = 2.0
-
-[sub_resource type="ShaderMaterial" id="ShaderMaterial_11odt"]
-shader = ExtResource("4_6w1kr")
-shader_parameter/stretch = 0.8
-shader_parameter/thing1 = 0.6
-shader_parameter/thing2 = 0.6
-shader_parameter/thing3 = 0.8
-shader_parameter/scale = 1.0
-shader_parameter/speed = 0.03
-
-[sub_resource type="StyleBoxTexture" id="StyleBoxTexture_njqv2"]
-texture = ExtResource("4_svf65")
-texture_margin_left = 2.0
-texture_margin_top = 2.0
-texture_margin_right = 2.0
-texture_margin_bottom = 2.0
-
-[sub_resource type="StyleBoxTexture" id="StyleBoxTexture_svf65"]
-texture = ExtResource("4_svf65")
-texture_margin_left = 2.0
-texture_margin_top = 2.0
-texture_margin_right = 2.0
-texture_margin_bottom = 2.0
-
-[sub_resource type="StyleBoxTexture" id="StyleBoxTexture_638yv"]
-texture = ExtResource("5_6w1kr")
-texture_margin_left = 2.0
-texture_margin_top = 2.0
-texture_margin_right = 2.0
-texture_margin_bottom = 2.0
+[ext_resource type="Script" path="res://components/apps/ower_view/ower_view.gd" id="1"]
+[ext_resource type="Texture2D" path="res://assets/logos/owerview_logo.png" id="2"]
 
 [node name="OwerView" type="PanelContainer"]
 anchors_preset = 15
@@ -53,217 +12,23 @@ grow_vertical = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
 mouse_filter = 1
-theme_override_styles/panel = SubResource("StyleBoxTexture_aemln")
-script = ExtResource("1_t43hg")
+script = ExtResource("1")
 window_title = "OwerView"
-window_icon = ExtResource("3_svf65")
+window_icon = ExtResource("2")
 default_window_size = Vector2(600, 500)
 default_position = "left"
 
-[node name="ColorRect" type="ColorRect" parent="."]
-material = SubResource("ShaderMaterial_11odt")
-layout_mode = 2
-
 [node name="MarginContainer" type="MarginContainer" parent="."]
-layout_mode = 2
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
 theme_override_constants/margin_left = 15
 theme_override_constants/margin_top = 15
 theme_override_constants/margin_right = 15
 theme_override_constants/margin_bottom = 15
 
-[node name="HBoxContainer" type="HBoxContainer" parent="MarginContainer"]
-layout_mode = 2
-
-[node name="VBoxContainer" type="VBoxContainer" parent="MarginContainer/HBoxContainer"]
-layout_mode = 2
-
-[node name="ShortTerm" type="MarginContainer" parent="MarginContainer/HBoxContainer/VBoxContainer"]
-layout_mode = 2
-theme_override_constants/margin_left = 25
-theme_override_constants/margin_top = 25
-theme_override_constants/margin_right = 25
-theme_override_constants/margin_bottom = 25
-
-[node name="CreditCardSummary" type="PanelContainer" parent="MarginContainer/HBoxContainer/VBoxContainer/ShortTerm"]
-unique_name_in_owner = true
-custom_minimum_size = Vector2(300, 50)
-layout_mode = 2
-size_flags_horizontal = 0
-size_flags_vertical = 2
-mouse_filter = 1
-theme_override_styles/panel = SubResource("StyleBoxTexture_njqv2")
-
-[node name="MarginContainer" type="MarginContainer" parent="MarginContainer/HBoxContainer/VBoxContainer/ShortTerm/CreditCardSummary"]
-layout_mode = 2
-theme_override_constants/margin_left = 10
-theme_override_constants/margin_top = 10
-theme_override_constants/margin_right = 10
-theme_override_constants/margin_bottom = 10
-
-[node name="VBoxContainer" type="VBoxContainer" parent="MarginContainer/HBoxContainer/VBoxContainer/ShortTerm/CreditCardSummary/MarginContainer"]
-layout_mode = 2
-size_flags_vertical = 0
-
-[node name="Label" type="Label" parent="MarginContainer/HBoxContainer/VBoxContainer/ShortTerm/CreditCardSummary/MarginContainer/VBoxContainer"]
-layout_mode = 2
-text = "Credit Card"
-
-[node name="CreditLabel" type="Label" parent="MarginContainer/HBoxContainer/VBoxContainer/ShortTerm/CreditCardSummary/MarginContainer/VBoxContainer"]
+[node name="Wallet" type="VBoxContainer" parent="MarginContainer"]
 unique_name_in_owner = true
 layout_mode = 2
-size_flags_horizontal = 0
-text = "Credit Card"
-
-[node name="CreditInterestLabel" type="Label" parent="MarginContainer/HBoxContainer/VBoxContainer/ShortTerm/CreditCardSummary/MarginContainer/VBoxContainer"]
-unique_name_in_owner = true
-layout_mode = 2
-size_flags_horizontal = 0
-text = "Interest %
-"
-
-[node name="CreditProgressBar" type="ProgressBar" parent="MarginContainer/HBoxContainer/VBoxContainer/ShortTerm/CreditCardSummary/MarginContainer/VBoxContainer"]
-unique_name_in_owner = true
-layout_mode = 2
-
-[node name="HBoxContainer" type="HBoxContainer" parent="MarginContainer/HBoxContainer/VBoxContainer/ShortTerm/CreditCardSummary/MarginContainer/VBoxContainer"]
-layout_mode = 2
-
-[node name="CreditSlider" type="HSlider" parent="MarginContainer/HBoxContainer/VBoxContainer/ShortTerm/CreditCardSummary/MarginContainer/VBoxContainer/HBoxContainer"]
-unique_name_in_owner = true
-layout_mode = 2
-size_flags_horizontal = 3
-
-[node name="CreditSliderLabel" type="Label" parent="MarginContainer/HBoxContainer/VBoxContainer/ShortTerm/CreditCardSummary/MarginContainer/VBoxContainer/HBoxContainer"]
-unique_name_in_owner = true
-layout_mode = 2
-size_flags_horizontal = 3
-size_flags_stretch_ratio = 0.46
-mouse_filter = 1
-text = "$0.00"
-
-[node name="PayCreditButton" type="Button" parent="MarginContainer/HBoxContainer/VBoxContainer/ShortTerm/CreditCardSummary/MarginContainer/VBoxContainer"]
-unique_name_in_owner = true
-layout_mode = 2
-size_flags_horizontal = 4
-size_flags_vertical = 0
-focus_mode = 0
-text = " Pay "
-
-[node name="LongTerm" type="MarginContainer" parent="MarginContainer/HBoxContainer/VBoxContainer"]
-layout_mode = 2
-theme_override_constants/margin_left = 25
-theme_override_constants/margin_top = 25
-theme_override_constants/margin_right = 25
-theme_override_constants/margin_bottom = 25
-
-[node name="StudentLoanSummary" type="PanelContainer" parent="MarginContainer/HBoxContainer/VBoxContainer/LongTerm"]
-unique_name_in_owner = true
-custom_minimum_size = Vector2(300, 50)
-layout_mode = 2
-size_flags_horizontal = 0
-size_flags_vertical = 0
-mouse_filter = 1
-theme_override_styles/panel = SubResource("StyleBoxTexture_svf65")
-
-[node name="MarginContainer" type="MarginContainer" parent="MarginContainer/HBoxContainer/VBoxContainer/LongTerm/StudentLoanSummary"]
-layout_mode = 2
-theme_override_constants/margin_left = 10
-theme_override_constants/margin_top = 10
-theme_override_constants/margin_right = 10
-theme_override_constants/margin_bottom = 10
-
-[node name="VBoxContainer2" type="VBoxContainer" parent="MarginContainer/HBoxContainer/VBoxContainer/LongTerm/StudentLoanSummary/MarginContainer"]
-layout_mode = 2
-
-[node name="Label" type="Label" parent="MarginContainer/HBoxContainer/VBoxContainer/LongTerm/StudentLoanSummary/MarginContainer/VBoxContainer2"]
-layout_mode = 2
-text = "Student Loans"
-
-[node name="StudentLoanLabel" type="Label" parent="MarginContainer/HBoxContainer/VBoxContainer/LongTerm/StudentLoanSummary/MarginContainer/VBoxContainer2"]
-unique_name_in_owner = true
-layout_mode = 2
-size_flags_horizontal = 0
-text = "Credit Card"
-
-[node name="HBoxContainer" type="HBoxContainer" parent="MarginContainer/HBoxContainer/VBoxContainer/LongTerm/StudentLoanSummary/MarginContainer/VBoxContainer2"]
-layout_mode = 2
-
-[node name="LoanSlider" type="HSlider" parent="MarginContainer/HBoxContainer/VBoxContainer/LongTerm/StudentLoanSummary/MarginContainer/VBoxContainer2/HBoxContainer"]
-unique_name_in_owner = true
-layout_mode = 2
-size_flags_horizontal = 3
-
-[node name="LoanSliderLabel" type="Label" parent="MarginContainer/HBoxContainer/VBoxContainer/LongTerm/StudentLoanSummary/MarginContainer/VBoxContainer2/HBoxContainer"]
-unique_name_in_owner = true
-layout_mode = 2
-size_flags_horizontal = 3
-size_flags_stretch_ratio = 0.46
-mouse_filter = 1
-text = "$0.00"
-
-[node name="PayStudentLoanButton" type="Button" parent="MarginContainer/HBoxContainer/VBoxContainer/LongTerm/StudentLoanSummary/MarginContainer/VBoxContainer2"]
-unique_name_in_owner = true
-layout_mode = 2
-size_flags_horizontal = 4
-focus_mode = 0
-text = " Pay "
-
-[node name="PanelContainer" type="PanelContainer" parent="MarginContainer/HBoxContainer"]
-layout_mode = 2
-mouse_filter = 1
-theme_override_styles/panel = SubResource("StyleBoxTexture_638yv")
-
-[node name="MarginContainer" type="MarginContainer" parent="MarginContainer/HBoxContainer/PanelContainer"]
-layout_mode = 2
-theme_override_constants/margin_left = 5
-theme_override_constants/margin_top = 10
-theme_override_constants/margin_right = 5
-theme_override_constants/margin_bottom = 25
-
-[node name="VBoxContainer" type="VBoxContainer" parent="MarginContainer/HBoxContainer/PanelContainer/MarginContainer"]
-layout_mode = 2
-
-[node name="CreditScore" type="Label" parent="MarginContainer/HBoxContainer/PanelContainer/MarginContainer/VBoxContainer"]
-layout_mode = 2
-size_flags_horizontal = 4
-theme_override_font_sizes/font_size = 12
-text = "Credit Score:"
-
-[node name="CreditScoreLabel" type="Label" parent="MarginContainer/HBoxContainer/PanelContainer/MarginContainer/VBoxContainer"]
-unique_name_in_owner = true
-layout_mode = 2
-size_flags_horizontal = 4
-theme_override_font_sizes/font_size = 17
-text = "Credit Score:"
-
-[node name="ProgressBar" type="ProgressBar" parent="MarginContainer/HBoxContainer/PanelContainer/MarginContainer/VBoxContainer"]
-custom_minimum_size = Vector2(15, 0)
-layout_mode = 2
-size_flags_horizontal = 4
-size_flags_vertical = 3
-min_value = 300.0
-max_value = 850.0
-value = 700.0
-fill_mode = 3
-show_percentage = false
-
-[node name="CenterContainer" type="CenterContainer" parent="MarginContainer/HBoxContainer"]
-layout_mode = 2
-size_flags_vertical = 0
-
-[node name="TextureRect" type="TextureRect" parent="MarginContainer/HBoxContainer/CenterContainer"]
-layout_mode = 2
-texture = ExtResource("3_svf65")
-stretch_mode = 3
-
-[node name="NOTELabel" type="Label" parent="MarginContainer/HBoxContainer/CenterContainer"]
-visible = false
-layout_mode = 2
-text = "+1 credit score per day
-and then mayvbe implement
-using cc -1 credit
-and you can upgrade 
-credit score recovery speed"
-
-[connection signal="pressed" from="MarginContainer/HBoxContainer/VBoxContainer/ShortTerm/CreditCardSummary/MarginContainer/VBoxContainer/PayCreditButton" to="." method="_on_pay_credit_button_pressed"]
-[connection signal="pressed" from="MarginContainer/HBoxContainer/VBoxContainer/LongTerm/StudentLoanSummary/MarginContainer/VBoxContainer2/PayStudentLoanButton" to="." method="_on_pay_student_loan_button_pressed"]

--- a/components/apps/ower_view/debt_card_ui.gd
+++ b/components/apps/ower_view/debt_card_ui.gd
@@ -1,0 +1,48 @@
+extends PanelContainer
+class_name DebtCardUI
+
+@onready var name_label: Label = %NameLabel
+@onready var amount_label: Label = %AmountLabel
+@onready var limit_bar: ProgressBar = %LimitBar
+@onready var pay_slider: HSlider = %PaySlider
+@onready var slider_label: Label = %SliderLabel
+@onready var pay_button: Button = %PayButton
+
+var resource_data: Dictionary
+
+func init(resource: Dictionary) -> void:
+	resource_data = resource
+	pay_slider.value_changed.connect(_on_slider_changed)
+	pay_button.pressed.connect(_on_pay_pressed)
+	update_display()
+
+func update_display() -> void:
+	name_label.text = resource_data.get("name", "")
+	var balance: float = resource_data.get("balance", 0.0)
+	amount_label.text = "$" + NumberFormatter.format_commas(balance)
+	var has_limit: bool = resource_data.get("has_credit_limit", false)
+	if has_limit:
+		var limit: float = resource_data.get("credit_limit", 0.0)
+		limit_bar.max_value = limit
+		limit_bar.value = balance
+		limit_bar.visible = true
+	else:
+		limit_bar.visible = false
+	update_slider()
+
+func update_slider() -> void:
+	var cash: float = PortfolioManager.cash
+	var balance: float = resource_data.get("balance", 0.0)
+	var max_pay: float = min(balance, cash)
+	pay_slider.max_value = max_pay
+	if pay_slider.value > max_pay:
+		pay_slider.value = max_pay
+	slider_label.text = "$%.2f" % pay_slider.value
+
+func _on_slider_changed(value: float) -> void:
+	slider_label.text = "$%.2f" % value
+
+func _on_pay_pressed() -> void:
+	var amount: float = pay_slider.value
+	BillManager.pay_debt(resource_data.get("name", ""), amount)
+	update_display()

--- a/components/apps/ower_view/debt_card_ui.tscn
+++ b/components/apps/ower_view/debt_card_ui.tscn
@@ -1,0 +1,55 @@
+[gd_scene load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://components/apps/ower_view/debt_card_ui.gd" id="1"]
+
+[node name="DebtCardUI" type="PanelContainer"]
+script = ExtResource("1")
+custom_minimum_size = Vector2(300, 120)
+
+[node name="MarginContainer" type="MarginContainer" parent="."]
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_constants/margin_left = 10
+theme_override_constants/margin_top = 10
+theme_override_constants/margin_right = 10
+theme_override_constants/margin_bottom = 10
+
+[node name="VBox" type="VBoxContainer" parent="MarginContainer"]
+layout_mode = 2
+
+[node name="NameLabel" type="Label" parent="MarginContainer/VBox"]
+unique_name_in_owner = true
+layout_mode = 2
+text = "Debt"
+
+[node name="AmountLabel" type="Label" parent="MarginContainer/VBox"]
+unique_name_in_owner = true
+layout_mode = 2
+text = "$0"
+
+[node name="LimitBar" type="ProgressBar" parent="MarginContainer/VBox"]
+unique_name_in_owner = true
+layout_mode = 2
+visible = false
+
+[node name="HBox" type="HBoxContainer" parent="MarginContainer/VBox"]
+layout_mode = 2
+
+[node name="PaySlider" type="HSlider" parent="MarginContainer/VBox/HBox"]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 3
+
+[node name="SliderLabel" type="Label" parent="MarginContainer/VBox/HBox"]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 3
+text = "$0.00"
+
+[node name="PayButton" type="Button" parent="MarginContainer/VBox"]
+unique_name_in_owner = true
+layout_mode = 2
+text = "Pay"

--- a/components/apps/ower_view/ower_view.gd
+++ b/components/apps/ower_view/ower_view.gd
@@ -1,98 +1,23 @@
 extends Pane
 
-@onready var credit_label := %CreditLabel
-@onready var credit_interest_label: Label = %CreditInterestLabel
-@onready var credit_bar := %CreditProgressBar
-@onready var credit_pay_btn := %PayCreditButton
-@onready var credit_slider := %CreditSlider
-@onready var credit_slider_label := %CreditSliderLabel
+@onready var wallet: VBoxContainer = %Wallet
+var card_scene: PackedScene = preload("res://components/apps/ower_view/debt_card_ui.tscn")
 
-@onready var loan_label := %StudentLoanLabel
-@onready var loan_pay_btn := %PayStudentLoanButton
-@onready var loan_slider := %LoanSlider
-@onready var loan_slider_label := %LoanSliderLabel
-
-@onready var credit_score_label := %CreditScoreLabel
-
-func _ready():
-	#app_title = "OwerView"
-	#emit_signal("title_updated", app_title)
-
-	PortfolioManager.credit_updated.connect(update_credit)
-	PortfolioManager.resource_changed.connect(_on_resource_changed)
+func _ready() -> void:
+	BillManager.debt_resources_changed.connect(_on_debt_changed)
 	PortfolioManager.cash_updated.connect(_on_cash_updated)
+	_on_debt_changed()
 
-	credit_slider.value_changed.connect(_on_credit_slider_changed)
-	loan_slider.value_changed.connect(_on_loan_slider_changed)
+func _on_debt_changed() -> void:
+	for child in wallet.get_children():
+		child.queue_free()
+	var resources: Array = BillManager.get_debt_resources()
+	for res in resources:
+		var card: DebtCardUI = card_scene.instantiate()
+		card.init(res)
+		wallet.add_child(card)
 
-	update_credit(PortfolioManager.credit_used, PortfolioManager.credit_limit)
-	update_student_loans()
-	update_credit_score()
-	update_credit_interest_label()
-	update_sliders()
-
-func update_credit(used: float, limit: float):
-	credit_label.text = "Credit Used: " + NumberFormatter.format_commas(used) + "   Credit Limit: " + NumberFormatter.format_commas(limit)
-	credit_bar.value = (used / limit) * 100.0
-	update_credit_interest_label()
-	update_sliders()
-
-func update_student_loans():
-	var loans := PortfolioManager.get_student_loans()
-	loan_label.text = "Student Loans: " + NumberFormatter.format_commas(loans)
-	update_sliders()
-
-func update_credit_interest_label():
-	credit_interest_label.text = "Interest Rate: %.1f%% per 4 weeks" % (PortfolioManager.credit_interest_rate * 100.0)
-
-
-func update_credit_score():
-	var score = PortfolioManager.get_credit_score()
-	credit_score_label.text = "%d" % score
-
-func _on_resource_changed(resource_name: String, _value: float):
-	if resource_name == "student_loans":
-		update_student_loans()
-	elif resource_name == "debt":
-		update_credit_score()
-
-func _on_cash_updated(_cash: float):
-	update_sliders()
-
-func update_sliders():
-	var cash := PortfolioManager.cash
-
-	# Credit Slider
-	var credit_max = min(PortfolioManager.credit_used, cash)
-	credit_slider.max_value = credit_max
-	if credit_slider.value > credit_max:
-		credit_slider.value = credit_max
-	credit_slider_label.text = "$%.2f" % credit_slider.value
-
-	# Loan Slider
-	var loan_max = min(PortfolioManager.get_student_loans(), cash)
-	loan_slider.max_value = loan_max
-	if loan_slider.value > loan_max:
-		loan_slider.value = loan_max
-	loan_slider_label.text = "$%.2f" % loan_slider.value
-
-func _on_credit_slider_changed(value: float):
-	credit_slider_label.text = "$%.2f" % value
-
-func _on_loan_slider_changed(value: float):
-	loan_slider_label.text = "$%.2f" % value
-
-
-func _on_pay_credit_button_pressed() -> void:
-	var amount = credit_slider.value
-	PortfolioManager.pay_down_credit(amount)
-	update_sliders()
-
-
-func _on_pay_student_loan_button_pressed() -> void:
-	var amount = loan_slider.value
-	if PortfolioManager.pay_with_cash(amount):
-		var new_amt = max(PortfolioManager.get_student_loans() - amount, 0.0)
-		PortfolioManager.set_student_loans(new_amt)
-
-	update_sliders()
+func _on_cash_updated(_cash: float) -> void:
+	for child in wallet.get_children():
+		if child is DebtCardUI:
+			child.update_slider()


### PR DESCRIPTION
## Summary
- Add reusable DebtCardUI to display and pay down debts with optional credit limits
- Revamp OwerView to build a wallet of debt cards from BillManager
- Persist debt resources in BillManager and initialize profile with credit card and student loan

## Testing
- `godot --headless -s tests/test_runner.gd` *(fails: command not found)*
- `apt-get install -y godot4` *(fails: Unable to locate package godot4)*

------
https://chatgpt.com/codex/tasks/task_e_68a74f9c411c832589c70eec518336c6