### PR TITLE
Show numeric values for suitor stats

### DIFF
--- a/components/popups/suitor_popup.tscn
+++ b/components/popups/suitor_popup.tscn
@@ -80,7 +80,8 @@ layout_mode = 2
 show_percentage = false
 script = ExtResource("5")
 
-[node name="Label" type="Label" parent="MarginContainer/VBox/RelationshipBar"]
+[node name="RelationshipValueLabel" type="Label" parent="MarginContainer/VBox/RelationshipBar"]
+unique_name_in_owner = true
 layout_mode = 1
 anchors_preset = 8
 anchor_left = 0.5
@@ -93,7 +94,7 @@ offset_right = 20.0
 offset_bottom = 7.5
 grow_horizontal = 2
 grow_vertical = 2
-text = "Relationship Progress"
+text = ""
 horizontal_alignment = 1
 
 [node name="NextStageButton" type="Button" parent="MarginContainer/VBox"]
@@ -112,7 +113,8 @@ show_percentage = false
 script = ExtResource("3")
 tooltip_name = "Affinity"
 
-[node name="Label" type="Label" parent="MarginContainer/VBox/AffinityBar"]
+[node name="AffinityValueLabel" type="Label" parent="MarginContainer/VBox/AffinityBar"]
+unique_name_in_owner = true
 layout_mode = 1
 anchors_preset = 8
 anchor_left = 0.5
@@ -125,7 +127,7 @@ offset_right = 25.0
 offset_bottom = 7.5
 grow_horizontal = 2
 grow_vertical = 2
-text = "Affinity"
+text = ""
 horizontal_alignment = 1
 
 [node name="VBoxContainer" type="VBoxContainer" parent="MarginContainer/VBox"]

--- a/components/popups/suitor_view.gd
+++ b/components/popups/suitor_view.gd
@@ -10,6 +10,8 @@ const LOVE_COOLDOWN_MINUTES: int = 24 * 60
 @onready var relationship_bar: RelationshipBar = %RelationshipBar
 @onready var next_stage_button: Button = %NextStageButton
 @onready var affinity_bar: StatProgressBar = %AffinityBar
+@onready var relationship_value_label: Label = %RelationshipValueLabel
+@onready var affinity_value_label: Label = %AffinityValueLabel
 @onready var love_button: Button = %LoveButton
 @onready var love_cooldown_label: Label = %LoveCooldownLabel
 @onready var gift_button: Button = %GiftButton
@@ -78,25 +80,30 @@ func _update_all() -> void:
 	date_button.disabled = blocked
 	apologize_button.visible = UpgradeManager.get_level("fumble_talk_therapy") > 0 and npc.relationship_stage in [NPC.RelationshipStage.DIVORCED, NPC.RelationshipStage.EX]
 func _update_relationship_bar() -> void:
-	var current_stage: int = npc.relationship_stage
-	if current_stage == NPC.RelationshipStage.MARRIED:
-		var level: int = npc.get_marriage_level()
-		relationship_stage_label.text = "Level %d Marriage" % level
+        var current_stage: int = npc.relationship_stage
+        if current_stage == NPC.RelationshipStage.MARRIED:
+                var level: int = npc.get_marriage_level()
+                relationship_stage_label.text = "Level %d Marriage" % level
 	elif current_stage in [NPC.RelationshipStage.DIVORCED, NPC.RelationshipStage.EX]:
 		relationship_stage_label.text = STAGE_NAMES[current_stage]
 	else:
 		var next_stage: int = current_stage + 1
 		relationship_stage_label.text = "%s -> %s" % [STAGE_NAMES[current_stage], STAGE_NAMES[next_stage]]
-	var bounds: Vector2 = SuitorLogic.get_stage_bounds(current_stage, npc.relationship_progress)
-	relationship_bar.max_value = bounds.y - bounds.x
-	relationship_bar.update_value(npc.relationship_progress - bounds.x)
-	if current_stage < NPC.RelationshipStage.MARRIED:
-		relationship_bar.set_mark_fractions(logic.get_stop_marks())
-	else:
-		relationship_bar.set_mark_fractions([])
+        var bounds: Vector2 = SuitorLogic.get_stage_bounds(current_stage, npc.relationship_progress)
+        relationship_bar.max_value = bounds.y - bounds.x
+        relationship_bar.update_value(npc.relationship_progress - bounds.x)
+        relationship_value_label.text = "%s / %s" % [
+                NumberFormatter.format_commas(npc.relationship_progress - bounds.x, 2),
+                NumberFormatter.format_commas(bounds.y - bounds.x, 2)
+        ]
+        if current_stage < NPC.RelationshipStage.MARRIED:
+                relationship_bar.set_mark_fractions(logic.get_stop_marks())
+        else:
+                relationship_bar.set_mark_fractions([])
 func _update_affinity_bar() -> void:
-	affinity_bar.max_value = 100
-	affinity_bar.update_value(npc.affinity)
+        affinity_bar.max_value = 100
+        affinity_bar.update_value(npc.affinity)
+        affinity_value_label.text = "%s / 100" % NumberFormatter.format_commas(npc.affinity, 0)
 
 func _update_breakup_button_text() -> void:
 	if npc.relationship_stage >= NPC.RelationshipStage.DIVORCED:


### PR DESCRIPTION
## Summary
- Display the current relationship progress as numeric values in the suitor view.
- Show the affinity stat numerically on the affinity bar.

## Testing
- `godot3 --headless -s res://tests/test_runner.gd` *(fails: project requires a newer Godot config version)*

------
https://chatgpt.com/codex/tasks/task_e_68a761d039d48325a86762a82634d35c