### PR TITLE
Initialize debt resources from education selection

### DIFF
--- a/components/ui/profile_creation/education_selection_screen.gd
+++ b/components/ui/profile_creation/education_selection_screen.gd
@@ -76,7 +76,30 @@ func _on_option_pressed(button: Button) -> void:
 
 
 func save_data() -> void:
-	var user_data = PlayerManager.user_data
-	user_data["education_level"] = selected_level
-	user_data["starting_student_debt"] = selected_student_debt
-	user_data["starting_credit_limit"] = selected_credit_limit
+        var user_data = PlayerManager.user_data
+        user_data["education_level"] = selected_level
+        user_data["starting_student_debt"] = selected_student_debt
+        user_data["starting_credit_limit"] = selected_credit_limit
+
+        # Initialize debt resources so other systems can immediately reflect the
+        # player's financial starting point.
+        BillManager.debt_resources.clear()
+        BillManager.debt_resources_changed.emit()
+
+        BillManager.add_debt_resource({
+                "name": "Credit Card",
+                "balance": 0.0,
+                "has_credit_limit": true,
+                "credit_limit": selected_credit_limit,
+        })
+
+        if selected_student_debt > 0.0:
+                BillManager.add_debt_resource({
+                        "name": "Student Loan",
+                        "balance": selected_student_debt,
+                        "has_credit_limit": false,
+                        "credit_limit": 0.0,
+                })
+
+        PortfolioManager.set_credit_limit(selected_credit_limit)
+        PortfolioManager.set_student_loans(selected_student_debt)


### PR DESCRIPTION
## Summary
- Build credit card and student loan debt resources directly when education is chosen.
- Sync PortfolioManager with selected credit limits and student loan balances.

## Testing
- `godot3 --headless -s tests/test_runner.gd` *(fails: project requires newer Godot)*
- `wget https://downloads.tuxfamily.org/godotengine/4.2.1/Godot_v4.2.1-stable_linux.x86_64.zip` *(fails: 503 Service Unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68a75414aca88325a2bdf27d9bbdffc1