### PR TITLE
Fix Minerr crypto card setup

### DIFF
--- a/components/apps/minerr/crypto_card.gd
+++ b/components/apps/minerr/crypto_card.gd
@@ -30,6 +30,7 @@ var displayed_chance: float = 0.0
 var lerp_speed: float = 5.0
 
 func setup(crypto_data: Cryptocurrency) -> void:
+	await ready
 	crypto = crypto_data
 
 	add_gpu_button.pressed.connect(func(): emit_signal("add_gpu", crypto.symbol))

--- a/components/apps/minerr/minerr_ui.gd
+++ b/components/apps/minerr/minerr_ui.gd
@@ -33,7 +33,7 @@ func refresh_cards_from_market() -> void:
 		var symbol: String = crypto.symbol
 		var card: CryptoCard = crypto_card_scene.instantiate() as CryptoCard
 		crypto_container.add_child(card)
-		card.call_deferred("setup", crypto)
+		card.setup(crypto)
 
 		card.add_gpu.connect(_on_add_gpu)
 		card.remove_gpu.connect(_on_remove_gpu)


### PR DESCRIPTION
## Summary
- Ensure Minerr creates a crypto card for each cryptocurrency
- Wait for CryptoCard `ready` before setup to attach data correctly

## Testing
- `godot4 --headless --run-tests tests/test_runner.tscn` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a76856efa083259f9e91987c79da2c