### PR TITLE
Avoid duplicate block sprite signal connections

### DIFF
--- a/components/apps/minerr/crypto_card.gd
+++ b/components/apps/minerr/crypto_card.gd
@@ -34,14 +34,18 @@ var displayed_chance: float = 0.0
 var lerp_speed: float = 5.0
 
 func _ready() -> void:
-	# Start disabled; enable in setup() when crypto is assigned.
-	set_process(false)
-	# Safe default UI so labels don't show nonsense before setup.
-	_reset_ui_placeholders()
-	# Optional: connect hover/cursor signals that don't need crypto
-	block_sprite.gui_input.connect(_on_block_sprite_gui_input)
-	block_sprite.mouse_entered.connect(_on_block_sprite_mouse_entered)
-	block_sprite.mouse_exited.connect(_on_block_sprite_mouse_exited)
+        # Start disabled; enable in setup() when crypto is assigned.
+        set_process(false)
+        # Safe default UI so labels don't show nonsense before setup.
+        _reset_ui_placeholders()
+        # Optional: connect hover/cursor signals that don't need crypto.
+        # Guard against double-connecting if this node re-enters the tree.
+        if not block_sprite.gui_input.is_connected(_on_block_sprite_gui_input):
+                block_sprite.gui_input.connect(_on_block_sprite_gui_input)
+        if not block_sprite.mouse_entered.is_connected(_on_block_sprite_mouse_entered):
+                block_sprite.mouse_entered.connect(_on_block_sprite_mouse_entered)
+        if not block_sprite.mouse_exited.is_connected(_on_block_sprite_mouse_exited):
+                block_sprite.mouse_exited.connect(_on_block_sprite_mouse_exited)
 
 func setup(crypto_data: Cryptocurrency) -> void:
 	if not is_node_ready():


### PR DESCRIPTION
## Summary
- guard CryptoCard block_sprite signal connections to prevent double-connecting when node re-enters the tree

## Testing
- `godot --headless --run tests/test_runner.tscn` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68a777e621d88325a1ceba383636a557