### PR TITLE
Isolate RNG streams per subsystem

### DIFF
--- a/autoloads/fumble_manager.gd
+++ b/autoloads/fumble_manager.gd
@@ -56,7 +56,7 @@ func start_battle(npc_idx: int) -> String:
 		return ""
 
 	if not has_active_battle(npc_idx):
-		var rng = RNGManager.get_rng()
+             var rng = RNGManager.fumble_manager.get_rng()
 		var battle_id = "%s_%d" % [str(Time.get_unix_time_from_system()), rng.randi() % 1000000]
 		print("Creating new fumble battle", battle_id, "slot", SaveManager.current_slot_id)
 		DBManager.save_fumble_battle(

--- a/autoloads/gpu_manager.gd
+++ b/autoloads/gpu_manager.gd
@@ -62,7 +62,7 @@ func _on_minute_tick(_unused: int) -> void:
                scheduled_burns.erase(minute_of_hour)
                _execute_scheduled_burns(burns)
 
-var rng: RandomNumberGenerator = RNGManager.get_rng()
+var rng: RandomNumberGenerator = RNGManager.gpu.get_rng()
 var current_time: int = TimeManager.total_minutes_elapsed
 
        for symbol in next_block_time.keys():
@@ -125,7 +125,7 @@ func get_symbol_burnout_multiplier(symbol: String) -> float:
 
 func _run_hourly_burn_batch() -> void:
 	scheduled_burns.clear()
-	var rng: RandomNumberGenerator = RNGManager.get_rng()
+    var rng: RandomNumberGenerator = RNGManager.gpu.get_rng()
 	for crypto in MarketManager.crypto_market.values():
 	var symbol: String = crypto.symbol
 	var m_used: int = get_used_gpu_count_for(symbol)
@@ -179,7 +179,7 @@ func _sample_burnouts(T: int, p_eff: float, m_used: int, rng: RandomNumberGenera
 	return K
 
 func _execute_scheduled_burns(burns: Dictionary) -> void:
-	var rng: RandomNumberGenerator = RNGManager.get_rng()
+    var rng: RandomNumberGenerator = RNGManager.gpu.get_rng()
 	for symbol in burns.keys():
 	var count: int = int(burns[symbol])
 	_burn_random_gpus(symbol, count, rng)
@@ -306,7 +306,7 @@ func set_overclocked(index: int, overclocked: bool) -> void:
 			is_overclocked[index] = 0
 
 func process_gpu_tick() -> void:
-	var rng = RNGManager.get_rng()
+    var rng = RNGManager.gpu.get_rng()
 	total_power = 0  # Recalculate total power
 
 	for i in range(gpu_cryptos.size()):

--- a/autoloads/market_manager.gd
+++ b/autoloads/market_manager.gd
@@ -106,7 +106,7 @@ func refresh_prices():
 	_update_stock_prices()
 
 func _update_stock_prices():
-	var rng = RNGManager.get_rng()
+    var rng = RNGManager.market_manager.get_rng()
 	for stock in stock_market.values():
 		stock.intrinsic_value += rng.randf_range(0.0001, 0.001)
 

--- a/autoloads/name_generator.gd
+++ b/autoloads/name_generator.gd
@@ -31,7 +31,7 @@ func _ready():
 
 # --- Public API ---
 func get_random_name(fem: float = 0.0, masc: float = 0.0, enby: float = 0.0, top_n: int = 1) -> String:
-	var rng = RNGManager.get_rng()
+     var rng = RNGManager.name_generator.get_rng()
 	if name_pool.is_empty():
 		printerr("⚠️ Name pool is empty!")
 		return "Unnamed"
@@ -39,7 +39,7 @@ func get_random_name(fem: float = 0.0, masc: float = 0.0, enby: float = 0.0, top
 	if fem + masc + enby == 0.0:
 		# Choose random name when called without arguments
 		var available := name_pool.map(func(e): return e.name)
-		RNGManager.shuffle(available)
+            RNGManager.name_generator.shuffle(available)
 		var new_name = available[0]
 		_add_to_recent(new_name)
 		return new_name
@@ -60,7 +60,7 @@ func get_random_name(fem: float = 0.0, masc: float = 0.0, enby: float = 0.0, top
 	if top_n > 0:
 		scored_names.sort_custom(func(a, b): return b["score"] < a["score"])
 		var top_candidates := scored_names.slice(0, min(top_n, scored_names.size()))
-		RNGManager.shuffle(top_candidates)
+            RNGManager.name_generator.shuffle(top_candidates)
 		var name = top_candidates[0]["name"]
 		_add_to_recent(name)
 		return name

--- a/autoloads/rizz_battle_data.gd
+++ b/autoloads/rizz_battle_data.gd
@@ -73,7 +73,7 @@ static func get_type_mod_chance_adjust(npc_type: String, move_type: String) -> f
 
 func get_random_block_warning() -> String:
 	if npc_block_warnings is Array and npc_block_warnings.size() > 0:
-			var rng = RNGManager.get_rng()
+                     var rng = RNGManager.rizz_battle_data.get_rng()
 			var entry = npc_block_warnings[rng.randi() % npc_block_warnings.size()]
 			var core = str(entry.get("core", ""))
 			var suffixes = entry.get("suffixes", [])

--- a/autoloads/rng_manager.gd
+++ b/autoloads/rng_manager.gd
@@ -1,24 +1,128 @@
 extends Node
 
-var rng := RandomNumberGenerator.new()
+# Master seed used to derive deterministic seeds for each subsystem
 var seed: int = 0
 
+class RNGStream:
+    var rng := RandomNumberGenerator.new()
+    var seed: int = 0
+
+    func init_seed(seed_value: int) -> void:
+        seed = seed_value
+        rng.seed = seed
+        rng.state = 0
+
+    func get_rng() -> RandomNumberGenerator:
+        return rng
+
+    func shuffle(arr: Array) -> void:
+        for i in range(arr.size() - 1, 0, -1):
+            var j = rng.randi_range(0, i)
+            var temp = arr[i]
+            arr[i] = arr[j]
+            arr[j] = temp
+
+class GlobalRNG extends RNGStream:
+    pass
+
+class GPURNG extends RNGStream:
+    pass
+
+class RizzBattleDataRNG extends RNGStream:
+    pass
+
+class NameGeneratorRNG extends RNGStream:
+    pass
+
+class FumbleManagerRNG extends RNGStream:
+    pass
+
+class WorkerManagerRNG extends RNGStream:
+    pass
+
+class MarketManagerRNG extends RNGStream:
+    pass
+
+class SiggyRNG extends RNGStream:
+    pass
+
+class TickerRNG extends RNGStream:
+    pass
+
+class EarlyBirdRNG extends RNGStream:
+    pass
+
+class CryptoRNG extends RNGStream:
+    pass
+
+class PortraitCreatorRNG extends RNGStream:
+    pass
+
+class FumbleBattleUIRNG extends RNGStream:
+    pass
+
+class LockedInRNG extends RNGStream:
+    pass
+
+class FumbleBattleLogicRNG extends RNGStream:
+    pass
+
+class TaskManagerRNG extends RNGStream:
+    pass
+
+class NPCManagerRNG extends RNGStream:
+    pass
+
+var global := GlobalRNG.new()
+var gpu := GPURNG.new()
+var rizz_battle_data := RizzBattleDataRNG.new()
+var name_generator := NameGeneratorRNG.new()
+var fumble_manager := FumbleManagerRNG.new()
+var worker_manager := WorkerManagerRNG.new()
+var market_manager := MarketManagerRNG.new()
+var siggy := SiggyRNG.new()
+var ticker := TickerRNG.new()
+var early_bird := EarlyBirdRNG.new()
+var crypto := CryptoRNG.new()
+var portrait_creator := PortraitCreatorRNG.new()
+var fumble_battle_ui := FumbleBattleUIRNG.new()
+var locked_in := LockedInRNG.new()
+var fumble_battle_logic := FumbleBattleLogicRNG.new()
+var task_manager := TaskManagerRNG.new()
+var npc_manager := NPCManagerRNG.new()
+
+func _derive_seed(name: String) -> int:
+    return hash(str(seed) + ":" + name)
+
 func init_seed(seed_value: int) -> void:
-		seed = seed_value
-		rng.seed = seed
-		if OS.is_debug_build():
-				print("Global RNG Seed: ", seed)
+    seed = seed_value
+    global.init_seed(seed)
+    gpu.init_seed(_derive_seed("gpu"))
+    rizz_battle_data.init_seed(_derive_seed("rizz_battle_data"))
+    name_generator.init_seed(_derive_seed("name_generator"))
+    fumble_manager.init_seed(_derive_seed("fumble_manager"))
+    worker_manager.init_seed(_derive_seed("worker_manager"))
+    market_manager.init_seed(_derive_seed("market_manager"))
+    siggy.init_seed(_derive_seed("siggy"))
+    ticker.init_seed(_derive_seed("ticker"))
+    early_bird.init_seed(_derive_seed("early_bird"))
+    crypto.init_seed(_derive_seed("crypto"))
+    portrait_creator.init_seed(_derive_seed("portrait_creator"))
+    fumble_battle_ui.init_seed(_derive_seed("fumble_battle_ui"))
+    locked_in.init_seed(_derive_seed("locked_in"))
+    fumble_battle_logic.init_seed(_derive_seed("fumble_battle_logic"))
+    task_manager.init_seed(_derive_seed("task_manager"))
+    npc_manager.init_seed(_derive_seed("npc_manager"))
+    if OS.is_debug_build():
+        print("Global RNG Seed: ", seed)
 
 func get_rng() -> RandomNumberGenerator:
-		return rng
+    return global.get_rng()
 
 func reseed_with_unix_time() -> void:
-		init_seed(Time.get_unix_time_from_system())
-		PlayerManager.user_data["global_rng_seed"] = seed
+    init_seed(Time.get_unix_time_from_system())
+    PlayerManager.user_data["global_rng_seed"] = seed
 
 func shuffle(arr: Array) -> void:
-		for i in range(arr.size() - 1, 0, -1):
-				var j = rng.randi_range(0, i)
-				var temp = arr[i]
-				arr[i] = arr[j]
-				arr[j] = temp
+    global.shuffle(arr)
+

--- a/autoloads/task_manager.gd
+++ b/autoloads/task_manager.gd
@@ -57,7 +57,7 @@ func unregister_task(category: String, task: WorkerTask) -> void:
 
 func generate_random_tasks(category: String, count: int) -> Array[WorkerTask]:
 	var filtered := base_tasks.filter(func(t): return t.show_in_grinderr and category == "grinderr")
-	RNGManager.shuffle(filtered)
+     RNGManager.task_manager.shuffle(filtered)
 
 	var selected: Array[WorkerTask] = []
 	for i in min(count, filtered.size()):

--- a/autoloads/worker_manager.gd
+++ b/autoloads/worker_manager.gd
@@ -147,7 +147,7 @@ func generate_available_workers() -> void:
 
 func _generate_random_worker(is_contractor: bool) -> Worker:
 	var worker = Worker.new()
-	var rng = RNGManager.get_rng()
+    var rng = RNGManager.worker_manager.get_rng()
 
 	''' Gender generator
 	var fem = randi_range(0, 1)

--- a/components/apps/early_bird/pipe_pair.gd
+++ b/components/apps/early_bird/pipe_pair.gd
@@ -30,7 +30,7 @@ func randomize_gap_position() -> void:
 	var safe_margin = 50.0
 
 	# Randomize center Y position for the GAP
-	var rng = RNGManager.get_rng()
+     var rng = RNGManager.early_bird.get_rng()
 	var gap_center_y = rng.randf_range(
 			safe_margin + gap_size / 2,
 			viewport_height - safe_margin - gap_size / 2

--- a/components/apps/early_bird/worm.gd
+++ b/components/apps/early_bird/worm.gd
@@ -66,6 +66,6 @@ func _on_worm_texture_gui_input(event: InputEvent) -> void:
 
 
 func _on_timer_timeout() -> void:
-	var rng = RNGManager.get_rng()
+     var rng = RNGManager.early_bird.get_rng()
 	var angle_deg = rng.randf_range(30.0, 70.0)
 	worm_texture.rotation += deg_to_rad(angle_deg)

--- a/components/apps/fumble/fumble_battle/battle_logic.gd
+++ b/components/apps/fumble/fumble_battle/battle_logic.gd
@@ -11,7 +11,7 @@ func setup(npc_ref, stats_dict = {}):
 
 func resolve_move(move_type: String) -> Dictionary:
 	var chance = get_success_chance(move_type)
-	var success = RNGManager.get_rng().randf() < chance
+     var success = RNGManager.fumble_battle_logic.get_rng().randf() < chance
 	var mod = get_move_type_modifier(npc.chat_battle_type, move_type)
 	var reaction = ""
 	if mod == 2.0:

--- a/components/apps/fumble/fumble_battle/battle_ui.gd
+++ b/components/apps/fumble/fumble_battle/battle_ui.gd
@@ -170,7 +170,7 @@ func load_battle(new_battle_id: String, new_npc: NPC, chatlog_in: Array = [], st
 	move_usage_counts["catch"] = move_counts_to_use.get("catch", 0)
 	if chatlog.size() == 0 and move_counts_to_use.size() == 0:
 			var reveal_levels = UpgradeManager.get_level("fumble_speaking_from_experience")
-			var rng = RNGManager.get_rng()
+                    var rng = RNGManager.fumble_battle_ui.get_rng()
 			for i in range(reveal_levels):
 					var options := []
 					for m in equipped_moves:
@@ -406,7 +406,7 @@ func do_move(move_type: String) -> void:
 		is_animating = false
 		return
 
-	var rng = RNGManager.get_rng()
+    var rng = RNGManager.fumble_battle_ui.get_rng()
 	var chosen_line = options[rng.randi() % options.size()]
 	var prefix := ""
 	if chosen_line["prefixes"].size() > 0:
@@ -700,7 +700,7 @@ func _apply_effects(effects: Dictionary):
 
 func process_npc_response(move_type, response_id, success: bool) -> ChatBox:
 
-	var rng = RNGManager.get_rng()
+    var rng = RNGManager.fumble_battle_ui.get_rng()
 	var response_text = ""
 	var key = "FALSE"
 	if success:

--- a/components/apps/locked_in/profile_ui.gd
+++ b/components/apps/locked_in/profile_ui.gd
@@ -62,7 +62,7 @@ func update_name_label():
 	username_button.text = "@" + PlayerManager.user_data["username"]
 
 func update_work_label():
-	var rng = RNGManager.get_rng()
+     var rng = RNGManager.locked_in.get_rng()
 	if rng.randi_range(0,1) > 0:
 			work_label.text = PlayerManager.user_data["name"] + " woke up this morning and chose violence"
 	else:

--- a/components/npc/npc_manager.gd
+++ b/components/npc/npc_manager.gd
@@ -89,7 +89,7 @@ func get_npcs_by_gender_dot(app_name: String, preferred_gender: Vector3, min_sim
 		var sim = gender_dot_similarity(preferred_gender, npc.gender_vector)
 		if sim >= min_similarity:
 			matches.append(idx)
-	RNGManager.shuffle(matches)
+     RNGManager.npc_manager.shuffle(matches)
 	return matches.slice(0, count)
 
 func gender_dot_similarity(a: Vector3, b: Vector3) -> float:
@@ -206,7 +206,7 @@ func get_batch_of_recycled_npc_indices(app_name: String, count: int) -> Array[in
 	for idx in encountered:
 		if not active.has(idx) and not persistent_npcs.has(idx):
 			pool.append(idx)
-	RNGManager.shuffle(pool)
+    RNGManager.npc_manager.shuffle(pool)
 	var result: Array[int] = []
 	for idx in pool.slice(0, count):
 		result.append(idx)

--- a/components/portrait/portrait_creator.gd
+++ b/components/portrait/portrait_creator.gd
@@ -126,7 +126,7 @@ func _on_name_submitted(_text: String) -> void:
 
 
 func _on_randomize_pressed() -> void:
-	var rng = RNGManager.get_rng()
+    var rng = RNGManager.portrait_creator.get_rng()
 	config = PortraitFactory.generate_config_for_name(str(rng.randi()))
 	config.name = name_edit.text
 	_sync_ui_with_config()

--- a/components/siggy/siggy.gd
+++ b/components/siggy/siggy.gd
@@ -105,7 +105,7 @@ func talk(text: String, time_per_char := 0.05) -> void:
 
 	var original_pos = siggy_sprite.position
 	var original_rotation = siggy_sprite.rotation_degrees
-	var rng = RNGManager.get_rng()
+    var rng = RNGManager.siggy.get_rng()
 
 	for i in range(total_chars):
 		speech_label.visible_ratio = float(i + 1) / total_chars
@@ -155,7 +155,7 @@ func get_money_tip() -> String:
 	if tips.is_empty():
 		return "Try cutting back on spending for now."
 
-	var rng = RNGManager.get_rng()
+    var rng = RNGManager.siggy.get_rng()
 	return tips[rng.randi() % tips.size()]
 
 func out_of_pocket_wildcard() -> String:
@@ -164,7 +164,7 @@ func out_of_pocket_wildcard() -> String:
 	wildcards.append("...all I'm saying is, buildings don't just fall down like that!")
 	wildcards.append("And that's the day I learned why they're called sperm whales")
 
-	var rng = RNGManager.get_rng()
+    var rng = RNGManager.siggy.get_rng()
 	return str(wildcards[rng.randi_range(0, wildcards.size() - 1)])
 
 func _on_talk_button_pressed() -> void:

--- a/components/ticker.gd
+++ b/components/ticker.gd
@@ -103,7 +103,7 @@ func get_next_ticker_template() -> String:
 			candidates.append(entry)
 	if candidates.is_empty():
 		return "No news is good news."
-	var rng = RNGManager.get_rng()
+    var rng = RNGManager.ticker.get_rng()
 	var selected = candidates[rng.randi() % candidates.size()]
 	return selected.text
 

--- a/resources/crypto/cryptocurrency.gd
+++ b/resources/crypto/cryptocurrency.gd
@@ -26,7 +26,7 @@ func update_price(delta: float) -> void:
 
 
 func update_from_market(volatility_scale: float = 1.0) -> void:
-	var rng: RandomNumberGenerator = RNGManager.get_rng()
+     var rng: RandomNumberGenerator = RNGManager.crypto.get_rng()
 	var noise: float = rng.randf_range(-0.5, 0.5)
 	var max_percent_change: float = volatility / 100.0 * volatility_scale
 	var delta: float = price * max_percent_change * noise


### PR DESCRIPTION
## Summary
- derive deterministic RNG streams for each subsystem in `RNGManager`
- update managers and components to use their dedicated RNG stream

## Testing
- `godot3 --headless -s tests/test_runner.gd` *(fails: expected config version 4)*

------
https://chatgpt.com/codex/tasks/task_e_68a7c4bf75808325b862869d0b66147a