### PR TITLE
feat: introduce shader controller module

### DIFF
--- a/components/apps/app_scenes/settings.tscn
+++ b/components/apps/app_scenes/settings.tscn
@@ -4,6 +4,7 @@
 [ext_resource type="Texture2D" uid="uid://c8phbkv60p2pa" path="res://assets/logos/mycog.png" id="2_wlela"]
 [ext_resource type="Shader" uid="uid://n1vlc8cxnun0" path="res://assets/shaders/warp_shader.gdshader" id="3_wxdtm"]
 [ext_resource type="FontFile" uid="uid://c7qyq2f5dk3iy" path="res://assets/fonts/Monoton-Regular.ttf" id="4_a82ne"]
+[ext_resource type="Script" path="res://components/shader_controller_module.gd" id="5_p2fk4"]
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_wlela"]
 bg_color = Color(0.156141, 0.265577, 0.156147, 1)
@@ -182,6 +183,15 @@ layout_mode = 2
 layout_mode = 2
 size_flags_horizontal = 6
 mouse_filter = 1
+script = ExtResource("5_p2fk4")
+shader_name = "BlueWarp"
+collect_warp_shaders = true
+toggle_button_path = NodePath("MarginContainer/VBoxContainer/BlueWarpButton")
+reset_button_path = NodePath("MarginContainer/VBoxContainer/BlueWarpResetButton")
+slider_nodes = [NodePath("MarginContainer/VBoxContainer/HBoxContainer/BlueWarpStretchSlider"), NodePath("MarginContainer/VBoxContainer/HBoxContainer2/BlueWarpThing1Slider"), NodePath("MarginContainer/VBoxContainer/HBoxContainer3/BlueWarpThing2Slider"), NodePath("MarginContainer/VBoxContainer/HBoxContainer4/BlueWarpThing3Slider"), NodePath("MarginContainer/VBoxContainer/HBoxContainer5/BlueWarpSpeedSlider")]
+slider_params = ["stretch", "thing1", "thing2", "thing3", "speed"]
+color_picker_nodes = [NodePath("MarginContainer/VBoxContainer/ColorRowLow/BlueWarpColorLowPicker"), NodePath("MarginContainer/VBoxContainer/ColorRowMid/BlueWarpColorMidPicker"), NodePath("MarginContainer/VBoxContainer/ColorRowHigh/BlueWarpColorHighPicker")]
+color_picker_params = ["color_low", "color_mid", "color_high"]
 
 [node name="MarginContainer" type="MarginContainer" parent="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/BlueWarpContainer"]
 layout_mode = 2
@@ -677,16 +687,6 @@ text = "Reset"
 
 [connection signal="toggled" from="Panel/MarginContainer/TabContainer/General/HBoxContainer/VBoxContainer2/SiggyButton" to="." method="_on_siggy_button_toggled"]
 [connection signal="pressed" from="Panel/MarginContainer/TabContainer/General/HBoxContainer/VBoxContainer2/CreateAppsFolderButton" to="." method="_on_create_apps_folder_button_pressed"]
-[connection signal="toggled" from="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/BlueWarpContainer/MarginContainer/VBoxContainer/BlueWarpButton" to="." method="_on_blue_warp_button_toggled"]
-[connection signal="color_changed" from="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/BlueWarpContainer/MarginContainer/VBoxContainer/ColorRowLow/BlueWarpColorLowPicker" to="." method="_on_blue_warp_color_low_picker_color_changed"]
-[connection signal="color_changed" from="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/BlueWarpContainer/MarginContainer/VBoxContainer/ColorRowMid/BlueWarpColorMidPicker" to="." method="_on_blue_warp_color_mid_picker_color_changed"]
-[connection signal="color_changed" from="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/BlueWarpContainer/MarginContainer/VBoxContainer/ColorRowHigh/BlueWarpColorHighPicker" to="." method="_on_blue_warp_color_high_picker_color_changed"]
-[connection signal="value_changed" from="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/BlueWarpContainer/MarginContainer/VBoxContainer/HBoxContainer/BlueWarpStretchSlider" to="." method="_on_blue_warp_stretch_slider_value_changed"]
-[connection signal="value_changed" from="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/BlueWarpContainer/MarginContainer/VBoxContainer/HBoxContainer2/BlueWarpThing1Slider" to="." method="_on_blue_warp_thing1_slider_value_changed"]
-[connection signal="value_changed" from="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/BlueWarpContainer/MarginContainer/VBoxContainer/HBoxContainer3/BlueWarpThing2Slider" to="." method="_on_blue_warp_thing2_slider_value_changed"]
-[connection signal="value_changed" from="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/BlueWarpContainer/MarginContainer/VBoxContainer/HBoxContainer4/BlueWarpThing3Slider" to="." method="_on_blue_warp_thing3_slider_value_changed"]
-[connection signal="value_changed" from="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/BlueWarpContainer/MarginContainer/VBoxContainer/HBoxContainer5/BlueWarpSpeedSlider" to="." method="_on_blue_warp_speed_slider_value_changed"]
-[connection signal="pressed" from="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/BlueWarpContainer/MarginContainer/VBoxContainer/BlueWarpResetButton" to="." method="_on_blue_warp_reset_button_pressed"]
 [connection signal="toggled" from="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/WavesContainer/MarginContainer/VBoxContainer/WavesButton" to="." method="_on_waves_button_toggled"]
 [connection signal="color_changed" from="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/WavesContainer/MarginContainer/VBoxContainer/HBoxContainer/BottomColorPicker" to="." method="_on_bottom_color_picker_color_changed"]
 [connection signal="color_changed" from="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/WavesContainer/MarginContainer/VBoxContainer/HBoxContainer/TopColorPicker" to="." method="_on_top_color_picker_color_changed"]

--- a/components/settings_window.gd
+++ b/components/settings_window.gd
@@ -6,7 +6,6 @@ extends Pane
 @onready var autosave_check_box: CheckBox = %AutosaveCheckBox
 @onready var autosave_timer_label: Label = %AutosaveTimerLabel
 
-@onready var blue_warp_button: CheckButton = %BlueWarpButton
 @onready var comic_dots1_button: CheckButton = %ComicDots1Button
 @onready var comic_dots2_button: CheckButton = %ComicDots2Button
 @onready var waves_button: CheckButton = %WavesButton
@@ -16,14 +15,6 @@ extends Pane
 @onready var wave_size_slider: HSlider = %WaveSizeSlider
 @onready var wave_time_mul_slider: HSlider = %WaveTimeMulSlider
 @onready var total_phases_slider: HSlider = %TotalPhasesSlider
-@onready var blue_warp_stretch_slider: HSlider = %BlueWarpStretchSlider
-@onready var blue_warp_thing1_slider: HSlider = %BlueWarpThing1Slider
-@onready var blue_warp_thing2_slider: HSlider = %BlueWarpThing2Slider
-@onready var blue_warp_thing3_slider: HSlider = %BlueWarpThing3Slider
-@onready var blue_warp_speed_slider: HSlider = %BlueWarpSpeedSlider
-@onready var blue_warp_color_low_picker: ColorPickerButton = %BlueWarpColorLowPicker
-@onready var blue_warp_color_mid_picker: ColorPickerButton = %BlueWarpColorMidPicker
-@onready var blue_warp_color_high_picker: ColorPickerButton = %BlueWarpColorHighPicker
 @onready var comic_dots1_color_picker: ColorPickerButton = %ComicDots1ColorPicker
 @onready var comic_dots1_multiplier_slider: HSlider = %ComicDots1MultiplierSlider
 @onready var comic_dots1_speed_slider: HSlider = %ComicDots1SpeedSlider
@@ -41,12 +32,9 @@ extends Pane
 @onready var tab_container: TabContainer = %TabContainer
 @onready var create_apps_folder_button: Button = %CreateAppsFolderButton
 @onready var waves_shader_material: ShaderMaterial = get_tree().root.get_node("Main/DesktopEnv/ShaderBackgroundsContainer/WavesShader").material
-@onready var blue_warp_shader_material: ShaderMaterial = get_tree().root.get_node("Main/DesktopEnv/ShaderBackgroundsContainer/BlueWarpShader").material
 @onready var comic_dots1_shader_material: ShaderMaterial = get_tree().root.get_node("Main/DesktopEnv/ShaderBackgroundsContainer/ComicDotsBlueVert").material
 @onready var comic_dots2_shader_material: ShaderMaterial = get_tree().root.get_node("Main/DesktopEnv/ShaderBackgroundsContainer/ComicDotsBlueHor").material
 @onready var electric_shader_material: ShaderMaterial = get_tree().root.get_node("Main/DesktopEnv/ShaderBackgroundsContainer/ElectricShader").material
-
-var warp_shader_materials: Array[ShaderMaterial] = []
 
 func setup_custom(tab_name: String) -> void:
 		if tab_name == "Backgrounds":
@@ -66,29 +54,18 @@ func _ready() -> void:
 	autosave_check_box.button_pressed = TimeManager.autosave_enabled
 	_update_autosave_timer_label()
 	TimeManager.minute_passed.connect(_on_minute_passed)
-	blue_warp_button.button_pressed = Events.is_desktop_background_visible("BlueWarp")
-	comic_dots1_button.button_pressed = Events.is_desktop_background_visible("ComicDots1")
-	comic_dots2_button.button_pressed = Events.is_desktop_background_visible("ComicDots2")
-	waves_button.button_pressed = Events.is_desktop_background_visible("Waves")
-	_refresh_warp_shader_materials()
-	get_tree().node_added.connect(_on_node_added)
+        comic_dots1_button.button_pressed = Events.is_desktop_background_visible("ComicDots1")
+        comic_dots2_button.button_pressed = Events.is_desktop_background_visible("ComicDots2")
+        waves_button.button_pressed = Events.is_desktop_background_visible("Waves")
 	bottom_color_picker.color = waves_shader_material.get_shader_parameter("bottom_color")
 	top_color_picker.color = waves_shader_material.get_shader_parameter("top_color")
 	wave_amp_slider.value = waves_shader_material.get_shader_parameter("wave_amp")
 	wave_size_slider.value = waves_shader_material.get_shader_parameter("wave_size")
 	wave_time_mul_slider.value = waves_shader_material.get_shader_parameter("wave_time_mul")
 	total_phases_slider.value = waves_shader_material.get_shader_parameter("total_phases")
-	blue_warp_stretch_slider.value = blue_warp_shader_material.get_shader_parameter("stretch")
-	blue_warp_thing1_slider.value = blue_warp_shader_material.get_shader_parameter("thing1")
-	blue_warp_thing2_slider.value = blue_warp_shader_material.get_shader_parameter("thing2")
-	blue_warp_thing3_slider.value = blue_warp_shader_material.get_shader_parameter("thing3")
-	blue_warp_speed_slider.value = blue_warp_shader_material.get_shader_parameter("speed")
-	blue_warp_color_low_picker.color = blue_warp_shader_material.get_shader_parameter("color_low")
-	blue_warp_color_mid_picker.color = blue_warp_shader_material.get_shader_parameter("color_mid")
-	blue_warp_color_high_picker.color = blue_warp_shader_material.get_shader_parameter("color_high")
-	comic_dots1_color_picker.color = comic_dots1_shader_material.get_shader_parameter("circle_color")
-	comic_dots1_multiplier_slider.value = comic_dots1_shader_material.get_shader_parameter("circle_multiplier")
-	comic_dots1_speed_slider.value = comic_dots1_shader_material.get_shader_parameter("speed")
+        comic_dots1_color_picker.color = comic_dots1_shader_material.get_shader_parameter("circle_color")
+        comic_dots1_multiplier_slider.value = comic_dots1_shader_material.get_shader_parameter("circle_multiplier")
+        comic_dots1_speed_slider.value = comic_dots1_shader_material.get_shader_parameter("speed")
 	comic_dots2_color_picker.color = comic_dots2_shader_material.get_shader_parameter("circle_color")
 	comic_dots2_multiplier_slider.value = comic_dots2_shader_material.get_shader_parameter("circle_multiplier")
 	comic_dots2_speed_slider.value = comic_dots2_shader_material.get_shader_parameter("speed")
@@ -102,38 +79,6 @@ func _ready() -> void:
 	electric_scale_x_slider.value = electric_scale.x
 	electric_scale_y_slider.value = electric_scale.y
 
-func _refresh_warp_shader_materials() -> void:
-		warp_shader_materials.clear()
-		_collect_warp_shader_materials(get_tree().root)
-
-func _collect_warp_shader_materials(node: Node) -> void:
-		if node is CanvasItem:
-				var mat = node.material
-				if mat is ShaderMaterial and mat.shader and mat.shader.resource_path.ends_with("warp_shader.gdshader"):
-						if mat not in warp_shader_materials:
-								warp_shader_materials.append(mat)
-								_apply_saved_params_to_material(mat)
-		for child in node.get_children():
-				_collect_warp_shader_materials(child)
-
-func _on_node_added(node: Node) -> void:
-		_collect_warp_shader_materials(node)
-
-func _apply_saved_params_to_material(mat: ShaderMaterial) -> void:
-
-	var d: Dictionary = PlayerManager.DEFAULT_BACKGROUND_SHADERS["BlueWarp"]
-	mat.set_shader_parameter("stretch", PlayerManager.get_shader_param("BlueWarp", "stretch", d["stretch"]))
-	mat.set_shader_parameter("thing1", PlayerManager.get_shader_param("BlueWarp", "thing1", d["thing1"]))
-	mat.set_shader_parameter("thing2", PlayerManager.get_shader_param("BlueWarp", "thing2", d["thing2"]))
-	mat.set_shader_parameter("thing3", PlayerManager.get_shader_param("BlueWarp", "thing3", d["thing3"]))
-	mat.set_shader_parameter("speed", PlayerManager.get_shader_param("BlueWarp", "speed", d["speed"]))
-	if mat == blue_warp_shader_material:
-		var color_low: Color = PlayerManager.get_shader_param("BlueWarp", "color_low", PlayerManager.dict_to_color(d["color_low"]))
-		var color_mid: Color = PlayerManager.get_shader_param("BlueWarp", "color_mid", PlayerManager.dict_to_color(d["color_mid"]))
-		var color_high: Color = PlayerManager.get_shader_param("BlueWarp", "color_high", PlayerManager.dict_to_color(d["color_high"]))
-		mat.set_shader_parameter("color_low", color_low)
-		mat.set_shader_parameter("color_mid", color_mid)
-		mat.set_shader_parameter("color_high", color_high)
 
 
 func update_checked_mode() -> void:
@@ -179,11 +124,8 @@ func _on_create_apps_folder_button_pressed() -> void:
 	if desktop_env:
 		desktop_env._create_or_update_apps_folder()
 
-func _on_blue_warp_button_toggled(toggled_on: bool) -> void:
-	Events.set_desktop_background_visible("BlueWarp", toggled_on)
-
 func _on_comic_dots_1_button_toggled(toggled_on: bool) -> void:
-	Events.set_desktop_background_visible("ComicDots1", toggled_on)
+        Events.set_desktop_background_visible("ComicDots1", toggled_on)
 
 func _on_comic_dots_2_button_toggled(toggled_on: bool) -> void:
 	Events.set_desktop_background_visible("ComicDots2", toggled_on)
@@ -214,44 +156,6 @@ func _on_wave_time_mul_slider_value_changed(value: float) -> void:
 func _on_total_phases_slider_value_changed(value: float) -> void:
 	waves_shader_material.set_shader_parameter("total_phases", value)
 	PlayerManager.set_shader_param("Waves", "total_phases", value)
-
-func _on_blue_warp_stretch_slider_value_changed(value: float) -> void:
-		for mat in warp_shader_materials:
-				mat.set_shader_parameter("stretch", value)
-		PlayerManager.set_shader_param("BlueWarp", "stretch", value)
-
-func _on_blue_warp_thing1_slider_value_changed(value: float) -> void:
-		for mat in warp_shader_materials:
-				mat.set_shader_parameter("thing1", value)
-		PlayerManager.set_shader_param("BlueWarp", "thing1", value)
-
-func _on_blue_warp_thing2_slider_value_changed(value: float) -> void:
-		for mat in warp_shader_materials:
-				mat.set_shader_parameter("thing2", value)
-		PlayerManager.set_shader_param("BlueWarp", "thing2", value)
-
-func _on_blue_warp_thing3_slider_value_changed(value: float) -> void:
-		for mat in warp_shader_materials:
-				mat.set_shader_parameter("thing3", value)
-		PlayerManager.set_shader_param("BlueWarp", "thing3", value)
-
-func _on_blue_warp_speed_slider_value_changed(value: float) -> void:
-		for mat in warp_shader_materials:
-				mat.set_shader_parameter("speed", value)
-		PlayerManager.set_shader_param("BlueWarp", "speed", value)
-
-func _on_blue_warp_color_low_picker_color_changed(color: Color) -> void:
-
-	blue_warp_shader_material.set_shader_parameter("color_low", color)
-	PlayerManager.set_shader_param("BlueWarp", "color_low", color)
-
-func _on_blue_warp_color_mid_picker_color_changed(color: Color) -> void:
-	blue_warp_shader_material.set_shader_parameter("color_mid", color)
-	PlayerManager.set_shader_param("BlueWarp", "color_mid", color)
-
-func _on_blue_warp_color_high_picker_color_changed(color: Color) -> void:
-	blue_warp_shader_material.set_shader_parameter("color_high", color)
-	PlayerManager.set_shader_param("BlueWarp", "color_high", color)
 
 
 func _on_comic_dots_1_color_picker_color_changed(color: Color) -> void:
@@ -314,8 +218,8 @@ func _on_electric_scale_y_slider_value_changed(value: float) -> void:
 				PlayerManager.set_shader_param("Electric", "scale_y", value)
 
 func _on_waves_reset_button_pressed() -> void:
-		PlayerManager.reset_shader("Waves")
-		var d = PlayerManager.DEFAULT_BACKGROUND_SHADERS["Waves"]
+                PlayerManager.reset_shader("Waves")
+                var d = PlayerManager.DEFAULT_BACKGROUND_SHADERS["Waves"]
 		var bottom = PlayerManager.dict_to_color(d["bottom_color"])
 		var top = PlayerManager.dict_to_color(d["top_color"])
 		waves_shader_material.set_shader_parameter("bottom_color", bottom)
@@ -328,34 +232,8 @@ func _on_waves_reset_button_pressed() -> void:
 		top_color_picker.color = top
 		wave_amp_slider.value = d["wave_amp"]
 		wave_size_slider.value = d["wave_size"]
-		wave_time_mul_slider.value = d["wave_time_mul"]
-		total_phases_slider.value = d["total_phases"]
-
-func _on_blue_warp_reset_button_pressed() -> void:
-
-	PlayerManager.reset_shader("BlueWarp")
-	var d: Dictionary = PlayerManager.DEFAULT_BACKGROUND_SHADERS["BlueWarp"]
-	for mat in warp_shader_materials:
-		mat.set_shader_parameter("stretch", d["stretch"])
-		mat.set_shader_parameter("thing1", d["thing1"])
-		mat.set_shader_parameter("thing2", d["thing2"])
-		mat.set_shader_parameter("thing3", d["thing3"])
-		mat.set_shader_parameter("speed", d["speed"])
-	var color_low: Color = PlayerManager.dict_to_color(d["color_low"])
-	var color_mid: Color = PlayerManager.dict_to_color(d["color_mid"])
-	var color_high: Color = PlayerManager.dict_to_color(d["color_high"])
-	blue_warp_shader_material.set_shader_parameter("color_low", color_low)
-	blue_warp_shader_material.set_shader_parameter("color_mid", color_mid)
-	blue_warp_shader_material.set_shader_parameter("color_high", color_high)
-	blue_warp_stretch_slider.value = d["stretch"]
-	blue_warp_thing1_slider.value = d["thing1"]
-	blue_warp_thing2_slider.value = d["thing2"]
-	blue_warp_thing3_slider.value = d["thing3"]
-	blue_warp_speed_slider.value = d["speed"]
-	blue_warp_color_low_picker.color = color_low
-	blue_warp_color_mid_picker.color = color_mid
-	blue_warp_color_high_picker.color = color_high
-
+                wave_time_mul_slider.value = d["wave_time_mul"]
+                total_phases_slider.value = d["total_phases"]
 
 func _on_comic_dots_1_reset_button_pressed() -> void:
 				PlayerManager.reset_shader("ComicDots1")

--- a/components/shader_controller_module.gd
+++ b/components/shader_controller_module.gd
@@ -1,0 +1,112 @@
+extends PanelContainer
+class_name ShaderControllerModule
+
+@export var shader_name: String
+@export var shader_node_paths: Array[String] = []
+@export var slider_nodes: Array[NodePath] = []
+@export var slider_params: Array[StringName] = []
+@export var color_picker_nodes: Array[NodePath] = []
+@export var color_picker_params: Array[StringName] = []
+@export var toggle_button_path: NodePath
+@export var reset_button_path: NodePath
+@export var collect_warp_shaders: bool = false
+
+var shader_materials: Array[ShaderMaterial] = []
+
+func _ready() -> void:
+    if collect_warp_shaders:
+        _refresh_warp_shader_materials()
+        get_tree().node_added.connect(_on_node_added)
+    else:
+        for p in shader_node_paths:
+            var n = get_tree().root.get_node_or_null(p)
+            if n and n is CanvasItem:
+                var mat = n.material
+                if mat is ShaderMaterial:
+                    shader_materials.append(mat)
+    for i in range(slider_nodes.size()):
+        var node = get_node_or_null(slider_nodes[i])
+        if node and node is HSlider:
+            var param = slider_params[i]
+            node.value = _get_param(param)
+            node.value_changed.connect(_on_slider_changed.bind(param))
+    for i in range(color_picker_nodes.size()):
+        var node = get_node_or_null(color_picker_nodes[i])
+        if node and node is ColorPickerButton:
+            var param = color_picker_params[i]
+            node.color = _get_param(param)
+            node.color_changed.connect(_on_color_changed.bind(param))
+    if toggle_button_path != NodePath():
+        var button = get_node_or_null(toggle_button_path)
+        if button and button is CheckButton:
+            button.button_pressed = Events.is_desktop_background_visible(shader_name)
+            button.toggled.connect(_on_toggled)
+    if reset_button_path != NodePath():
+        var reset = get_node_or_null(reset_button_path)
+        if reset and reset is Button:
+            reset.pressed.connect(_on_reset_pressed)
+
+func _refresh_warp_shader_materials() -> void:
+    shader_materials.clear()
+    _collect_warp_shader_materials(get_tree().root)
+
+func _collect_warp_shader_materials(n: Node) -> void:
+    if n is CanvasItem:
+        var mat = n.material
+        if mat is ShaderMaterial and mat.shader and mat.shader.resource_path.ends_with("warp_shader.gdshader"):
+            if mat not in shader_materials:
+                shader_materials.append(mat)
+    for c in n.get_children():
+        _collect_warp_shader_materials(c)
+
+func _on_node_added(n: Node) -> void:
+    _collect_warp_shader_materials(n)
+
+func _on_slider_changed(value: float, param: StringName) -> void:
+    _set_param(param, value)
+
+func _on_color_changed(color: Color, param: StringName) -> void:
+    _set_param(param, color)
+
+func _on_toggled(toggled_on: bool) -> void:
+    Events.set_desktop_background_visible(shader_name, toggled_on)
+
+func _get_param(param: StringName):
+    if shader_materials.is_empty():
+        return 0
+    if param == "scale_x" or param == "scale_y":
+        var scale: Vector2 = shader_materials[0].get_shader_parameter("scale")
+        return scale.x if param == "scale_x" else scale.y
+    return shader_materials[0].get_shader_parameter(param)
+
+func _set_param(param: StringName, value) -> void:
+    if param == "scale_x" or param == "scale_y":
+        for mat in shader_materials:
+            var scale: Vector2 = mat.get_shader_parameter("scale")
+            if param == "scale_x":
+                scale.x = value
+            else:
+                scale.y = value
+            mat.set_shader_parameter("scale", scale)
+    else:
+        for mat in shader_materials:
+            mat.set_shader_parameter(param, value)
+    PlayerManager.set_shader_param(shader_name, param, value)
+
+func _on_reset_pressed() -> void:
+    PlayerManager.reset_shader(shader_name)
+    var d = PlayerManager.DEFAULT_BACKGROUND_SHADERS[shader_name]
+    for i in range(slider_nodes.size()):
+        var node = get_node_or_null(slider_nodes[i])
+        if node and node is HSlider:
+            var param = slider_params[i]
+            var val = d[param]
+            node.value = val
+            _set_param(param, val)
+    for i in range(color_picker_nodes.size()):
+        var node = get_node_or_null(color_picker_nodes[i])
+        if node and node is ColorPickerButton:
+            var param = color_picker_params[i]
+            var val = PlayerManager.dict_to_color(d[param])
+            node.color = val
+            _set_param(param, val)


### PR DESCRIPTION
## Summary
- create reusable `ShaderControllerModule` for configuring shader parameters
- integrate warp background controls with the new module framework
- simplify settings window by removing dedicated warp logic

## Testing
- `godot --headless -s tests/test_runner.gd` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a7be765b8083258c0caff2f3bce138