### PR TITLE
Fix suitor love action to apply only affinity gain

### DIFF
--- a/components/popups/suitor_view.gd
+++ b/components/popups/suitor_view.gd
@@ -159,14 +159,12 @@ func _on_love_pressed() -> void:
 	if now - npc.love_cooldown < LOVE_COOLDOWN_MINUTES:
 		return
 	npc.love_cooldown = now
-	#var reached_next_stage: bool = logic.apply_love()
+	logic.apply_love()
 	if npc_idx != -1:
 		NPCManager.promote_to_persistent(npc_idx)
 		NPCManager.set_npc_field(npc_idx, "love_cooldown", npc.love_cooldown)
 		NPCManager.set_npc_field(npc_idx, "affinity", npc.affinity)
 		NPCManager.set_npc_field(npc_idx, "relationship_progress", npc.relationship_progress)
-	#if reached_next_stage:
-	#	next_stage_button.visible = true
 	_update_affinity_bar()
 	_update_relationship_bar()
 	_update_breakup_button_text()

--- a/tests/suitor_love_test.gd
+++ b/tests/suitor_love_test.gd
@@ -1,11 +1,11 @@
 extends SceneTree
 
-func _ready():
-    var npc := NPC.new()
-    npc.affinity = 0.0
-    var logic := SuitorLogic.new()
-    logic.setup(npc)
-    logic.apply_love()
-    assert(npc.affinity == 5.0)
-    print("suitor_love_test passed")
-    quit()
+func _ready() -> void:
+	var npc: NPC = NPC.new()
+	npc.affinity = 0.0
+	var logic: SuitorLogic = SuitorLogic.new()
+	logic.setup(npc)
+	logic.apply_love()
+	assert(npc.affinity == 5.0)
+	print("suitor_love_test passed")
+	quit()


### PR DESCRIPTION
## Summary
- ensure love button uses SuitorLogic.apply_love so only LOVE_AFFINITY_GAIN adjusts affinity
- update love logic test to use explicit typing

## Testing
- `godot3-server --headless --path . --script tests/test_runner.gd` *(fails: Can't open project due to engine version mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_68a75e91f31c8325a2f1c7ee068601a0