### PR TITLE
Refactor suitor logic into state machine

### DIFF
--- a/components/popups/suitor_logic.gd
+++ b/components/popups/suitor_logic.gd
@@ -3,6 +3,7 @@ extends Node
 
 var npc: NPC
 var progress_paused: bool = false
+var state: SuitorState
 
 const STAGE_THRESHOLDS: Array[float] = [0.0, 0.0, 100.0, 1000.0, 10000.0, 100000.0]
 const LN10: float = 2.302585092994046  # natural log of 10
@@ -31,31 +32,36 @@ static func get_marriage_level(progress: float) -> int:
 func setup(npc_instance: NPC) -> void:
 	npc = npc_instance
 	progress_paused = false
+	change_state(npc.relationship_stage)
+
+func change_state(stage: int) -> void:
+	if state != null:
+		state.exit()
+	match stage:
+		NPC.RelationshipStage.STRANGER:
+			state = StrangerState.new(self)
+		NPC.RelationshipStage.TALKING:
+			state = TalkingState.new(self)
+		NPC.RelationshipStage.DATING:
+			state = DatingState.new(self)
+		NPC.RelationshipStage.SERIOUS:
+			state = SeriousState.new(self)
+		NPC.RelationshipStage.ENGAGED:
+			state = EngagedState.new(self)
+		NPC.RelationshipStage.MARRIED:
+			state = MarriedState.new(self)
+		NPC.RelationshipStage.DIVORCED:
+			state = DivorcedState.new(self)
+		NPC.RelationshipStage.EX:
+			state = ExState.new(self)
+	state.enter()
 
 func process(delta: float) -> void:
-	if npc == null or progress_paused or npc.relationship_stage >= NPC.RelationshipStage.DIVORCED:
+	if npc == null or progress_paused:
 		return
-	var bounds: Vector2 = get_stage_bounds(npc.relationship_stage, npc.relationship_progress)
-	var rate: float = max(npc.affinity, 0.0) * 0.1
-	npc.relationship_progress += rate * delta
-	apply_stop_points()
-	if npc.relationship_stage < NPC.RelationshipStage.MARRIED and npc.relationship_progress >= bounds.y:
-		npc.relationship_progress = bounds.y
-		progress_paused = true
+	if state != null:
+		state.update(delta)
 
-func apply_stop_points() -> void:
-	var stage: int = npc.relationship_stage
-	var bounds: Vector2 = get_stage_bounds(stage, npc.relationship_progress)
-	var stage_range: float = bounds.y - bounds.x
-	var stops: Array = get_stop_points(stage)
-	var progress_fraction: float = (npc.relationship_progress - bounds.x) / stage_range
-	for stop in stops:
-		var fraction: float = stop["fraction"]
-		var required: int = stop["required"]
-		if progress_fraction >= fraction and npc.dates_paid < required:
-			npc.relationship_progress = bounds.x + fraction * stage_range
-			progress_paused = true
-			break
 
 func on_date_paid() -> void:
 	npc.dates_paid += 1
@@ -66,15 +72,9 @@ func apply_love() -> void:
 
 
 func get_stop_marks() -> Array[float]:
-	var marks: Array[float] = []
-	var stage: int = npc.relationship_stage
-	var stops: Array = get_stop_points(stage)
-	for stop in stops:
-		var fraction: float = stop["fraction"]
-		var required: int = stop["required"]
-		if npc.dates_paid < required:
-			marks.append(fraction)
-	return marks
+	if state != null:
+		return state.get_stop_marks()
+	return []
 
 static func get_stop_points(stage: int) -> Array:
 	if stage >= NPC.RelationshipStage.MARRIED:
@@ -86,3 +86,91 @@ static func get_stop_points(stage: int) -> Array:
 		var required: int = prev_required + i
 		points.append({"fraction": fraction, "required": required})
 	return points
+
+class SuitorState:
+	var machine: SuitorLogic
+	var npc: NPC
+
+	func _init(machine: SuitorLogic) -> void:
+		self.machine = machine
+		npc = machine.npc
+
+	func enter() -> void:
+		pass
+
+	func exit() -> void:
+		pass
+
+	func update(delta: float) -> void:
+		pass
+
+	func get_stop_marks() -> Array[float]:
+		return []
+
+class PreMarriageState extends SuitorState:
+	var stage: int
+
+	func _init(machine: SuitorLogic, stage_id: int) -> void:
+		super._init(machine)
+		stage = stage_id
+
+	func update(delta: float) -> void:
+		var bounds: Vector2 = SuitorLogic.get_stage_bounds(stage, npc.relationship_progress)
+		var rate: float = max(npc.affinity, 0.0) * 0.1
+		npc.relationship_progress += rate * delta
+		var stage_range: float = bounds.y - bounds.x
+		var stops: Array = SuitorLogic.get_stop_points(stage)
+		var progress_fraction: float = 0.0
+		if stage_range > 0.0:
+			progress_fraction = (npc.relationship_progress - bounds.x) / stage_range
+		for stop in stops:
+			var fraction: float = stop["fraction"]
+			var required: int = stop["required"]
+			if progress_fraction >= fraction and npc.dates_paid < required:
+				npc.relationship_progress = bounds.x + fraction * stage_range
+				machine.progress_paused = true
+				break
+		if stage < NPC.RelationshipStage.MARRIED and npc.relationship_progress >= bounds.y:
+			npc.relationship_progress = bounds.y
+			machine.progress_paused = true
+
+	func get_stop_marks() -> Array[float]:
+		var marks: Array[float] = []
+		var stops: Array = SuitorLogic.get_stop_points(stage)
+		for stop in stops:
+			var fraction: float = stop["fraction"]
+			var required: int = stop["required"]
+			if npc.dates_paid < required:
+				marks.append(fraction)
+		return marks
+
+class StrangerState extends PreMarriageState:
+	func _init(machine: SuitorLogic) -> void:
+		super._init(machine, NPC.RelationshipStage.STRANGER)
+
+class TalkingState extends PreMarriageState:
+	func _init(machine: SuitorLogic) -> void:
+		super._init(machine, NPC.RelationshipStage.TALKING)
+
+class DatingState extends PreMarriageState:
+	func _init(machine: SuitorLogic) -> void:
+		super._init(machine, NPC.RelationshipStage.DATING)
+
+class SeriousState extends PreMarriageState:
+	func _init(machine: SuitorLogic) -> void:
+		super._init(machine, NPC.RelationshipStage.SERIOUS)
+
+class EngagedState extends PreMarriageState:
+	func _init(machine: SuitorLogic) -> void:
+		super._init(machine, NPC.RelationshipStage.ENGAGED)
+
+class MarriedState extends SuitorState:
+	func update(delta: float) -> void:
+		var rate: float = max(npc.affinity, 0.0) * 0.1
+		npc.relationship_progress += rate * delta
+
+class DivorcedState extends SuitorState:
+	pass
+
+class ExState extends SuitorState:
+	pass

--- a/components/popups/suitor_view.gd
+++ b/components/popups/suitor_view.gd
@@ -157,6 +157,7 @@ func _on_next_stage_pressed() -> void:
 	logic.progress_paused = false
 	if npc.relationship_stage < NPC.RelationshipStage.MARRIED:
 		npc.relationship_stage += 1
+	logic.change_state(npc.relationship_stage)
 	_update_all()
 func _on_gift_pressed() -> void:
 	if PortfolioManager.attempt_spend(npc.gift_cost):
@@ -231,6 +232,7 @@ func _on_breakup_confirm_yes_pressed() -> void:
 		npc.relationship_stage = NPC.RelationshipStage.EX
 	npc.relationship_progress = 0.0
 	npc.affinity *= 0.2
+	logic.change_state(npc.relationship_stage)
 	logic.progress_paused = true
 	next_stage_button.visible = false
 	gift_button.disabled = true
@@ -257,6 +259,7 @@ func _on_apologize_pressed() -> void:
 	npc.relationship_progress = 0.0
 	npc.affinity = 1.0
 	logic.progress_paused = false
+	logic.change_state(npc.relationship_stage)
 	#npc.gift_cost = 25.0
 	#npc.date_cost = 200.0
 	breakup_reward = 0.0


### PR DESCRIPTION
## Summary
- Reimplemented suitor logic as a state machine with dedicated classes for each relationship stage
- Synced SuitorView with new state machine when relationship stages change

## Testing
- `godot --headless -s tests/suitor_love_test.gd` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a7a71639288325902ad01f378ac1a4