### PR TITLE
Populate AIM contacts from Daterbase

### DIFF
--- a/components/apps/alpha_instant_messenger/alpha_instant_messenger.gd
+++ b/components/apps/alpha_instant_messenger/alpha_instant_messenger.gd
@@ -1,18 +1,39 @@
 extends Pane
 class_name AlphaInstantMessenger
 
+const SUITOR_POPUP_SCENE: PackedScene = preload("res://components/popups/suitor_popup.tscn")
+
+@onready var contacts_vbox: VBoxContainer = %ContactsVBox
+@onready var contact_button_template: Button = %ContactButtonTemplate
 
 func _ready() -> void:
-	#default_window_size = Vector2(350, 420)
-	#app_title = "AIM"
-#	app_icon = preload("res://assets/Tralalero_tralala.png")
-	#emit_signal("title_updated", app_title)
+    update_ui()
+    _populate_contacts()
 
-	update_ui()
+func _populate_contacts() -> void:
+    for child in contacts_vbox.get_children():
+        if child != contact_button_template:
+            child.queue_free()
+    var entries: Array = DBManager.get_daterbase_entries()
+    for entry in entries:
+        var idx: int = int(entry.npc_id)
+        var npc: NPC = NPCManager.get_npc_by_index(idx)
+        var btn: Button = contact_button_template.duplicate()
+        btn.visible = true
+        btn.text = "@%s" % npc.username
+        btn.pressed.connect(func() -> void:
+            _open_suitor_popup(idx, npc)
+        )
+        contacts_vbox.add_child(btn)
+    contact_button_template.visible = false
 
-func _on_window_close():
-	print("closegrinder")
-	hide()
+func _open_suitor_popup(idx: int, npc: NPC) -> void:
+    var key: String = "suitor_%d" % npc.get_instance_id()
+    WindowManager.launch_popup(SUITOR_POPUP_SCENE, key, {"npc": npc, "npc_idx": idx})
 
-func update_ui():
-	pass
+func _on_window_close() -> void:
+    print("closegrinder")
+    hide()
+
+func update_ui() -> void:
+    pass

--- a/components/apps/app_scenes/alpha_instant_messenger.tscn
+++ b/components/apps/app_scenes/alpha_instant_messenger.tscn
@@ -57,12 +57,15 @@ layout_mode = 2
 layout_mode = 2
 size_flags_vertical = 3
 
-[node name="VBoxContainer" type="VBoxContainer" parent="MarginContainer/VBoxContainer/ScrollContainer"]
+[node name="ContactsVBox" type="VBoxContainer" parent="MarginContainer/VBoxContainer/ScrollContainer"]
+unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 6
 size_flags_vertical = 3
 
-[node name="Button" type="Button" parent="MarginContainer/VBoxContainer/ScrollContainer/VBoxContainer"]
+[node name="ContactButtonTemplate" type="Button" parent="MarginContainer/VBoxContainer/ScrollContainer/ContactsVBox"]
+unique_name_in_owner = true
+visible = false
 custom_minimum_size = Vector2(170, 0)
 layout_mode = 2
 focus_mode = 0
@@ -77,128 +80,7 @@ theme_override_styles/hover = SubResource("StyleBoxFlat_8iipa")
 theme_override_styles/pressed = SubResource("StyleBoxFlat_bgumh")
 theme_override_styles/normal = SubResource("StyleBoxFlat_eppfh")
 toggle_mode = true
-text = "Robert Cob
-@skazz"
-icon = ExtResource("4_bgumh")
-alignment = 0
-text_overrun_behavior = 3
-
-[node name="Button2" type="Button" parent="MarginContainer/VBoxContainer/ScrollContainer/VBoxContainer"]
-custom_minimum_size = Vector2(170, 0)
-layout_mode = 2
-focus_mode = 0
-theme_override_colors/font_disabled_color = Color(0, 0, 0, 1)
-theme_override_colors/font_hover_pressed_color = Color(0, 0, 0, 1)
-theme_override_colors/font_hover_color = Color(0, 0, 0, 1)
-theme_override_colors/font_color = Color(0, 0, 0, 1)
-theme_override_colors/font_focus_color = Color(0, 0, 0, 1)
-theme_override_colors/font_pressed_color = Color(0, 0, 0, 1)
-theme_override_styles/hover_pressed = SubResource("StyleBoxFlat_w0u3w")
-theme_override_styles/hover = SubResource("StyleBoxFlat_8iipa")
-theme_override_styles/pressed = SubResource("StyleBoxFlat_bgumh")
-theme_override_styles/normal = SubResource("StyleBoxFlat_eppfh")
-toggle_mode = true
-text = "@soyboy69"
-icon = ExtResource("4_bgumh")
-alignment = 0
-text_overrun_behavior = 3
-
-[node name="Button3" type="Button" parent="MarginContainer/VBoxContainer/ScrollContainer/VBoxContainer"]
-custom_minimum_size = Vector2(170, 0)
-layout_mode = 2
-focus_mode = 0
-theme_override_colors/font_disabled_color = Color(0, 0, 0, 1)
-theme_override_colors/font_hover_pressed_color = Color(0, 0, 0, 1)
-theme_override_colors/font_hover_color = Color(0, 0, 0, 1)
-theme_override_colors/font_color = Color(0, 0, 0, 1)
-theme_override_colors/font_focus_color = Color(0, 0, 0, 1)
-theme_override_colors/font_pressed_color = Color(0, 0, 0, 1)
-theme_override_styles/hover_pressed = SubResource("StyleBoxFlat_w0u3w")
-theme_override_styles/hover = SubResource("StyleBoxFlat_8iipa")
-theme_override_styles/pressed = SubResource("StyleBoxFlat_bgumh")
-theme_override_styles/normal = SubResource("StyleBoxFlat_eppfh")
-toggle_mode = true
-text = "@soyboy69"
-icon = ExtResource("4_bgumh")
-alignment = 0
-text_overrun_behavior = 3
-
-[node name="Button4" type="Button" parent="MarginContainer/VBoxContainer/ScrollContainer/VBoxContainer"]
-custom_minimum_size = Vector2(170, 0)
-layout_mode = 2
-focus_mode = 0
-theme_override_colors/font_disabled_color = Color(0, 0, 0, 1)
-theme_override_colors/font_hover_pressed_color = Color(0, 0, 0, 1)
-theme_override_colors/font_hover_color = Color(0, 0, 0, 1)
-theme_override_colors/font_color = Color(0, 0, 0, 1)
-theme_override_colors/font_focus_color = Color(0, 0, 0, 1)
-theme_override_colors/font_pressed_color = Color(0, 0, 0, 1)
-theme_override_styles/hover_pressed = SubResource("StyleBoxFlat_w0u3w")
-theme_override_styles/hover = SubResource("StyleBoxFlat_8iipa")
-theme_override_styles/pressed = SubResource("StyleBoxFlat_bgumh")
-theme_override_styles/normal = SubResource("StyleBoxFlat_eppfh")
-toggle_mode = true
-text = "@soyboy69"
-icon = ExtResource("4_bgumh")
-alignment = 0
-text_overrun_behavior = 3
-
-[node name="Button5" type="Button" parent="MarginContainer/VBoxContainer/ScrollContainer/VBoxContainer"]
-custom_minimum_size = Vector2(170, 0)
-layout_mode = 2
-focus_mode = 0
-theme_override_colors/font_disabled_color = Color(0, 0, 0, 1)
-theme_override_colors/font_hover_pressed_color = Color(0, 0, 0, 1)
-theme_override_colors/font_hover_color = Color(0, 0, 0, 1)
-theme_override_colors/font_color = Color(0, 0, 0, 1)
-theme_override_colors/font_focus_color = Color(0, 0, 0, 1)
-theme_override_colors/font_pressed_color = Color(0, 0, 0, 1)
-theme_override_styles/hover_pressed = SubResource("StyleBoxFlat_w0u3w")
-theme_override_styles/hover = SubResource("StyleBoxFlat_8iipa")
-theme_override_styles/pressed = SubResource("StyleBoxFlat_bgumh")
-theme_override_styles/normal = SubResource("StyleBoxFlat_eppfh")
-toggle_mode = true
-text = "@soyboy69"
-icon = ExtResource("4_bgumh")
-alignment = 0
-text_overrun_behavior = 3
-
-[node name="Button6" type="Button" parent="MarginContainer/VBoxContainer/ScrollContainer/VBoxContainer"]
-custom_minimum_size = Vector2(170, 0)
-layout_mode = 2
-focus_mode = 0
-theme_override_colors/font_disabled_color = Color(0, 0, 0, 1)
-theme_override_colors/font_hover_pressed_color = Color(0, 0, 0, 1)
-theme_override_colors/font_hover_color = Color(0, 0, 0, 1)
-theme_override_colors/font_color = Color(0, 0, 0, 1)
-theme_override_colors/font_focus_color = Color(0, 0, 0, 1)
-theme_override_colors/font_pressed_color = Color(0, 0, 0, 1)
-theme_override_styles/hover_pressed = SubResource("StyleBoxFlat_w0u3w")
-theme_override_styles/hover = SubResource("StyleBoxFlat_8iipa")
-theme_override_styles/pressed = SubResource("StyleBoxFlat_bgumh")
-theme_override_styles/normal = SubResource("StyleBoxFlat_eppfh")
-toggle_mode = true
-text = "@soyboy69"
-icon = ExtResource("4_bgumh")
-alignment = 0
-text_overrun_behavior = 3
-
-[node name="Button7" type="Button" parent="MarginContainer/VBoxContainer/ScrollContainer/VBoxContainer"]
-custom_minimum_size = Vector2(170, 0)
-layout_mode = 2
-focus_mode = 0
-theme_override_colors/font_disabled_color = Color(0, 0, 0, 1)
-theme_override_colors/font_hover_pressed_color = Color(0, 0, 0, 1)
-theme_override_colors/font_hover_color = Color(0, 0, 0, 1)
-theme_override_colors/font_color = Color(0, 0, 0, 1)
-theme_override_colors/font_focus_color = Color(0, 0, 0, 1)
-theme_override_colors/font_pressed_color = Color(0, 0, 0, 1)
-theme_override_styles/hover_pressed = SubResource("StyleBoxFlat_w0u3w")
-theme_override_styles/hover = SubResource("StyleBoxFlat_8iipa")
-theme_override_styles/pressed = SubResource("StyleBoxFlat_bgumh")
-theme_override_styles/normal = SubResource("StyleBoxFlat_eppfh")
-toggle_mode = true
-text = "@soyboy69"
+text = "@username"
 icon = ExtResource("4_bgumh")
 alignment = 0
 text_overrun_behavior = 3


### PR DESCRIPTION
## Summary
- Auto-generate Alpha Instant Messenger contact buttons from Daterbase NPCs.
- Open each NPC in Suitor view when its contact button is pressed.

## Testing
- ⚠️ `godot --headless -s tests/test_runner.gd` (command not found: godot)


------
https://chatgpt.com/codex/tasks/task_e_68a7a88650048325840284d17793dddf