### PR TITLE
Add flat color and image background controllers

### DIFF
--- a/assets/shaders/flat_color_background.gdshader
+++ b/assets/shaders/flat_color_background.gdshader
@@ -1,0 +1,7 @@
+shader_type canvas_item;
+
+uniform vec4 color : source_color = vec4(0.0, 0.0, 0.0, 1.0);
+
+void fragment() {
+    COLOR = color;
+}

--- a/autoloads/events.gd
+++ b/autoloads/events.gd
@@ -4,11 +4,13 @@ signal desktop_background_toggled(name: String, visible: bool)
 signal upgrade_purchased(id: String, level: int)
 
 var desktop_backgrounds: Dictionary = {
-	"BlueWarp": true,
-	"ComicDots1": false,
-	"ComicDots2": false,
-	"Waves": false,
-	"Electric": false,
+        "BlueWarp": true,
+        "ComicDots1": false,
+        "ComicDots2": false,
+        "Waves": false,
+        "Electric": false,
+        "Background": false,
+        "FlatColor": false,
 }
 
 func set_desktop_background_visible(name: String, visible: bool) -> void:

--- a/autoloads/player_manager.gd
+++ b/autoloads/player_manager.gd
@@ -39,6 +39,9 @@ const DEFAULT_BACKGROUND_SHADERS := {
 "scale_x": 3.25,
 "scale_y": 15.43,
 },
+"FlatColor": {
+"color": {"r": 0.0, "g": 0.0, "b": 0.0, "a": 1.0},
+},
 }
 
 var default_user_data: Dictionary = {

--- a/components/apps/app_scenes/settings.tscn
+++ b/components/apps/app_scenes/settings.tscn
@@ -684,6 +684,88 @@ unique_name_in_owner = true
 layout_mode = 2
 text = "Reset"
 
+[node name="FlatColorContainer" type="PanelContainer" parent="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer2"]
+layout_mode = 2
+size_flags_horizontal = 6
+mouse_filter = 1
+script = ExtResource("5_p2fk4")
+shader_name = "FlatColor"
+shader_node_paths = Array[NodePath]([NodePath("Main/DesktopEnv/ShaderBackgroundsContainer/FlatColorBackground")])
+color_picker_nodes = Array[NodePath]([NodePath("MarginContainer/VBoxContainer/HBoxContainer/FlatColorPicker")])
+color_picker_params = Array[StringName]([&"color"])
+toggle_button_path = NodePath("MarginContainer/VBoxContainer/FlatColorButton")
+reset_button_path = NodePath("MarginContainer/VBoxContainer/FlatColorResetButton")
+
+[node name="MarginContainer" type="MarginContainer" parent="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer2/FlatColorContainer"]
+layout_mode = 2
+theme_override_constants/margin_left = 15
+theme_override_constants/margin_top = 15
+theme_override_constants/margin_right = 15
+theme_override_constants/margin_bottom = 15
+
+[node name="VBoxContainer" type="VBoxContainer" parent="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer2/FlatColorContainer/MarginContainer"]
+custom_minimum_size = Vector2(180, 0)
+layout_mode = 2
+
+[node name="FlatColorButton" type="CheckButton" parent="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer2/FlatColorContainer/MarginContainer/VBoxContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+focus_mode = 0
+theme_override_fonts/font = ExtResource("4_a82ne")
+theme_override_font_sizes/font_size = 24
+theme_override_styles/normal = SubResource("StyleBoxFlat_dij2h")
+text = "   Flat"
+
+[node name="HBoxContainer" type="HBoxContainer" parent="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer2/FlatColorContainer/MarginContainer/VBoxContainer"]
+layout_mode = 2
+
+[node name="FlatColorPicker" type="ColorPickerButton" parent="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer2/FlatColorContainer/MarginContainer/VBoxContainer/HBoxContainer"]
+unique_name_in_owner = true
+custom_minimum_size = Vector2(16, 16)
+layout_mode = 2
+
+[node name="FlatColorResetButton" type="Button" parent="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer2/FlatColorContainer/MarginContainer/VBoxContainer"]
+layout_mode = 2
+text = "Reset"
+
+[node name="BackgroundContainer" type="PanelContainer" parent="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer2"]
+layout_mode = 2
+size_flags_horizontal = 6
+mouse_filter = 1
+script = ExtResource("5_p2fk4")
+shader_name = "Background"
+shader_node_paths = Array[NodePath]([NodePath("Main/DesktopEnv/Background")])
+toggle_button_path = NodePath("MarginContainer/VBoxContainer/BackgroundButton")
+
+[node name="MarginContainer" type="MarginContainer" parent="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer2/BackgroundContainer"]
+layout_mode = 2
+theme_override_constants/margin_left = 15
+theme_override_constants/margin_top = 15
+theme_override_constants/margin_right = 15
+theme_override_constants/margin_bottom = 15
+
+[node name="VBoxContainer" type="VBoxContainer" parent="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer2/BackgroundContainer/MarginContainer"]
+custom_minimum_size = Vector2(180, 0)
+layout_mode = 2
+
+[node name="BackgroundButton" type="CheckButton" parent="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer2/BackgroundContainer/MarginContainer/VBoxContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+focus_mode = 0
+theme_override_fonts/font = ExtResource("4_a82ne")
+theme_override_font_sizes/font_size = 24
+theme_override_styles/normal = SubResource("StyleBoxFlat_dij2h")
+text = "   Image"
+
+[node name="BackgroundSelectImageButton" type="Button" parent="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer2/BackgroundContainer/MarginContainer/VBoxContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+text = "Select Image"
+
+[node name="BackgroundFileDialog" type="FileDialog" parent="."]
+unique_name_in_owner = true
+access = 2
+
 [connection signal="toggled" from="Panel/MarginContainer/TabContainer/General/HBoxContainer/VBoxContainer2/SiggyButton" to="." method="_on_siggy_button_toggled"]
 [connection signal="pressed" from="Panel/MarginContainer/TabContainer/General/HBoxContainer/VBoxContainer2/CreateAppsFolderButton" to="." method="_on_create_apps_folder_button_pressed"]
 [connection signal="toggled" from="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/WavesContainer/MarginContainer/VBoxContainer/WavesButton" to="." method="_on_waves_button_toggled"]
@@ -713,3 +795,5 @@ text = "Reset"
 [connection signal="value_changed" from="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer2/ComicDotsContainer/MarginContainer/HBoxContainer4/VBoxContainer2/HBoxContainer2/ComicDots2MultiplierSlider" to="." method="_on_comic_dots_2_multiplier_slider_value_changed"]
 [connection signal="value_changed" from="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer2/ComicDotsContainer/MarginContainer/HBoxContainer4/VBoxContainer2/HBoxContainer3/ComicDots2SpeedSlider" to="." method="_on_comic_dots_2_speed_slider_value_changed"]
 [connection signal="pressed" from="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer2/ComicDotsContainer/MarginContainer/HBoxContainer4/VBoxContainer2/ComicDots2ResetButton" to="." method="_on_comic_dots_2_reset_button_pressed"]
+[connection signal="pressed" from="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer2/BackgroundContainer/MarginContainer/VBoxContainer/BackgroundSelectImageButton" to="." method="_on_background_select_image_button_pressed"]
+[connection signal="file_selected" from="BackgroundFileDialog" to="." method="_on_background_file_dialog_file_selected"]

--- a/components/desktop_env.tscn
+++ b/components/desktop_env.tscn
@@ -29,6 +29,7 @@
 [ext_resource type="PackedScene" uid="uid://bxbwmaa2wwr33" path="res://components/calendar/calendar_day_panel.tscn" id="20_vxmwr"]
 [ext_resource type="Script" uid="uid://cmmevgi7d0n3h" path="res://components/start_panel_window.gd" id="23_dik0q"]
 [ext_resource type="Script" uid="uid://c7t01yq8wloqf" path="res://components/desktop_background.gd" id="24_jkb4t"]
+[ext_resource type="Shader" uid="uid://flatcolorbg" path="res://assets/shaders/flat_color_background.gdshader" id="25_flat"]
 
 [sub_resource type="ShaderMaterial" id="ShaderMaterial_668nl"]
 shader = ExtResource("8_iij0d")
@@ -139,6 +140,10 @@ shader_parameter/circle_multiplier = 32.0
 shader_parameter/speed = 0.1
 shader_parameter/direction = Vector2(1, 1)
 shader_parameter/rotation = Transform2D(1, -1, 1, 1, 0, 0)
+
+[sub_resource type="ShaderMaterial" id="ShaderMaterial_flat"]
+shader = ExtResource("25_flat")
+shader_parameter/color = Color(0, 0, 0, 1)
 
 [sub_resource type="StyleBoxTexture" id="StyleBoxTexture_m483i"]
 texture = ExtResource("9_m483i")
@@ -259,6 +264,8 @@ scale = Vector2(0.916622, 0.916622)
 texture = ExtResource("3_0utxc")
 expand_mode = 2
 stretch_mode = 5
+script = ExtResource("24_jkb4t")
+background_name = "Background"
 
 [node name="ColorRect" type="ColorRect" parent="."]
 unique_name_in_owner = true
@@ -367,6 +374,19 @@ grow_horizontal = 2
 grow_vertical = 2
 script = ExtResource("24_jkb4t")
 background_name = "ComicDots2"
+
+[node name="FlatColorBackground" type="ColorRect" parent="ShaderBackgroundsContainer"]
+unique_name_in_owner = true
+visible = false
+material = SubResource("ShaderMaterial_flat")
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+script = ExtResource("24_jkb4t")
+background_name = "FlatColor"
 
 [node name="TopBar" type="Control" parent="."]
 layout_mode = 1

--- a/components/settings_window.gd
+++ b/components/settings_window.gd
@@ -31,6 +31,7 @@ extends Pane
 @onready var electric_scale_y_slider: HSlider = %ElectricScaleYSlider
 @onready var tab_container: TabContainer = %TabContainer
 @onready var create_apps_folder_button: Button = %CreateAppsFolderButton
+@onready var background_file_dialog: FileDialog = %BackgroundFileDialog
 @onready var waves_shader_material: ShaderMaterial = get_tree().root.get_node("Main/DesktopEnv/ShaderBackgroundsContainer/WavesShader").material
 @onready var comic_dots1_shader_material: ShaderMaterial = get_tree().root.get_node("Main/DesktopEnv/ShaderBackgroundsContainer/ComicDotsBlueVert").material
 @onready var comic_dots2_shader_material: ShaderMaterial = get_tree().root.get_node("Main/DesktopEnv/ShaderBackgroundsContainer/ComicDotsBlueHor").material
@@ -280,14 +281,26 @@ func _on_minute_passed(_total_minutes: int) -> void:
 		_update_autosave_timer_label()
 
 func _update_autosave_timer_label() -> void:
-	if not TimeManager.autosave_enabled:
-		autosave_timer_label.text = "Autosave disabled"
-		return
-	if not is_instance_valid(SaveManager) or SaveManager.current_slot_id <= 0:
-		autosave_timer_label.text = "No save loaded"
-		return
-	var total_minutes_left = TimeManager.autosave_interval * 60 - (TimeManager.autosave_hour_counter * 60 + TimeManager.current_minute)
-	total_minutes_left = max(total_minutes_left, 0)
-	var hours = total_minutes_left / 60
-	var minutes = total_minutes_left % 60
-	autosave_timer_label.text = "%d:%02d" % [hours, minutes]
+        if not TimeManager.autosave_enabled:
+                autosave_timer_label.text = "Autosave disabled"
+                return
+        if not is_instance_valid(SaveManager) or SaveManager.current_slot_id <= 0:
+                autosave_timer_label.text = "No save loaded"
+                return
+        var total_minutes_left = TimeManager.autosave_interval * 60 - (TimeManager.autosave_hour_counter * 60 + TimeManager.current_minute)
+        total_minutes_left = max(total_minutes_left, 0)
+        var hours = total_minutes_left / 60
+        var minutes = total_minutes_left % 60
+        autosave_timer_label.text = "%d:%02d" % [hours, minutes]
+
+func _on_background_select_image_button_pressed() -> void:
+        background_file_dialog.popup_centered()
+
+func _on_background_file_dialog_file_selected(path: String) -> void:
+        var tex: Resource = load(path)
+        if tex is Texture2D:
+                var bg: TextureRect = get_tree().root.get_node("Main/DesktopEnv/Background")
+                bg.texture = tex
+                PlayerManager.set_var("background_path", path)
+        else:
+                print("❌ Couldn't load texture from path: ", path)

--- a/scripts/desktop_env.gd
+++ b/scripts/desktop_env.gd
@@ -15,6 +15,7 @@ const FOLDER_SHORTCUT_SCENE: PackedScene = preload("res://components/desktop/fol
 @onready var comic_dots2_shader_material: ShaderMaterial = %ComicDotsBlueHor.material
 @onready var waves_shader_material: ShaderMaterial = %WavesShader.material
 @onready var electric_shader_material: ShaderMaterial = %ElectricShader.material
+@onready var flat_color_shader_material: ShaderMaterial = %FlatColorBackground.material
 
 
 
@@ -107,10 +108,14 @@ func _apply_shader_settings() -> void:
 	var scale_y = PlayerManager.get_shader_param("Electric", "scale_y", e_def["scale_y"])
 	electric_shader_material.set_shader_parameter("background_color", bg_color)
 	electric_shader_material.set_shader_parameter("line_color", line_color)
-	electric_shader_material.set_shader_parameter("line_freq", line_freq)
-	electric_shader_material.set_shader_parameter("height", height)
-	electric_shader_material.set_shader_parameter("speed", speed)
-	electric_shader_material.set_shader_parameter("scale", Vector2(scale_x, scale_y))
+        electric_shader_material.set_shader_parameter("line_freq", line_freq)
+        electric_shader_material.set_shader_parameter("height", height)
+        electric_shader_material.set_shader_parameter("speed", speed)
+        electric_shader_material.set_shader_parameter("scale", Vector2(scale_x, scale_y))
+
+        var flat_def = defaults["FlatColor"]
+        var flat_col = PlayerManager.get_shader_param("FlatColor", "color", PlayerManager.dict_to_color(flat_def["color"]))
+        flat_color_shader_material.set_shader_parameter("color", flat_col)
 
 
 func hide_all_windows_and_panels() -> void:


### PR DESCRIPTION
## Summary
- Support flat color background with new shader and settings controls
- Allow choosing custom background image via settings with file picker
- Store visibility preferences for new backgrounds

## Testing
- `godot --headless -s tests/test_runner.gd` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a7c3976a508325b88f4ec24386ebfb