### PR TITLE
Add flat color overlay controls for warp shader

### DIFF
--- a/autoloads/player_manager.gd
+++ b/autoloads/player_manager.gd
@@ -11,6 +11,8 @@ const DEFAULT_BACKGROUND_SHADERS := {
 "color_low": {"r": 0.02, "g": 0.05, "b": 0.10, "a": 1.0},
 "color_mid": {"r": 0.10, "g": 0.30, "b": 0.55, "a": 1.0},
 "color_high": {"r": 0.30, "g": 0.60, "b": 0.85, "a": 1.0},
+"flat_color": {"r": 0.0, "g": 0.0, "b": 0.2, "a": 1.0},
+"flat_visible": false,
 },
 "ComicDots1": {
 "circle_color": {"r": 0.00000481308, "g": 0.665883, "b": 0.95733, "a": 1.0},

--- a/components/apps/app_scenes/settings.tscn
+++ b/components/apps/app_scenes/settings.tscn
@@ -192,6 +192,9 @@ color_picker_params = Array[StringName]([&"color_low", &"color_mid", &"color_hig
 toggle_button_path = NodePath("MarginContainer/VBoxContainer/BlueWarpButton")
 reset_button_path = NodePath("MarginContainer/VBoxContainer/BlueWarpResetButton")
 collect_warp_shaders = true
+flat_color_picker_path = NodePath("MarginContainer/VBoxContainer/ColorRowFlat/BlueWarpFlatColorPicker")
+flat_color_toggle_path = NodePath("MarginContainer/VBoxContainer/ColorRowFlat/BlueWarpFlatToggle")
+flat_color_rect_path = NodePath("/root/DesktopEnv/ShaderBackgroundsContainer/BlueWarpFlatColor")
 
 [node name="MarginContainer" type="MarginContainer" parent="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/BlueWarpContainer"]
 layout_mode = 2
@@ -248,6 +251,25 @@ text = "High"
 unique_name_in_owner = true
 custom_minimum_size = Vector2(32, 0)
 layout_mode = 2
+
+[node name="ColorRowFlat" type="HBoxContainer" parent="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/BlueWarpContainer/MarginContainer/VBoxContainer"]
+layout_mode = 2
+
+[node name="Label" type="Label" parent="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/BlueWarpContainer/MarginContainer/VBoxContainer/ColorRowFlat"]
+layout_mode = 2
+text = "Flat"
+
+[node name="BlueWarpFlatColorPicker" type="ColorPickerButton" parent="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/BlueWarpContainer/MarginContainer/VBoxContainer/ColorRowFlat"]
+unique_name_in_owner = true
+custom_minimum_size = Vector2(32, 0)
+layout_mode = 2
+color = Color(0, 0, 0.2, 1)
+
+[node name="BlueWarpFlatToggle" type="CheckButton" parent="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/BlueWarpContainer/MarginContainer/VBoxContainer/ColorRowFlat"]
+unique_name_in_owner = true
+layout_mode = 2
+focus_mode = 0
+text = "Show"
 
 [node name="HBoxContainer" type="HBoxContainer" parent="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/BlueWarpContainer/MarginContainer/VBoxContainer"]
 layout_mode = 2

--- a/components/desktop_env.tscn
+++ b/components/desktop_env.tscn
@@ -331,6 +331,17 @@ grow_vertical = 2
 script = ExtResource("24_jkb4t")
 background_name = "Waves"
 
+[node name="BlueWarpFlatColor" type="ColorRect" parent="ShaderBackgroundsContainer"]
+unique_name_in_owner = true
+visible = false
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+color = Color(0, 0, 0.2, 1)
+
 [node name="BlueWarpShader" type="PanelContainer" parent="ShaderBackgroundsContainer"]
 unique_name_in_owner = true
 visible = false

--- a/scripts/desktop_env.gd
+++ b/scripts/desktop_env.gd
@@ -11,6 +11,7 @@ const FOLDER_SHORTCUT_SCENE: PackedScene = preload("res://components/desktop/fol
 @onready var background: TextureRect = %Background
 
 @onready var blue_warp_shader_material: ShaderMaterial = %BlueWarpShader.material
+@onready var blue_warp_flat_color_rect: ColorRect = %BlueWarpFlatColor
 @onready var comic_dots1_shader_material: ShaderMaterial = %ComicDotsBlueVert.material
 @onready var comic_dots2_shader_material: ShaderMaterial = %ComicDotsBlueHor.material
 @onready var waves_shader_material: ShaderMaterial = %WavesShader.material
@@ -81,6 +82,10 @@ func _apply_shader_settings() -> void:
 	blue_warp_shader_material.set_shader_parameter("color_low", PlayerManager.get_shader_param("BlueWarp", "color_low", PlayerManager.dict_to_color(bw_def["color_low"])))
 	blue_warp_shader_material.set_shader_parameter("color_mid", PlayerManager.get_shader_param("BlueWarp", "color_mid", PlayerManager.dict_to_color(bw_def["color_mid"])))
 	blue_warp_shader_material.set_shader_parameter("color_high", PlayerManager.get_shader_param("BlueWarp", "color_high", PlayerManager.dict_to_color(bw_def["color_high"])))
+	var flat_color = PlayerManager.get_shader_param("BlueWarp", "flat_color", PlayerManager.dict_to_color(bw_def.get("flat_color", {"r": 0.0, "g": 0.0, "b": 0.2, "a": 1.0})))
+	var flat_visible = PlayerManager.get_shader_param("BlueWarp", "flat_visible", bw_def.get("flat_visible", false))
+	blue_warp_flat_color_rect.color = flat_color
+	blue_warp_flat_color_rect.visible = flat_visible
 
 	var cd1_def = defaults["ComicDots1"]
 	var cd1_color = PlayerManager.get_shader_param("ComicDots1", "circle_color", PlayerManager.dict_to_color(cd1_def["circle_color"]))


### PR DESCRIPTION
## Summary
- add flat color overlay layer behind BlueWarp background
- expose color picker and toggle controls in settings
- store and apply flat color and visibility through PlayerManager
- normalize indentation in shader controller and desktop environment scripts to match project style

## Testing
- `apt-get install -y godot3-server`
- `godot3-server --headless -s tests/test_runner.gd` *(fails: Can't open project; config_version 5 requires newer engine)*
- `wget https://downloads.tuxfamily.org/godotengine/4.2.1/Godot_v4.2.1-stable_linux_headless.64.zip -O godot_headless.zip` *(fails: 503 Service Unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68a7cf37ac2c832583da8ff382a0320b