### PR TITLE
refactor: unify warp shaders with color controls

### DIFF
--- a/autoloads/player_manager.gd
+++ b/autoloads/player_manager.gd
@@ -8,6 +8,9 @@ const DEFAULT_BACKGROUND_SHADERS := {
 "thing2": 0.6,
 "thing3": 0.8,
 "speed": 0.03,
+"color_low": {"r": 0.02, "g": 0.05, "b": 0.10, "a": 1.0},
+"color_mid": {"r": 0.10, "g": 0.30, "b": 0.55, "a": 1.0},
+"color_high": {"r": 0.30, "g": 0.60, "b": 0.85, "a": 1.0},
 },
 "ComicDots1": {
 "circle_color": {"r": 0.00000481308, "g": 0.665883, "b": 0.95733, "a": 1.0},

--- a/components/apps/app_scenes/broke_rage.tscn
+++ b/components/apps/app_scenes/broke_rage.tscn
@@ -4,7 +4,7 @@
 [ext_resource type="Script" uid="uid://dvxyytygay71s" path="res://components/apps/broke_rage/broke_rage_ui.gd" id="2_o2yqo"]
 [ext_resource type="Texture2D" uid="uid://sfksofhgkiwu" path="res://assets/logos/dollar_rage.png" id="3_m7phi"]
 [ext_resource type="Texture2D" uid="uid://bht5uooi8rjgf" path="res://assets/ui/buttons/grey_button_pressed.png" id="4_frira"]
-[ext_resource type="Shader" uid="uid://dugjfbyh5i7br" path="res://assets/shaders/black_warp_shader.gdshader" id="4_gnfo0"]
+[ext_resource type="Shader" uid="uid://n1vlc8cxnun0" path="res://assets/shaders/warp_shader.gdshader" id="4_gnfo0"]
 [ext_resource type="Script" uid="uid://bq3i6eu2isf1d" path="res://components/apps/broke_rage/stock_market.gd" id="5_lgac0"]
 [ext_resource type="Theme" uid="uid://dyhdr7sojcl5h" path="res://assets/windows_xp_theme.tres" id="5_n67s2"]
 [ext_resource type="Texture2D" uid="uid://bsal74mys2v4b" path="res://assets/logos/owerview_logo.png" id="6_m7phi"]
@@ -17,6 +17,7 @@ axis_stretch_horizontal = 1
 axis_stretch_vertical = 1
 
 [sub_resource type="ShaderMaterial" id="ShaderMaterial_o2yqo"]
+resource_local_to_scene = true
 shader = ExtResource("4_gnfo0")
 shader_parameter/stretch = 0.8
 shader_parameter/thing1 = 0.6
@@ -24,6 +25,9 @@ shader_parameter/thing2 = 0.6
 shader_parameter/thing3 = 0.8
 shader_parameter/scale = 1.0
 shader_parameter/speed = 0.03
+shader_parameter/color_low = Color(0, 0, 0, 1)
+shader_parameter/color_mid = Color(0.15, 0.15, 0.15, 1)
+shader_parameter/color_high = Color(0.25, 0.25, 0.25, 1)
 
 [sub_resource type="StyleBoxTexture" id="StyleBoxTexture_gnfo0"]
 texture = ExtResource("4_frira")

--- a/components/apps/app_scenes/minerr.tscn
+++ b/components/apps/app_scenes/minerr.tscn
@@ -3,11 +3,12 @@
 [ext_resource type="Script" uid="uid://c2u2e7rvja8k" path="res://components/apps/minerr/minerr_ui.gd" id="2_0t4uf"]
 [ext_resource type="PackedScene" uid="uid://cd6b75613o34u" path="res://components/apps/minerr/crypto_card.tscn" id="3_ykms3"]
 [ext_resource type="Texture2D" uid="uid://brs7oc40iion5" path="res://assets/cursors/pickaxe.png" id="4_23boj"]
-[ext_resource type="Shader" uid="uid://cn7uadn4j8e8u" path="res://assets/shaders/brown_warp_shader.gdshader" id="5_23boj"]
+[ext_resource type="Shader" uid="uid://n1vlc8cxnun0" path="res://assets/shaders/warp_shader.gdshader" id="5_23boj"]
 [ext_resource type="FontFile" uid="uid://cbjispsewggqv" path="res://assets/fonts/GALS.ttf" id="8_x88rl"]
 [ext_resource type="Theme" uid="uid://cesgvqexxaqev" path="res://assets/windows_95_theme.tres" id="9_0t4uf"]
 
 [sub_resource type="ShaderMaterial" id="ShaderMaterial_wupxk"]
+resource_local_to_scene = true
 shader = ExtResource("5_23boj")
 shader_parameter/stretch = 0.8
 shader_parameter/thing1 = 0.6
@@ -15,6 +16,9 @@ shader_parameter/thing2 = 0.6
 shader_parameter/thing3 = 0.8
 shader_parameter/scale = 1.0
 shader_parameter/speed = 0.03
+shader_parameter/color_low = Color(0.03, 0.02, 0.02, 1)
+shader_parameter/color_mid = Color(0.12, 0.08, 0.05, 1)
+shader_parameter/color_high = Color(0.35, 0.22, 0.15, 1)
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_v6dwf"]
 bg_color = Color(0, 0, 0, 1)

--- a/components/apps/app_scenes/settings.tscn
+++ b/components/apps/app_scenes/settings.tscn
@@ -2,13 +2,14 @@
 
 [ext_resource type="Script" uid="uid://byvybh3t7nbk" path="res://components/settings_window.gd" id="1_wlela"]
 [ext_resource type="Texture2D" uid="uid://c8phbkv60p2pa" path="res://assets/logos/mycog.png" id="2_wlela"]
-[ext_resource type="Shader" uid="uid://dugjfbyh5i7br" path="res://assets/shaders/black_warp_shader.gdshader" id="3_wxdtm"]
+[ext_resource type="Shader" uid="uid://n1vlc8cxnun0" path="res://assets/shaders/warp_shader.gdshader" id="3_wxdtm"]
 [ext_resource type="FontFile" uid="uid://c7qyq2f5dk3iy" path="res://assets/fonts/Monoton-Regular.ttf" id="4_a82ne"]
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_wlela"]
 bg_color = Color(0.156141, 0.265577, 0.156147, 1)
 
 [sub_resource type="ShaderMaterial" id="ShaderMaterial_a82ne"]
+resource_local_to_scene = true
 shader = ExtResource("3_wxdtm")
 shader_parameter/stretch = 0.8
 shader_parameter/thing1 = 0.6
@@ -16,6 +17,9 @@ shader_parameter/thing2 = 0.6
 shader_parameter/thing3 = 0.8
 shader_parameter/scale = 1.0
 shader_parameter/speed = 0.03
+shader_parameter/color_low = Color(0, 0, 0, 1)
+shader_parameter/color_mid = Color(0.15, 0.15, 0.15, 1)
+shader_parameter/color_high = Color(0.25, 0.25, 0.25, 1)
 
 [sub_resource type="ButtonGroup" id="ButtonGroup_jjwhp"]
 
@@ -197,6 +201,39 @@ focus_mode = 0
 theme_override_fonts/font = ExtResource("4_a82ne")
 theme_override_styles/normal = SubResource("StyleBoxFlat_a82ne")
 text = "Blue Warp"
+
+[node name="ColorRowLow" type="HBoxContainer" parent="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/BlueWarpContainer/MarginContainer/VBoxContainer"]
+layout_mode = 2
+
+[node name="Label" type="Label" parent="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/BlueWarpContainer/MarginContainer/VBoxContainer/ColorRowLow"]
+layout_mode = 2
+text = "Low"
+
+[node name="BlueWarpColorLowPicker" type="ColorPickerButton" parent="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/BlueWarpContainer/MarginContainer/VBoxContainer/ColorRowLow"]
+unique_name_in_owner = true
+layout_mode = 2
+
+[node name="ColorRowMid" type="HBoxContainer" parent="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/BlueWarpContainer/MarginContainer/VBoxContainer"]
+layout_mode = 2
+
+[node name="Label" type="Label" parent="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/BlueWarpContainer/MarginContainer/VBoxContainer/ColorRowMid"]
+layout_mode = 2
+text = "Mid"
+
+[node name="BlueWarpColorMidPicker" type="ColorPickerButton" parent="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/BlueWarpContainer/MarginContainer/VBoxContainer/ColorRowMid"]
+unique_name_in_owner = true
+layout_mode = 2
+
+[node name="ColorRowHigh" type="HBoxContainer" parent="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/BlueWarpContainer/MarginContainer/VBoxContainer"]
+layout_mode = 2
+
+[node name="Label" type="Label" parent="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/BlueWarpContainer/MarginContainer/VBoxContainer/ColorRowHigh"]
+layout_mode = 2
+text = "High"
+
+[node name="BlueWarpColorHighPicker" type="ColorPickerButton" parent="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/BlueWarpContainer/MarginContainer/VBoxContainer/ColorRowHigh"]
+unique_name_in_owner = true
+layout_mode = 2
 
 [node name="HBoxContainer" type="HBoxContainer" parent="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/BlueWarpContainer/MarginContainer/VBoxContainer"]
 layout_mode = 2
@@ -637,6 +674,9 @@ text = "Reset"
 [connection signal="toggled" from="Panel/MarginContainer/TabContainer/General/HBoxContainer/VBoxContainer2/SiggyButton" to="." method="_on_siggy_button_toggled"]
 [connection signal="pressed" from="Panel/MarginContainer/TabContainer/General/HBoxContainer/VBoxContainer2/CreateAppsFolderButton" to="." method="_on_create_apps_folder_button_pressed"]
 [connection signal="toggled" from="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/BlueWarpContainer/MarginContainer/VBoxContainer/BlueWarpButton" to="." method="_on_blue_warp_button_toggled"]
+[connection signal="color_changed" from="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/BlueWarpContainer/MarginContainer/VBoxContainer/ColorRowLow/BlueWarpColorLowPicker" to="." method="_on_blue_warp_color_low_picker_color_changed"]
+[connection signal="color_changed" from="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/BlueWarpContainer/MarginContainer/VBoxContainer/ColorRowMid/BlueWarpColorMidPicker" to="." method="_on_blue_warp_color_mid_picker_color_changed"]
+[connection signal="color_changed" from="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/BlueWarpContainer/MarginContainer/VBoxContainer/ColorRowHigh/BlueWarpColorHighPicker" to="." method="_on_blue_warp_color_high_picker_color_changed"]
 [connection signal="value_changed" from="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/BlueWarpContainer/MarginContainer/VBoxContainer/HBoxContainer/BlueWarpStretchSlider" to="." method="_on_blue_warp_stretch_slider_value_changed"]
 [connection signal="value_changed" from="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/BlueWarpContainer/MarginContainer/VBoxContainer/HBoxContainer2/BlueWarpThing1Slider" to="." method="_on_blue_warp_thing1_slider_value_changed"]
 [connection signal="value_changed" from="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/BlueWarpContainer/MarginContainer/VBoxContainer/HBoxContainer3/BlueWarpThing2Slider" to="." method="_on_blue_warp_thing2_slider_value_changed"]

--- a/components/apps/fumble/fumble.tscn
+++ b/components/apps/fumble/fumble.tscn
@@ -4,7 +4,7 @@
 [ext_resource type="PackedScene" uid="uid://dptnj8nxnr760" path="res://components/apps/fumble/fumble_special_offers.tscn" id="2_hf3uq"]
 [ext_resource type="FontFile" uid="uid://c7qyq2f5dk3iy" path="res://assets/fonts/Monoton-Regular.ttf" id="3_qj1tn"]
 [ext_resource type="PackedScene" uid="uid://duberm11i2cqq" path="res://components/npc/profile_card_stack.tscn" id="3_vq0mq"]
-[ext_resource type="Shader" uid="uid://cxfw6b7fdyskb" path="res://assets/shaders/green_warp_shader.gdshader" id="3_wfdmb"]
+[ext_resource type="Shader" uid="uid://n1vlc8cxnun0" path="res://assets/shaders/warp_shader.gdshader" id="3_wfdmb"]
 [ext_resource type="Texture2D" uid="uid://bq0jn8wlfmaae" path="res://assets/Flag_of_Turkey.svg.png" id="4_hf3uq"]
 [ext_resource type="PackedScene" uid="uid://drm1apbdsjj5g" path="res://components/portrait/portrait_view.tscn" id="5_5uoqt"]
 [ext_resource type="PackedScene" uid="uid://buvfo6k8fhu53" path="res://components/apps/fumble/chats_tab.tscn" id="5_dmsn0"]
@@ -20,6 +20,7 @@ border_width_bottom = 2
 border_color = Color(0, 0, 0, 1)
 
 [sub_resource type="ShaderMaterial" id="ShaderMaterial_jh1fk"]
+resource_local_to_scene = true
 shader = ExtResource("3_wfdmb")
 shader_parameter/stretch = 0.8
 shader_parameter/thing1 = 0.6
@@ -27,6 +28,9 @@ shader_parameter/thing2 = 0.6
 shader_parameter/thing3 = 0.8
 shader_parameter/scale = 1.0
 shader_parameter/speed = 0.03
+shader_parameter/color_low = Color(0.05, 0.1, 0.05, 1)
+shader_parameter/color_mid = Color(0.1, 0.4, 0.15, 1)
+shader_parameter/color_high = Color(0.25, 0.65, 0.3, 1)
 
 [sub_resource type="StyleBoxTexture" id="StyleBoxTexture_5fcgq"]
 texture = ExtResource("4_hf3uq")

--- a/components/apps/new_you/new_you.tscn
+++ b/components/apps/new_you/new_you.tscn
@@ -2,10 +2,11 @@
 
 [ext_resource type="Script" uid="uid://bndr8o5tre4hx" path="res://components/apps/new_you/new_you.gd" id="1"]
 [ext_resource type="PackedScene" uid="uid://bfyjk22acyf56" path="res://components/portrait/portrait_creator.tscn" id="2"]
-[ext_resource type="Shader" uid="uid://tggnnsekxdek" path="res://assets/shaders/light_blue_warp_shader.gdshader" id="2_3xhik"]
+[ext_resource type="Shader" uid="uid://n1vlc8cxnun0" path="res://assets/shaders/warp_shader.gdshader" id="2_3xhik"]
 [ext_resource type="Texture2D" uid="uid://cq21pla351uw0" path="res://assets/emojis/mirror_twemoji_x72_1fa9e.png" id="2_73mvd"]
 
 [sub_resource type="ShaderMaterial" id="ShaderMaterial_73mvd"]
+resource_local_to_scene = true
 shader = ExtResource("2_3xhik")
 shader_parameter/stretch = 0.8
 shader_parameter/thing1 = 0.6
@@ -13,6 +14,9 @@ shader_parameter/thing2 = 0.6
 shader_parameter/thing3 = 0.8
 shader_parameter/scale = 1.0
 shader_parameter/speed = 0.03
+shader_parameter/color_low = Color(0.6, 0.65, 1, 1)
+shader_parameter/color_mid = Color(0.3, 0.55, 1, 1)
+shader_parameter/color_high = Color(0.2, 0.25, 0.9, 1)
 
 [node name="NewYou" type="PanelContainer"]
 anchors_preset = 15

--- a/components/desktop_env.tscn
+++ b/components/desktop_env.tscn
@@ -7,7 +7,7 @@
 [ext_resource type="Script" uid="uid://nc5fi5e4a2r3" path="res://scripts/trauma_example.gd" id="3_5aheu"]
 [ext_resource type="Texture2D" uid="uid://crn8fnvyp4qgp" path="res://assets/logos/trashcan.png" id="3_05goa"]
 [ext_resource type="Texture2D" uid="uid://cjflmmx8qr1cg" path="res://assets/backgrounds/Bliss_(Windows_XP) (2).png" id="3_rbayd"]
-[ext_resource type="Shader" uid="uid://bow6hwdhrtw30" path="res://assets/shaders/deep_sky_blue_warp_shader.gdshader" id="4_fjtwy"]
+[ext_resource type="Shader" uid="uid://n1vlc8cxnun0" path="res://assets/shaders/warp_shader.gdshader" id="4_fjtwy"]
 [ext_resource type="Script" uid="uid://bwo1i6ejj0oqo" path="res://components/ticker.gd" id="5_g75lf"]
 [ext_resource type="Shader" uid="uid://c5g35g3kpk01d" path="res://assets/shaders/moving_circle_gradient.gdshader" id="5_yi8nh"]
 [ext_resource type="Theme" uid="uid://cesgvqexxaqev" path="res://assets/windows_95_theme.tres" id="6_bnui0"]
@@ -31,6 +31,7 @@
 [ext_resource type="Script" uid="uid://c7t01yq8wloqf" path="res://components/desktop_background.gd" id="24_jkb4t"]
 
 [sub_resource type="ShaderMaterial" id="ShaderMaterial_yi8nh"]
+resource_local_to_scene = true
 shader = ExtResource("4_fjtwy")
 shader_parameter/stretch = 0.8
 shader_parameter/thing1 = 0.6
@@ -38,6 +39,9 @@ shader_parameter/thing2 = 0.6
 shader_parameter/thing3 = 0.8
 shader_parameter/scale = 1.0
 shader_parameter/speed = 0.03
+shader_parameter/color_low = Color(0.02, 0.05, 0.1, 1)
+shader_parameter/color_mid = Color(0.1, 0.3, 0.55, 1)
+shader_parameter/color_high = Color(0.3, 0.6, 0.85, 1)
 
 [sub_resource type="ShaderMaterial" id="ShaderMaterial_ptlp0"]
 shader = ExtResource("7_ptlp0")

--- a/components/popups/suitor_popup.tscn
+++ b/components/popups/suitor_popup.tscn
@@ -3,11 +3,12 @@
 [ext_resource type="Theme" uid="uid://cesgvqexxaqev" path="res://assets/windows_95_theme.tres" id="1"]
 [ext_resource type="Script" uid="uid://d1rk5ob1oyitb" path="res://components/popups/suitor_view.gd" id="2"]
 [ext_resource type="Script" uid="uid://qeyobl0rg2cy" path="res://components/apps/fumble/stat_progress_bar.gd" id="3"]
-[ext_resource type="Shader" uid="uid://bfgsgplah4us" path="res://assets/shaders/white_warp_shader.gdshader" id="3_vl6ok"]
+[ext_resource type="Shader" uid="uid://n1vlc8cxnun0" path="res://assets/shaders/warp_shader.gdshader" id="3_vl6ok"]
 [ext_resource type="PackedScene" uid="uid://drm1apbdsjj5g" path="res://components/portrait/portrait_view.tscn" id="4"]
 [ext_resource type="Script" uid="uid://bvbiboe20qioe" path="res://components/popups/relationship_bar.gd" id="5"]
 
 [sub_resource type="ShaderMaterial" id="ShaderMaterial_78wgo"]
+resource_local_to_scene = true
 shader = ExtResource("3_vl6ok")
 shader_parameter/stretch = 0.8
 shader_parameter/thing1 = 0.6
@@ -15,6 +16,9 @@ shader_parameter/thing2 = 0.6
 shader_parameter/thing3 = 0.8
 shader_parameter/scale = 1.0
 shader_parameter/speed = 0.03
+shader_parameter/color_low = Color(1, 0.98, 0.94, 1)
+shader_parameter/color_mid = Color(1, 0.99, 0.99, 1)
+shader_parameter/color_high = Color(0.95, 0.95, 0.96, 1)
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_edh50"]
 bg_color = Color(0.0846899, 0.0846899, 0.0846899, 1)

--- a/components/settings_window.gd
+++ b/components/settings_window.gd
@@ -21,6 +21,9 @@ extends Pane
 @onready var blue_warp_thing2_slider: HSlider = %BlueWarpThing2Slider
 @onready var blue_warp_thing3_slider: HSlider = %BlueWarpThing3Slider
 @onready var blue_warp_speed_slider: HSlider = %BlueWarpSpeedSlider
+@onready var blue_warp_color_low_picker: ColorPickerButton = %BlueWarpColorLowPicker
+@onready var blue_warp_color_mid_picker: ColorPickerButton = %BlueWarpColorMidPicker
+@onready var blue_warp_color_high_picker: ColorPickerButton = %BlueWarpColorHighPicker
 @onready var comic_dots1_color_picker: ColorPickerButton = %ComicDots1ColorPicker
 @onready var comic_dots1_multiplier_slider: HSlider = %ComicDots1MultiplierSlider
 @onready var comic_dots1_speed_slider: HSlider = %ComicDots1SpeedSlider
@@ -43,6 +46,8 @@ extends Pane
 @onready var comic_dots2_shader_material: ShaderMaterial = get_tree().root.get_node("Main/DesktopEnv/ShaderBackgroundsContainer/ComicDotsBlueHor").material
 @onready var electric_shader_material: ShaderMaterial = get_tree().root.get_node("Main/DesktopEnv/ShaderBackgroundsContainer/ElectricShader").material
 
+var warp_shader_materials: Array[ShaderMaterial] = []
+
 func setup_custom(tab_name: String) -> void:
 		if tab_name == "Backgrounds":
 				var tab = tab_container.get_node_or_null("Backgrounds")
@@ -61,22 +66,27 @@ func _ready() -> void:
 	autosave_check_box.button_pressed = TimeManager.autosave_enabled
 	_update_autosave_timer_label()
 	TimeManager.minute_passed.connect(_on_minute_passed)
-	blue_warp_button.button_pressed = Events.is_desktop_background_visible("BlueWarp")
-	comic_dots1_button.button_pressed = Events.is_desktop_background_visible("ComicDots1")
-	comic_dots2_button.button_pressed = Events.is_desktop_background_visible("ComicDots2")
-	waves_button.button_pressed = Events.is_desktop_background_visible("Waves")
-	bottom_color_picker.color = waves_shader_material.get_shader_parameter("bottom_color")
-	top_color_picker.color = waves_shader_material.get_shader_parameter("top_color")
+        blue_warp_button.button_pressed = Events.is_desktop_background_visible("BlueWarp")
+        comic_dots1_button.button_pressed = Events.is_desktop_background_visible("ComicDots1")
+        comic_dots2_button.button_pressed = Events.is_desktop_background_visible("ComicDots2")
+        waves_button.button_pressed = Events.is_desktop_background_visible("Waves")
+        _refresh_warp_shader_materials()
+        get_tree().node_added.connect(_on_node_added)
+        bottom_color_picker.color = waves_shader_material.get_shader_parameter("bottom_color")
+        top_color_picker.color = waves_shader_material.get_shader_parameter("top_color")
 	wave_amp_slider.value = waves_shader_material.get_shader_parameter("wave_amp")
 	wave_size_slider.value = waves_shader_material.get_shader_parameter("wave_size")
 	wave_time_mul_slider.value = waves_shader_material.get_shader_parameter("wave_time_mul")
 	total_phases_slider.value = waves_shader_material.get_shader_parameter("total_phases")
-	blue_warp_stretch_slider.value = blue_warp_shader_material.get_shader_parameter("stretch")
-	blue_warp_thing1_slider.value = blue_warp_shader_material.get_shader_parameter("thing1")
-	blue_warp_thing2_slider.value = blue_warp_shader_material.get_shader_parameter("thing2")
-	blue_warp_thing3_slider.value = blue_warp_shader_material.get_shader_parameter("thing3")
-	blue_warp_speed_slider.value = blue_warp_shader_material.get_shader_parameter("speed")
-	comic_dots1_color_picker.color = comic_dots1_shader_material.get_shader_parameter("circle_color")
+        blue_warp_stretch_slider.value = blue_warp_shader_material.get_shader_parameter("stretch")
+        blue_warp_thing1_slider.value = blue_warp_shader_material.get_shader_parameter("thing1")
+        blue_warp_thing2_slider.value = blue_warp_shader_material.get_shader_parameter("thing2")
+        blue_warp_thing3_slider.value = blue_warp_shader_material.get_shader_parameter("thing3")
+        blue_warp_speed_slider.value = blue_warp_shader_material.get_shader_parameter("speed")
+        blue_warp_color_low_picker.color = blue_warp_shader_material.get_shader_parameter("color_low")
+        blue_warp_color_mid_picker.color = blue_warp_shader_material.get_shader_parameter("color_mid")
+        blue_warp_color_high_picker.color = blue_warp_shader_material.get_shader_parameter("color_high")
+        comic_dots1_color_picker.color = comic_dots1_shader_material.get_shader_parameter("circle_color")
 	comic_dots1_multiplier_slider.value = comic_dots1_shader_material.get_shader_parameter("circle_multiplier")
 	comic_dots1_speed_slider.value = comic_dots1_shader_material.get_shader_parameter("speed")
 	comic_dots2_color_picker.color = comic_dots2_shader_material.get_shader_parameter("circle_color")
@@ -89,8 +99,36 @@ func _ready() -> void:
 	electric_height_slider.value = electric_shader_material.get_shader_parameter("height")
 	electric_speed_slider.value = electric_shader_material.get_shader_parameter("speed")
 	var electric_scale: Vector2 = electric_shader_material.get_shader_parameter("scale")
-	electric_scale_x_slider.value = electric_scale.x
-	electric_scale_y_slider.value = electric_scale.y
+        electric_scale_x_slider.value = electric_scale.x
+        electric_scale_y_slider.value = electric_scale.y
+
+func _refresh_warp_shader_materials() -> void:
+        warp_shader_materials.clear()
+        _collect_warp_shader_materials(get_tree().root)
+
+func _collect_warp_shader_materials(node: Node) -> void:
+        if node is CanvasItem:
+                var mat = node.material
+                if mat is ShaderMaterial and mat.shader and mat.shader.resource_path.ends_with("warp_shader.gdshader"):
+                        if mat not in warp_shader_materials:
+                                warp_shader_materials.append(mat)
+                                _apply_saved_params_to_material(mat)
+        for child in node.get_children():
+                _collect_warp_shader_materials(child)
+
+func _on_node_added(node: Node) -> void:
+        _collect_warp_shader_materials(node)
+
+func _apply_saved_params_to_material(mat: ShaderMaterial) -> void:
+        var d = PlayerManager.DEFAULT_BACKGROUND_SHADERS["BlueWarp"]
+        mat.set_shader_parameter("stretch", PlayerManager.get_shader_param("BlueWarp", "stretch", d["stretch"]))
+        mat.set_shader_parameter("thing1", PlayerManager.get_shader_param("BlueWarp", "thing1", d["thing1"]))
+        mat.set_shader_parameter("thing2", PlayerManager.get_shader_param("BlueWarp", "thing2", d["thing2"]))
+        mat.set_shader_parameter("thing3", PlayerManager.get_shader_param("BlueWarp", "thing3", d["thing3"]))
+        mat.set_shader_parameter("speed", PlayerManager.get_shader_param("BlueWarp", "speed", d["speed"]))
+        mat.set_shader_parameter("color_low", PlayerManager.get_shader_param("BlueWarp", "color_low", PlayerManager.dict_to_color(d["color_low"])))
+        mat.set_shader_parameter("color_mid", PlayerManager.get_shader_param("BlueWarp", "color_mid", PlayerManager.dict_to_color(d["color_mid"])))
+        mat.set_shader_parameter("color_high", PlayerManager.get_shader_param("BlueWarp", "color_high", PlayerManager.dict_to_color(d["color_high"])))
 
 func update_checked_mode() -> void:
 	var mode = DisplayServer.window_get_mode()
@@ -172,24 +210,44 @@ func _on_total_phases_slider_value_changed(value: float) -> void:
 	PlayerManager.set_shader_param("Waves", "total_phases", value)
 
 func _on_blue_warp_stretch_slider_value_changed(value: float) -> void:
-	blue_warp_shader_material.set_shader_parameter("stretch", value)
-	PlayerManager.set_shader_param("BlueWarp", "stretch", value)
+        for mat in warp_shader_materials:
+                mat.set_shader_parameter("stretch", value)
+        PlayerManager.set_shader_param("BlueWarp", "stretch", value)
 
 func _on_blue_warp_thing1_slider_value_changed(value: float) -> void:
-	blue_warp_shader_material.set_shader_parameter("thing1", value)
-	PlayerManager.set_shader_param("BlueWarp", "thing1", value)
+        for mat in warp_shader_materials:
+                mat.set_shader_parameter("thing1", value)
+        PlayerManager.set_shader_param("BlueWarp", "thing1", value)
 
 func _on_blue_warp_thing2_slider_value_changed(value: float) -> void:
-	blue_warp_shader_material.set_shader_parameter("thing2", value)
-	PlayerManager.set_shader_param("BlueWarp", "thing2", value)
+        for mat in warp_shader_materials:
+                mat.set_shader_parameter("thing2", value)
+        PlayerManager.set_shader_param("BlueWarp", "thing2", value)
 
 func _on_blue_warp_thing3_slider_value_changed(value: float) -> void:
-	blue_warp_shader_material.set_shader_parameter("thing3", value)
-	PlayerManager.set_shader_param("BlueWarp", "thing3", value)
+        for mat in warp_shader_materials:
+                mat.set_shader_parameter("thing3", value)
+        PlayerManager.set_shader_param("BlueWarp", "thing3", value)
 
 func _on_blue_warp_speed_slider_value_changed(value: float) -> void:
-	blue_warp_shader_material.set_shader_parameter("speed", value)
-	PlayerManager.set_shader_param("BlueWarp", "speed", value)
+        for mat in warp_shader_materials:
+                mat.set_shader_parameter("speed", value)
+        PlayerManager.set_shader_param("BlueWarp", "speed", value)
+
+func _on_blue_warp_color_low_picker_color_changed(color: Color) -> void:
+        for mat in warp_shader_materials:
+                mat.set_shader_parameter("color_low", color)
+        PlayerManager.set_shader_param("BlueWarp", "color_low", color)
+
+func _on_blue_warp_color_mid_picker_color_changed(color: Color) -> void:
+        for mat in warp_shader_materials:
+                mat.set_shader_parameter("color_mid", color)
+        PlayerManager.set_shader_param("BlueWarp", "color_mid", color)
+
+func _on_blue_warp_color_high_picker_color_changed(color: Color) -> void:
+        for mat in warp_shader_materials:
+                mat.set_shader_parameter("color_high", color)
+        PlayerManager.set_shader_param("BlueWarp", "color_high", color)
 
 func _on_comic_dots_1_color_picker_color_changed(color: Color) -> void:
 	comic_dots1_shader_material.set_shader_parameter("circle_color", color)
@@ -269,18 +327,25 @@ func _on_waves_reset_button_pressed() -> void:
 		total_phases_slider.value = d["total_phases"]
 
 func _on_blue_warp_reset_button_pressed() -> void:
-		PlayerManager.reset_shader("BlueWarp")
-		var d = PlayerManager.DEFAULT_BACKGROUND_SHADERS["BlueWarp"]
-		blue_warp_shader_material.set_shader_parameter("stretch", d["stretch"])
-		blue_warp_shader_material.set_shader_parameter("thing1", d["thing1"])
-		blue_warp_shader_material.set_shader_parameter("thing2", d["thing2"])
-		blue_warp_shader_material.set_shader_parameter("thing3", d["thing3"])
-		blue_warp_shader_material.set_shader_parameter("speed", d["speed"])
-		blue_warp_stretch_slider.value = d["stretch"]
-		blue_warp_thing1_slider.value = d["thing1"]
-		blue_warp_thing2_slider.value = d["thing2"]
-		blue_warp_thing3_slider.value = d["thing3"]
-		blue_warp_speed_slider.value = d["speed"]
+                PlayerManager.reset_shader("BlueWarp")
+                var d = PlayerManager.DEFAULT_BACKGROUND_SHADERS["BlueWarp"]
+                for mat in warp_shader_materials:
+                                mat.set_shader_parameter("stretch", d["stretch"])
+                                mat.set_shader_parameter("thing1", d["thing1"])
+                                mat.set_shader_parameter("thing2", d["thing2"])
+                                mat.set_shader_parameter("thing3", d["thing3"])
+                                mat.set_shader_parameter("speed", d["speed"])
+                                mat.set_shader_parameter("color_low", PlayerManager.dict_to_color(d["color_low"]))
+                                mat.set_shader_parameter("color_mid", PlayerManager.dict_to_color(d["color_mid"]))
+                                mat.set_shader_parameter("color_high", PlayerManager.dict_to_color(d["color_high"]))
+                blue_warp_stretch_slider.value = d["stretch"]
+                blue_warp_thing1_slider.value = d["thing1"]
+                blue_warp_thing2_slider.value = d["thing2"]
+                blue_warp_thing3_slider.value = d["thing3"]
+                blue_warp_speed_slider.value = d["speed"]
+                blue_warp_color_low_picker.color = PlayerManager.dict_to_color(d["color_low"])
+                blue_warp_color_mid_picker.color = PlayerManager.dict_to_color(d["color_mid"])
+                blue_warp_color_high_picker.color = PlayerManager.dict_to_color(d["color_high"])
 
 func _on_comic_dots_1_reset_button_pressed() -> void:
 				PlayerManager.reset_shader("ComicDots1")

--- a/components/ui/profile_creation/background_selection_screen.tscn
+++ b/components/ui/profile_creation/background_selection_screen.tscn
@@ -7,92 +7,22 @@
 [ext_resource type="Texture2D" uid="uid://v4keep3vdsqt" path="res://assets/backgrounds/greenfieldpinkskyx480.png" id="5_eudh7"]
 [ext_resource type="Texture2D" uid="uid://f3id4mqiae6r" path="res://assets/backgrounds/purplefieldgreenskyx480_restrictive.png" id="6_tl8c1"]
 [ext_resource type="Texture2D" uid="uid://dnlhdvhhmjukf" path="res://assets/backgrounds/chairpaula-schmidtx480_adaptive.png" id="7_xt10x"]
+[ext_resource type="Shader" uid="uid://n1vlc8cxnun0" path="res://assets/shaders/warp_shader.gdshader" id="8_warp"]
 [ext_resource type="Shader" uid="uid://t13ojurwyi0y" path="res://assets/shaders/discrete_ocean_waves_shader.gdshader" id="9_waves"]
 [ext_resource type="Shader" uid="uid://d1ls4o7a32m4b" path="res://assets/shaders/electric_wiring_shader.gdshader" id="10_electric"]
 
-[sub_resource type="Shader" id="Shader_rlyer"]
-code = "shader_type canvas_item;
-
-// --- Controls ---
-uniform float stretch : hint_range(0.0, 100.0, 0.1) = 0.8;
-uniform float thing1  : hint_range(0.0, 100.0, 0.1) = 0.6;
-uniform float thing2  : hint_range(0.0, 100.0, 0.1) = 0.6;
-uniform float thing3  : hint_range(0.0, 100.0, 0.1) = 0.8;
-
-uniform float scale   : hint_range(0.000, 100.0, 0.001) = 1.0;
-uniform float speed   : hint_range(0.0, 5.0, 0.01) = 1.0;
-
-// --- Custom deep sky-blue colormap ---
-vec3 colormap(float x) {
-    float t = clamp(x, 0.0, 1.0);
-
-    // deep, moody sky blues
-    vec3 midnight_blue = vec3(0.02, 0.05, 0.10); // near-black blue
-    vec3 deep_sky      = vec3(0.05, 0.15, 0.30); // deep sky blue
-    vec3 mid_sky       = vec3(0.10, 0.30, 0.55); // saturated sky blue
-    vec3 bright_sky    = vec3(0.30, 0.60, 0.85); // highlight blue
-
-    if (t < 0.33) {
-        return mix(midnight_blue, deep_sky, t / 0.33);
-    } else if (t < 0.66) {
-        return mix(deep_sky, mid_sky, (t - 0.33) / 0.33);
-    } else {
-        return mix(mid_sky, bright_sky, (t - 0.66) / 0.34);
-    }
-}
-
-// --- Noise helpers ---
-float rand(vec2 n) {
-    return fract(sin(dot(n, vec2(12.9898, 4.1414))) * 43758.5453);
-}
-
-float noise(vec2 p) {
-    vec2 ip = floor(p);
-    vec2 u = fract(p);
-    u = u * u * (3.0 - 2.0 * u);
-
-    float res = mix(
-        mix(rand(ip), rand(ip + vec2(1.0, 0.0)), u.x),
-        mix(rand(ip + vec2(0.0, 1.0)), rand(ip + vec2(1.0, 1.0)), u.x),
-        u.y
-    );
-    return res * res;
-}
-
-// --- Core patterns ---
-float fbm(vec2 p) {
-    float t = TIME * speed;
-    float f = 0.0;
-    mat2 mtx = mat2(vec2(stretch, thing1), vec2(-thing2, thing3));
-    f += 0.500000 * noise(p + t); p = mtx * p * 2.02;
-    f += 0.031250 * noise(p);     p = mtx * p * 2.01;
-    f += 0.250000 * noise(p);     p = mtx * p * 2.03;
-    f += 0.125000 * noise(p);     p = mtx * p * 2.01;
-    f += 0.062500 * noise(p);     p = mtx * p * 2.04;
-    f += 0.015625 * noise(p + sin(t));
-    return f / 0.96875;
-}
-
-float pattern(vec2 p) {
-    return fbm(p + fbm(p + fbm(p)));
-}
-
-void fragment() {
-    vec2 uv = FRAGCOORD.xy / (scale / SCREEN_PIXEL_SIZE).y;
-    float shade = pattern(uv);
-    vec3 color = colormap(shade);
-    COLOR = vec4(color, 1.0);
-}
-"
-
 [sub_resource type="ShaderMaterial" id="ShaderMaterial_BlueWarp"]
-shader = SubResource("Shader_rlyer")
+resource_local_to_scene = true
+shader = ExtResource("8_warp")
 shader_parameter/stretch = 0.8
 shader_parameter/thing1 = 0.6
 shader_parameter/thing2 = 0.6
 shader_parameter/thing3 = 0.8
 shader_parameter/scale = 1.0
 shader_parameter/speed = 0.29
+shader_parameter/color_low = Color(0.02, 0.05, 0.1, 1)
+shader_parameter/color_mid = Color(0.1, 0.3, 0.55, 1)
+shader_parameter/color_high = Color(0.3, 0.6, 0.85, 1)
 
 [sub_resource type="ShaderMaterial" id="ShaderMaterial_Waves"]
 shader = ExtResource("9_waves")

--- a/scripts/desktop_env.gd
+++ b/scripts/desktop_env.gd
@@ -71,12 +71,15 @@ func _apply_shader_settings() -> void:
 	waves_shader_material.set_shader_parameter("wave_time_mul", wave_time_mul)
 	waves_shader_material.set_shader_parameter("total_phases", total_phases)
 
-	var bw_def = defaults["BlueWarp"]
-	blue_warp_shader_material.set_shader_parameter("stretch", PlayerManager.get_shader_param("BlueWarp", "stretch", bw_def["stretch"]))
-	blue_warp_shader_material.set_shader_parameter("thing1", PlayerManager.get_shader_param("BlueWarp", "thing1", bw_def["thing1"]))
-	blue_warp_shader_material.set_shader_parameter("thing2", PlayerManager.get_shader_param("BlueWarp", "thing2", bw_def["thing2"]))
-	blue_warp_shader_material.set_shader_parameter("thing3", PlayerManager.get_shader_param("BlueWarp", "thing3", bw_def["thing3"]))
-	blue_warp_shader_material.set_shader_parameter("speed", PlayerManager.get_shader_param("BlueWarp", "speed", bw_def["speed"]))
+        var bw_def = defaults["BlueWarp"]
+        blue_warp_shader_material.set_shader_parameter("stretch", PlayerManager.get_shader_param("BlueWarp", "stretch", bw_def["stretch"]))
+        blue_warp_shader_material.set_shader_parameter("thing1", PlayerManager.get_shader_param("BlueWarp", "thing1", bw_def["thing1"]))
+        blue_warp_shader_material.set_shader_parameter("thing2", PlayerManager.get_shader_param("BlueWarp", "thing2", bw_def["thing2"]))
+        blue_warp_shader_material.set_shader_parameter("thing3", PlayerManager.get_shader_param("BlueWarp", "thing3", bw_def["thing3"]))
+        blue_warp_shader_material.set_shader_parameter("speed", PlayerManager.get_shader_param("BlueWarp", "speed", bw_def["speed"]))
+        blue_warp_shader_material.set_shader_parameter("color_low", PlayerManager.get_shader_param("BlueWarp", "color_low", PlayerManager.dict_to_color(bw_def["color_low"])))
+        blue_warp_shader_material.set_shader_parameter("color_mid", PlayerManager.get_shader_param("BlueWarp", "color_mid", PlayerManager.dict_to_color(bw_def["color_mid"])))
+        blue_warp_shader_material.set_shader_parameter("color_high", PlayerManager.get_shader_param("BlueWarp", "color_high", PlayerManager.dict_to_color(bw_def["color_high"])))
 
 	var cd1_def = defaults["ComicDots1"]
 	var cd1_color = PlayerManager.get_shader_param("ComicDots1", "circle_color", PlayerManager.dict_to_color(cd1_def["circle_color"]))


### PR DESCRIPTION
## Summary
- replace color-specific warp shaders with generic `warp_shader`
- expose color settings for warp shaders in settings window
- apply warp shader parameters to all instances at runtime

## Testing
- `godot --headless -s tests/test_runner.gd` *(fails: command not found: godot)*

------
https://chatgpt.com/codex/tasks/task_e_68a7ad7b5d9c8325a752f213c6599c96