### PR TITLE
Fix background image selection dialog

### DIFF
--- a/components/apps/app_scenes/settings.tscn
+++ b/components/apps/app_scenes/settings.tscn
@@ -765,6 +765,8 @@ text = "Select Image"
 [node name="BackgroundFileDialog" type="FileDialog" parent="."]
 unique_name_in_owner = true
 access = 2
+file_mode = 0
+ok_button_text = "Open"
 
 [connection signal="toggled" from="Panel/MarginContainer/TabContainer/General/HBoxContainer/VBoxContainer2/SiggyButton" to="." method="_on_siggy_button_toggled"]
 [connection signal="pressed" from="Panel/MarginContainer/TabContainer/General/HBoxContainer/VBoxContainer2/CreateAppsFolderButton" to="." method="_on_create_apps_folder_button_pressed"]


### PR DESCRIPTION
## Summary
- Enable selecting background image via open file dialog instead of save dialog

## Testing
- `godot4 --headless -s tests/test_runner.gd` *(fails: command not found)*
- `godot --headless -s tests/test_runner.gd` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68a7d0e621588325bbc1171dd9a448bd