### PR TITLE
Enable dragging shortcuts between folders and desktop

### DIFF
--- a/autoloads/desktop_layout_manager.gd
+++ b/autoloads/desktop_layout_manager.gd
@@ -3,7 +3,7 @@ extends Node
 
 signal items_loaded
 signal item_created(item_id: int, data: Dictionary)
-signal item_moved(item_id: int, position: Vector2)
+signal item_moved(item_id: int, position: Vector2, parent_id: int, old_parent_id: int)
 signal item_deleted(item_id: int)
 signal item_renamed(item_id: int, new_title: String)
 
@@ -51,11 +51,19 @@ func create_folder(title: String, icon_path: String, position: Vector2, parent_i
 	item_created.emit(id, entry)
 	return id
 
-func move_item(id: int, position: Vector2) -> void:
+func move_item(id: int, position: Vector2, new_parent_id: int = -1) -> void:
 	if not items.has(id):
 		return
-	items[id]["desktop_position"] = position
-	item_moved.emit(id, position)
+	var item: Dictionary = items[id]
+	var old_parent: int = int(item.get("parent_id", 0))
+	item["desktop_position"] = position
+	if new_parent_id != -1 and new_parent_id != old_parent:
+		if old_parent != 0 and items.has(old_parent):
+			items[old_parent]["child_ids"].erase(id)
+		item["parent_id"] = new_parent_id
+		if new_parent_id != 0 and items.has(new_parent_id):
+			items[new_parent_id]["child_ids"].append(id)
+	item_moved.emit(id, position, int(item.get("parent_id", 0)), old_parent)
 
 func rename_item(id: int, new_title: String) -> void:
 	if not items.has(id):

--- a/components/desktop/app_shortcut.gd
+++ b/components/desktop/app_shortcut.gd
@@ -11,6 +11,7 @@ class_name AppShortcut
 
 var is_dragging: bool = false
 var drag_offset: Vector2
+var original_parent_id: int = 0
 
 func _ready() -> void:
 	icon_rect.texture = icon
@@ -26,10 +27,31 @@ func _on_gui_input(event: InputEvent) -> void:
 			elif mb.pressed:
 				is_dragging = true
 				drag_offset = mb.position
+				var data: Dictionary = DesktopLayoutManager.get_item(item_id)
+				original_parent_id = int(data.get("parent_id", 0))
+				if get_parent() is GridContainer:
+					var desktop: Node = get_tree().root.get_node_or_null("Main/DesktopEnv")
+					if desktop != null:
+						get_parent().remove_child(self)
+						desktop.add_child(self)
+						global_position = get_global_mouse_position() - drag_offset
 			else:
 				if is_dragging:
 					is_dragging = false
-					DesktopLayoutManager.move_item(item_id, global_position)
+					var target: Control = get_viewport().gui_pick(get_viewport().get_mouse_position())
+					var new_parent: int = 0
+					while target != null:
+						if target is FolderShortcut:
+							new_parent = target.item_id
+							break
+						if target is FolderWindow:
+							new_parent = target.folder_id
+							break
+						target = target.get_parent()
+					DesktopLayoutManager.move_item(item_id, global_position, new_parent)
+					if new_parent != 0:
+						queue_free()
 	elif event is InputEventMouseMotion:
 		if is_dragging:
 			global_position = get_global_mouse_position() - drag_offset
+

--- a/components/desktop/folder_window.gd
+++ b/components/desktop/folder_window.gd
@@ -7,7 +7,21 @@ class_name FolderWindow
 @onready var scroll: ScrollContainer = %Scroll
 
 func _ready() -> void:
-		call_deferred("_update_grid_columns")
+	call_deferred("_update_grid_columns")
+	DesktopLayoutManager.item_created.connect(_on_item_created)
+	DesktopLayoutManager.item_deleted.connect(_on_item_deleted)
+	DesktopLayoutManager.item_moved.connect(_on_item_moved)
+
+func _on_item_created(item_id: int, data: Dictionary) -> void:
+	if int(data.get("parent_id", 0)) == folder_id:
+		_populate()
+
+func _on_item_deleted(item_id: int) -> void:
+	_populate()
+
+func _on_item_moved(item_id: int, position: Vector2, parent_id: int, old_parent_id: int) -> void:
+	if parent_id == folder_id or old_parent_id == folder_id:
+		_populate()
 
 func _notification(what: int) -> void:
 		if what == NOTIFICATION_RESIZED:

--- a/scripts/desktop_env.gd
+++ b/scripts/desktop_env.gd
@@ -23,7 +23,7 @@ const FOLDER_SHORTCUT_SCENE: PackedScene = preload("res://components/desktop/fol
 
 func _ready() -> void:
 	#SaveManager.save_to_slot(PlayerManager.get_slot_id())
-	
+
 	GameManager.in_game = true
 	#hide_all_windows_and_panels()
 	WindowManager.taskbar_container = taskbar
@@ -31,7 +31,8 @@ func _ready() -> void:
 	DesktopLayoutManager.items_loaded.connect(_on_items_loaded)
 	DesktopLayoutManager.item_created.connect(_on_item_created)
 	DesktopLayoutManager.item_deleted.connect(_on_item_deleted)
-	
+	DesktopLayoutManager.item_moved.connect(_on_item_moved)
+
 	call_deferred("_deferred_load_save")
 	launch_startup_apps()
 	print("Active slot_id:", SaveManager.current_slot_id)
@@ -163,6 +164,22 @@ func _on_item_deleted(item_id: int) -> void:
 			child.queue_free()
 			break
 
+func _on_item_moved(item_id: int, position: Vector2, parent_id: int, old_parent_id: int) -> void:
+	if parent_id == 0:
+		var found: bool = false
+		for child in icons_layer.get_children():
+			if (child is AppShortcut or child is FolderShortcut) and child.item_id == item_id:
+				child.global_position = position
+				found = true
+				break
+		if not found:
+			var data: Dictionary = DesktopLayoutManager.get_item(item_id)
+			_spawn_item(data)
+	else:
+		for child in icons_layer.get_children():
+			if (child is AppShortcut or child is FolderShortcut) and child.item_id == item_id:
+				child.queue_free()
+				break
 
 func _spawn_item(data: Dictionary) -> void:
 	var scene: PackedScene


### PR DESCRIPTION
## Summary
- support changing a shortcut's parent when moving it
- handle drag-and-drop of shortcuts between desktop and folders
- refresh desktop and folder windows when shortcuts move

## Testing
- `godot --headless -s tests/test_runner.gd` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a759c5a5e8832594d7e999beea8d9d