### PR TITLE
Hourly affinity drift and equilibrium UI

### DIFF
--- a/components/npc/npc_manager.gd
+++ b/components/npc/npc_manager.gd
@@ -17,16 +17,11 @@ var npcs: Dictionary = {}
 var persistent_by_gender: Dictionary = {}
 var persistent_by_wealth: Dictionary = {}
 
-var _hours_since_affinity_drift: int = 0
-
 func _ready() -> void:
-	TimeManager.hour_passed.connect(_on_hour_passed)
+        TimeManager.hour_passed.connect(_on_hour_passed)
 
 func _on_hour_passed(_current_hour: int, _total_minutes: int) -> void:
-	_hours_since_affinity_drift += 1
-	if _hours_since_affinity_drift >= 4:
-			_hours_since_affinity_drift = 0
-			_drift_affinity_toward_equilibrium()
+        _drift_affinity_toward_equilibrium()
 
 func _drift_affinity_toward_equilibrium() -> void:
 	for idx in npcs.keys():

--- a/components/popups/affinity_bar.gd
+++ b/components/popups/affinity_bar.gd
@@ -1,0 +1,30 @@
+class_name AffinityBar
+extends StatProgressBar
+
+var equilibrium_value: float = 50.0
+
+func set_equilibrium(val: float) -> void:
+	equilibrium_value = val
+	queue_redraw()
+
+func _draw() -> void:
+	var bar_rect: Rect2 = Rect2(Vector2.ZERO, size)
+	var fraction: float = 0.0
+	if max_value != 0:
+		fraction = equilibrium_value / max_value
+	var x: float = bar_rect.position.x + bar_rect.size.x * fraction
+	draw_line(
+		Vector2(x, bar_rect.position.y),
+		Vector2(x, bar_rect.position.y + bar_rect.size.y),
+		Color.WHITE,
+		1.0
+	)
+
+func _get_tooltip(at_position: Vector2 = Vector2.ZERO) -> String:
+	var fraction: float = 0.0
+	if max_value != 0:
+		fraction = equilibrium_value / max_value
+	var x: float = size.x * fraction
+	if absf(at_position.x - x) <= 2.0:
+		return "Affinity will drift towards equilibrium over time"
+	return tooltip_text

--- a/components/popups/affinity_bar.gd.uid
+++ b/components/popups/affinity_bar.gd.uid
@@ -1,0 +1,1 @@
+uid://affinitybar

--- a/components/popups/suitor_logic.gd
+++ b/components/popups/suitor_logic.gd
@@ -62,8 +62,7 @@ func on_date_paid() -> void:
 	progress_paused = false
 
 func apply_love() -> void:
-	npc.affinity = min(npc.affinity + LOVE_AFFINITY_GAIN, 100.0)
-	npc.affinity_equilibrium = npc.affinity
+        npc.affinity = min(npc.affinity + LOVE_AFFINITY_GAIN, 100.0)
 
 
 func get_stop_marks() -> Array[float]:

--- a/components/popups/suitor_popup.tscn
+++ b/components/popups/suitor_popup.tscn
@@ -2,7 +2,7 @@
 
 [ext_resource type="Theme" uid="uid://cesgvqexxaqev" path="res://assets/windows_95_theme.tres" id="1"]
 [ext_resource type="Script" uid="uid://d1rk5ob1oyitb" path="res://components/popups/suitor_view.gd" id="2"]
-[ext_resource type="Script" uid="uid://qeyobl0rg2cy" path="res://components/apps/fumble/stat_progress_bar.gd" id="3"]
+[ext_resource type="Script" uid="uid://affinitybar" path="res://components/popups/affinity_bar.gd" id="3"]
 [ext_resource type="Shader" uid="uid://bfgsgplah4us" path="res://assets/shaders/white_warp_shader.gdshader" id="3_vl6ok"]
 [ext_resource type="PackedScene" uid="uid://drm1apbdsjj5g" path="res://components/portrait/portrait_view.tscn" id="4"]
 [ext_resource type="Script" uid="uid://bvbiboe20qioe" path="res://components/popups/relationship_bar.gd" id="5"]

--- a/components/popups/suitor_view.gd
+++ b/components/popups/suitor_view.gd
@@ -9,7 +9,7 @@ const LOVE_COOLDOWN_MINUTES: int = 24 * 60
 @onready var relationship_stage_label: Label = %RelationshipStageLabel
 @onready var relationship_bar: RelationshipBar = %RelationshipBar
 @onready var next_stage_button: Button = %NextStageButton
-@onready var affinity_bar: StatProgressBar = %AffinityBar
+@onready var affinity_bar: AffinityBar = %AffinityBar
 @onready var relationship_value_label: Label = %RelationshipValueLabel
 @onready var affinity_value_label: Label = %AffinityValueLabel
 @onready var love_button: Button = %LoveButton
@@ -101,9 +101,10 @@ func _update_relationship_bar() -> void:
 		else:
 				relationship_bar.set_mark_fractions([])
 func _update_affinity_bar() -> void:
-		affinity_bar.max_value = 100
-		affinity_bar.update_value(npc.affinity)
-		affinity_value_label.text = "%s / 100" % NumberFormatter.format_commas(npc.affinity, 0)
+	affinity_bar.max_value = 100
+	affinity_bar.update_value(npc.affinity)
+	affinity_bar.set_equilibrium(npc.affinity_equilibrium)
+	affinity_value_label.text = "%s / 100" % NumberFormatter.format_commas(npc.affinity, 0)
 
 func _update_breakup_button_text() -> void:
 	if npc.relationship_stage >= NPC.RelationshipStage.DIVORCED:


### PR DESCRIPTION
## Summary
- Drift each NPC's affinity 1 point toward equilibrium every in-game hour
- Remove equilibrium adjustments from love logic
- Add AffinityBar with equilibrium marker and tooltip

## Testing
- `godot3 --headless -s tests/test_runner.gd` *(fails: project requires newer Godot version)*

------
https://chatgpt.com/codex/tasks/task_e_68a776c5f96c83258142ff4ef88012fe