### PR TITLE
Fix crypto market initialization by loading TimeManager first

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -24,11 +24,11 @@ boot_splash/minimum_display_time=240
 
 ContextMenuManager="*res://autoloads/context_menu_manager.gd"
 WindowManager="*res://autoloads/window_manager.gd"
-PortfolioManager="*res://autoloads/portfolio_manager.gd"
+TimeManager="*res://autoloads/time_manager.gd"
 MarketManager="*res://autoloads/market_manager.gd"
+PortfolioManager="*res://autoloads/portfolio_manager.gd"
 GPUManager="*res://autoloads/gpu_manager.gd"
 HistoryManager="*res://autoloads/history_manager.gd"
-TimeManager="*res://autoloads/time_manager.gd"
 BillManager="*res://autoloads/bill_manager.gd"
 SaveManager="*res://autoloads/save_manager.gd"
 PlayerManager="*res://autoloads/player_manager.gd"


### PR DESCRIPTION
## Summary
- Ensure TimeManager autoloads before other managers so market initialization can connect to time events

## Testing
- `godot --headless -s tests/test_runner.gd` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a77c43c89c832589ef448697bed7fd