### PR TITLE
Ensure SuitorView affinity updates automatically

### DIFF
--- a/components/popups/suitor_view.gd
+++ b/components/popups/suitor_view.gd
@@ -55,6 +55,7 @@ func _ready() -> void:
 	breakup_confirm_yes_button.pressed.connect(_on_breakup_confirm_yes_pressed)
 	breakup_confirm_no_button.pressed.connect(_on_breakup_confirm_no_pressed)
 	love_button.pressed.connect(_on_love_pressed)
+	NPCManager.affinity_changed.connect(_on_npc_affinity_changed)
 	
 	await get_tree().process_frame
 	if Events.has_signal("fumble_talk_therapy_purchased"):
@@ -152,6 +153,12 @@ func _update_love_button() -> void:
 	else:
 			love_button.disabled = false
 			love_cooldown_label.visible = false
+func _on_npc_affinity_changed(idx: int, value: float) -> void:
+	if idx != npc_idx:
+		return
+	npc.affinity = value
+	_update_affinity_bar()
+
 func _on_next_stage_pressed() -> void:
 	next_stage_button.visible = false
 	logic.progress_paused = false


### PR DESCRIPTION
## Summary
- Refresh affinity bar in SuitorView when NPC affinity changes

## Testing
- `godot4 --headless -s tests/test_runner.gd` *(fails: script doesn't inherit from SceneTree or MainLoop)*
- `/tmp/godot/Godot_v4.2.1-stable_linux.x86_64 --headless tests/test_runner.tscn` *(fails: numerous parse errors and missing resources)*

------
https://chatgpt.com/codex/tasks/task_e_68a7b13d52088325b303501a83cfbc66