### PR TITLE
Add credit score progress bar to OwerView

### DIFF
--- a/components/apps/app_scenes/ower_view.tscn
+++ b/components/apps/app_scenes/ower_view.tscn
@@ -1,7 +1,8 @@
-[gd_scene load_steps=3 format=3 uid="uid://bkop7kx52hmpp"]
+[gd_scene load_steps=4 format=3 uid="uid://bkop7kx52hmpp"]
 
 [ext_resource type="Script" uid="uid://ce5ge1lmsdy7g" path="res://components/apps/ower_view/ower_view.gd" id="1"]
 [ext_resource type="Texture2D" uid="uid://bsal74mys2v4b" path="res://assets/logos/owerview_logo.png" id="2"]
+[ext_resource type="Script" uid="uid://bflpybq1kvp4a" path="res://components/apps/ower_view/credit_score_bar.gd" id="3"]
 
 [node name="OwerView" type="PanelContainer"]
 anchors_preset = 15
@@ -25,6 +26,15 @@ theme_override_constants/margin_top = 15
 theme_override_constants/margin_right = 15
 theme_override_constants/margin_bottom = 15
 
-[node name="Wallet" type="VBoxContainer" parent="MarginContainer"]
+[node name="HBoxContainer" type="HBoxContainer" parent="MarginContainer"]
+layout_mode = 2
+
+[node name="Wallet" type="VBoxContainer" parent="MarginContainer/HBoxContainer"]
 unique_name_in_owner = true
 layout_mode = 2
+size_flags_horizontal = 3
+
+[node name="CreditScoreBar" type="Control" parent="MarginContainer/HBoxContainer"]
+custom_minimum_size = Vector2(40, 0)
+size_flags_vertical = 3
+script = ExtResource("3")

--- a/components/apps/ower_view/credit_score_bar.gd
+++ b/components/apps/ower_view/credit_score_bar.gd
@@ -1,0 +1,28 @@
+extends Control
+
+@export var min_score: int = 300
+@export var max_score: int = 850
+@export var step: int = 50
+
+var current_score: int = min_score
+
+func _ready() -> void:
+    PortfolioManager.credit_updated.connect(_on_credit_changed)
+    _on_credit_changed(0.0, 0.0)
+
+func _on_credit_changed(_used: float, _limit: float) -> void:
+    current_score = PortfolioManager.get_credit_score()
+    queue_redraw()
+
+func _draw() -> void:
+    var rect: Rect2 = Rect2(Vector2.ZERO, size)
+    draw_rect(rect, Color(0.2, 0.2, 0.2))
+    var ratio: float = float(current_score - min_score) / float(max_score - min_score)
+    ratio = clamp(ratio, 0.0, 1.0)
+    var fill_height: float = rect.size.y * ratio
+    var fill_rect: Rect2 = Rect2(rect.position + Vector2(0, rect.size.y - fill_height), Vector2(rect.size.x, fill_height))
+    draw_rect(fill_rect, Color(0.3, 0.8, 0.3))
+    for score in range(min_score, max_score + 1, step):
+        var y: float = rect.size.y * (1.0 - float(score - min_score) / float(max_score - min_score))
+        draw_line(Vector2(0, y), Vector2(rect.size.x, y), Color.WHITE)
+

--- a/components/apps/ower_view/credit_score_bar.gd.uid
+++ b/components/apps/ower_view/credit_score_bar.gd.uid
@@ -1,0 +1,1 @@
+uid://bflpybq1kvp4a


### PR DESCRIPTION
## Summary
- add CreditScoreBar control to OwerView scene
- draw vertical bar with 50-point tick marks to show credit score
- update bar whenever PortfolioManager emits credit changes

## Testing
- `godot --headless --path . tests/test_runner.tscn` *(fails: command not found)*
- `apt-get install -y godot4` *(fails: Unable to locate package godot4)*

------
https://chatgpt.com/codex/tasks/task_e_68a75bddab10832594c89ca78b6c0556