### PR TITLE
Fix RNG seed initialization using password hash

### DIFF
--- a/autoloads/save_manager.gd
+++ b/autoloads/save_manager.gd
@@ -53,20 +53,27 @@ func initialize_new_profile(slot_id: int, user_data: Dictionary) -> void:
 		push_error("❌ Invalid slot_id: %d" % slot_id)
 		return
 
-	reset_managers()
-	BillManager.is_loading = true
-	current_slot_id = slot_id
-	var seed_val: int
-	if not user_data.has("global_rng_seed"):
-		var password = user_data.get("password", "")
-		if password != "":
-			seed_val = PlayerManager.djb2(password)
-	else:
-		seed_val = int(Time.get_unix_time_from_system())
-	user_data["global_rng_seed"] = seed_val
-	RNGManager.init_seed(int(user_data["global_rng_seed"]))
-	PlayerManager.user_data = user_data.duplicate(true)
-	PlayerManager.ensure_default_stats()
+        reset_managers()
+        BillManager.is_loading = true
+        current_slot_id = slot_id
+
+        # Respect an existing seed when creating a new profile. If no seed is
+        # provided (or it's 0), derive one from the user's password using the
+        # djb2 hash. Only fall back to the current Unix time when a password is
+        # unavailable. This avoids overwriting the deterministic seed generated
+        # during profile creation.
+        var seed_val: int = user_data.get("global_rng_seed", 0)
+        if seed_val == 0:
+                var password = user_data.get("password", "")
+                if password != "":
+                        seed_val = PlayerManager.djb2(password)
+                else:
+                        seed_val = int(Time.get_unix_time_from_system())
+                user_data["global_rng_seed"] = seed_val
+
+        RNGManager.init_seed(int(seed_val))
+        PlayerManager.user_data = user_data.duplicate(true)
+        PlayerManager.ensure_default_stats()
 
 	var background = user_data.get("background", "")
 	if background != "":


### PR DESCRIPTION
## Summary
- Preserve deterministic RNG seed set during profile creation
- Derive seed from password via djb2 hash when absent, falling back to unix time

## Testing
- `godot --headless --path /workspace/SigmaSim tests/test_runner.tscn` *(fails: resources not imported)*

------
https://chatgpt.com/codex/tasks/task_e_68a7df8ecf248325af445524f4ceb228