### PR TITLE
Fix love button to mirror gift with cooldown

### DIFF
--- a/components/popups/suitor_view.gd
+++ b/components/popups/suitor_view.gd
@@ -166,16 +166,13 @@ func _on_love_pressed() -> void:
 	if now - npc.love_cooldown < LOVE_COOLDOWN_MINUTES:
 		return
 	npc.love_cooldown = now
-	logic.apply_love()
-	if npc_idx != -1:
-		NPCManager.promote_to_persistent(npc_idx)
-		NPCManager.set_npc_field(npc_idx, "love_cooldown", npc.love_cooldown)
-		NPCManager.set_npc_field(npc_idx, "affinity", npc.affinity)
-		NPCManager.set_npc_field(npc_idx, "relationship_progress", npc.relationship_progress)
-	_update_affinity_bar()
-	_update_relationship_bar()
-	_update_breakup_button_text()
-	_update_love_button()
+        logic.apply_love()
+        if npc_idx != -1:
+                NPCManager.promote_to_persistent(npc_idx)
+                NPCManager.set_npc_field(npc_idx, "love_cooldown", npc.love_cooldown)
+                NPCManager.set_npc_field(npc_idx, "affinity", npc.affinity)
+        _update_affinity_bar()
+        _update_love_button()
 
 func _on_date_pressed() -> void:
 	if not PortfolioManager.attempt_spend(npc.date_cost):

--- a/tests/suitor_love_test.gd
+++ b/tests/suitor_love_test.gd
@@ -1,11 +1,13 @@
 extends SceneTree
 
 func _ready() -> void:
-	var npc: NPC = NPC.new()
-	npc.affinity = 0.0
-	var logic: SuitorLogic = SuitorLogic.new()
-	logic.setup(npc)
-	logic.apply_love()
-	assert(npc.affinity == 5.0)
-	print("suitor_love_test passed")
-	quit()
+        var npc: NPC = NPC.new()
+        npc.affinity = 0.0
+        npc.relationship_progress = 10.0
+        var logic: SuitorLogic = SuitorLogic.new()
+        logic.setup(npc)
+        logic.apply_love()
+        assert(npc.affinity == 5.0)
+        assert(npc.relationship_progress == 10.0)
+        print("suitor_love_test passed")
+        quit()


### PR DESCRIPTION
## Summary
- Ensure love action only grants +5 affinity on cooldown
- Extend love test to verify relationship progress unaffected

## Testing
- `godot3-server --headless -s tests/test_runner.gd` *(fails: project requires newer Godot version)*

------
https://chatgpt.com/codex/tasks/task_e_68a76433d2548325bd30a5eb2b380ee3