### PR TITLE
Drift affinity hourly toward equilibrium with UI marker

### DIFF
--- a/components/apps/fumble/stat_progress_bar.gd
+++ b/components/apps/fumble/stat_progress_bar.gd
@@ -12,6 +12,12 @@ extends ProgressBar
 
 var _tween: Tween = null
 var _actual_value: float = 0.0
+@export var equilibrium_value: float = NAN setget set_equilibrium_value
+@export var equilibrium_tooltip: String = "Affinity will drift towards equilibrium over time"
+
+func set_equilibrium_value(val: float) -> void:
+        equilibrium_value = val
+        queue_redraw()
 
 func _ready():
 		if stat_name != "":
@@ -44,8 +50,9 @@ func update_value(new_value: float) -> void:
 	if animate:
 		set_value_animated(display_value, _actual_value)
 	else:
-		value = clamp(display_value, min_value, max_value)
-		update_tooltip(_actual_value)
+                value = clamp(display_value, min_value, max_value)
+                update_tooltip(_actual_value)
+        queue_redraw()
 
 func set_value_animated(target_value: float, tooltip_value: float) -> void:
 	if _tween:
@@ -62,4 +69,18 @@ func update_tooltip(val: float) -> void:
 		str_val = "%.2f" % val
 	else:
 		str_val = str(int(val))
-		tooltip_text = "%s: %s" % [tooltip_name, str_val]
+                tooltip_text = "%s: %s" % [tooltip_name, str_val]
+
+func _draw() -> void:
+        if not is_nan(equilibrium_value):
+                var frac := (equilibrium_value - min_value) / (max_value - min_value)
+                var x := size.x * frac
+                draw_line(Vector2(x, 0), Vector2(x, size.y), Color.WHITE, 1.0)
+
+func _get_tooltip(at_position: Vector2 = Vector2.ZERO) -> String:
+        if not is_nan(equilibrium_value):
+                var frac := (equilibrium_value - min_value) / (max_value - min_value)
+                var x := size.x * frac
+                if absf(at_position.x - x) <= 2.0:
+                        return equilibrium_tooltip
+        return tooltip_text

--- a/components/npc/npc_manager.gd
+++ b/components/npc/npc_manager.gd
@@ -17,16 +17,11 @@ var npcs: Dictionary = {}
 var persistent_by_gender: Dictionary = {}
 var persistent_by_wealth: Dictionary = {}
 
-var _hours_since_affinity_drift: int = 0
-
 func _ready() -> void:
-	TimeManager.hour_passed.connect(_on_hour_passed)
+        TimeManager.hour_passed.connect(_on_hour_passed)
 
 func _on_hour_passed(_current_hour: int, _total_minutes: int) -> void:
-	_hours_since_affinity_drift += 1
-	if _hours_since_affinity_drift >= 4:
-			_hours_since_affinity_drift = 0
-			_drift_affinity_toward_equilibrium()
+        _drift_affinity_toward_equilibrium()
 
 func _drift_affinity_toward_equilibrium() -> void:
 	for idx in npcs.keys():

--- a/components/popups/suitor_logic.gd
+++ b/components/popups/suitor_logic.gd
@@ -62,8 +62,7 @@ func on_date_paid() -> void:
 	progress_paused = false
 
 func apply_love() -> void:
-	npc.affinity = min(npc.affinity + LOVE_AFFINITY_GAIN, 100.0)
-	npc.affinity_equilibrium = npc.affinity
+        npc.affinity = min(npc.affinity + LOVE_AFFINITY_GAIN, 100.0)
 
 
 func get_stop_marks() -> Array[float]:

--- a/components/popups/suitor_view.gd
+++ b/components/popups/suitor_view.gd
@@ -101,9 +101,10 @@ func _update_relationship_bar() -> void:
 		else:
 				relationship_bar.set_mark_fractions([])
 func _update_affinity_bar() -> void:
-		affinity_bar.max_value = 100
-		affinity_bar.update_value(npc.affinity)
-		affinity_value_label.text = "%s / 100" % NumberFormatter.format_commas(npc.affinity, 0)
+                affinity_bar.max_value = 100
+                affinity_bar.update_value(npc.affinity)
+                affinity_bar.equilibrium_value = npc.affinity_equilibrium
+                affinity_value_label.text = "%s / 100" % NumberFormatter.format_commas(npc.affinity, 0)
 
 func _update_breakup_button_text() -> void:
 	if npc.relationship_stage >= NPC.RelationshipStage.DIVORCED:


### PR DESCRIPTION
## Summary
- Adjust NPCManager to shift affinity by one point toward equilibrium every hour.
- Remove love logic resetting affinity equilibrium.
- Add equilibrium marker with tooltip to StatProgressBar and wire it into the suitor view.

## Testing
- `godot3-server --headless --path . --script tests/test_runner.gd` *(fails: project requires newer Godot engine)*


------
https://chatgpt.com/codex/tasks/task_e_68a776c5f96c83258142ff4ef88012fe