### PR TITLE
Limit wave total phases to 100 in settings slider

### DIFF
--- a/components/apps/app_scenes/settings.tscn
+++ b/components/apps/app_scenes/settings.tscn
@@ -416,7 +416,7 @@ unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 3
 min_value = 2.0
-max_value = 600.0
+max_value = 100.0
 value = 6.0
 
 [node name="WavesResetButton" type="Button" parent="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/WavesContainer/MarginContainer/VBoxContainer"]


### PR DESCRIPTION
## Summary
- Limit TotalPhasesSlider maximum to 100 so warp shader's total_phases caps at 100 when slider maxed

## Testing
- `godot3-server --headless -s tests/test_runner.gd` *(fails: project requires newer Godot version)*

------
https://chatgpt.com/codex/tasks/task_e_68a7b6e1c6bc8325875588fcc45a1978