### PR TITLE
Add Strong Bond upgrade and Ex Factor upgrade UI

### DIFF
--- a/components/npc/npc_manager.gd
+++ b/components/npc/npc_manager.gd
@@ -170,12 +170,13 @@ func _on_hour_passed(_current_hour: int, _total_minutes: int) -> void:
 	for entry in entries:
 		var npc_idx: int = int(entry.npc_id)
 		var npc: NPC = get_npc_by_index(npc_idx)
-		var target: float = npc.affinity_equilibrium
-		var current: float = npc.affinity
-		if current < target:
-			set_npc_field(npc_idx, "affinity", min(current + 1.0, target))
-		elif current > target:
-			set_npc_field(npc_idx, "affinity", max(current - 1.0, target))
+               var target: float = npc.affinity_equilibrium
+               var current: float = npc.affinity
+               var rate: float = StatManager.get_stat("affinity_drift_rate", 1.0)
+               if current < target:
+                       set_npc_field(npc_idx, "affinity", min(current + rate, target))
+               elif current > target:
+                       set_npc_field(npc_idx, "affinity", max(current - rate, target))
 
 # === BATCH HELPERS ===
 

--- a/components/popups/ex_factor_view.tscn
+++ b/components/popups/ex_factor_view.tscn
@@ -6,6 +6,7 @@
 [ext_resource type="Shader" uid="uid://n1vlc8cxnun0" path="res://assets/shaders/warp_shader.gdshader" id="3_vl6ok"]
 [ext_resource type="PackedScene" uid="uid://drm1apbdsjj5g" path="res://components/portrait/portrait_view.tscn" id="4"]
 [ext_resource type="Script" uid="uid://bvbiboe20qioe" path="res://components/popups/relationship_bar.gd" id="5"]
+[ext_resource type="PackedScene" path="res://components/upgrade_scenes/ex_factor_upgrade_ui.tscn" id="6"]
 
 [sub_resource type="ShaderMaterial" id="ShaderMaterial_78wgo"]
 resource_local_to_scene = true
@@ -44,6 +45,7 @@ is_popup = true
 color1 = Color(0.774734, 0.000462633, 0.774729, 1)
 color2 = Color(0.710983, 0.236749, 0.982591, 1)
 color3 = Color(0.992747, 0.58839, 1, 1)
+upgrade_pane = ExtResource("6")
 
 [node name="ColorRect" type="ColorRect" parent="."]
 material = SubResource("ShaderMaterial_78wgo")

--- a/components/upgrade_scenes/ex_factor_upgrade_ui.gd
+++ b/components/upgrade_scenes/ex_factor_upgrade_ui.gd
@@ -1,0 +1,2 @@
+extends Pane
+class_name ExFactorUpgradeUI

--- a/components/upgrade_scenes/ex_factor_upgrade_ui.tscn
+++ b/components/upgrade_scenes/ex_factor_upgrade_ui.tscn
@@ -1,0 +1,37 @@
+[gd_scene load_steps=3 format=3]
+
+[ext_resource type="Script" path="res://components/upgrade_scenes/ex_factor_upgrade_ui.gd" id="1"]
+[ext_resource type="PackedScene" path="res://data/upgrades/system_upgrade_ui.tscn" id="2"]
+
+[node name="ExFactorUpgradeUI" type="PanelContainer"]
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+mouse_filter = 1
+script = ExtResource("1")
+window_title = "e[sup]x[/sup] Factor Upgrades"
+default_window_size = Vector2(480, 480)
+
+[node name="MarginContainer" type="MarginContainer" parent="."]
+layout_mode = 2
+theme_override_constants/margin_left = 15
+theme_override_constants/margin_top = 15
+theme_override_constants/margin_right = 15
+theme_override_constants/margin_bottom = 15
+
+[node name="VBoxContainer" type="VBoxContainer" parent="MarginContainer"]
+layout_mode = 2
+
+[node name="RichTextLabel" type="RichTextLabel" parent="MarginContainer/VBoxContainer"]
+layout_mode = 2
+text = "e[sup]x[/sup] Factor Upgrades"
+horizontal_alignment = 1
+
+[node name="SystemUpgradeUI" parent="MarginContainer/VBoxContainer" instance=ExtResource("2")]
+layout_mode = 2
+size_flags_vertical = 3
+system_name = "e[sup]x[/sup] Factor"

--- a/data/stats/base_stats.json
+++ b/data/stats/base_stats.json
@@ -7,6 +7,7 @@
   "power_per_click": 1.0,
   "cash_per_score": 0.01,
   "autopilot_cost": 1.0,
+  "affinity_drift_rate": 1.0,
   "worm_yield": 1.0,
   "upgrade_cooldown_multiplier": 1.0
 }

--- a/data/upgrades/ex_factor_strong_bond.json
+++ b/data/upgrades/ex_factor_strong_bond.json
@@ -1,0 +1,22 @@
+{
+  "id": "ex_factor_strong_bond",
+  "name": "Strong Bond",
+  "description": "Halves the speed of affinity drift towards equilibrium.",
+  "effects": [
+    {
+      "target": "affinity_drift_rate",
+      "operation": "mul",
+      "value": 0.5,
+      "scale_with_level": false
+    }
+  ],
+  "systems": [
+    "e[sup]x[/sup] Factor"
+  ],
+  "dependencies": [],
+  "cost_per_level": {
+    "ex": 100
+  },
+  "max_level": 1,
+  "repeatable": false
+}


### PR DESCRIPTION
## Summary
- Add ExFactorUpgradeUI scene and wire it into ExFactorView
- Introduce Strong Bond upgrade that halves affinity drift toward equilibrium
- Track affinity_drift_rate in stats and apply it in NPCManager

## Testing
- `godot3 --headless -s tests/test_runner.gd` *(fails: project's config_version requires Godot 4)*

------
https://chatgpt.com/codex/tasks/task_e_68a7f3a24970832595701c64b1f999ff