### PR TITLE
Use shader colors for pane palettes

### DIFF
--- a/components/apps/app_scenes/alpha_instant_messenger.tscn
+++ b/components/apps/app_scenes/alpha_instant_messenger.tscn
@@ -45,6 +45,9 @@ window_title = "AIM"
 window_icon = ExtResource("3_8iipa")
 default_window_size = Vector2(190, 480)
 default_position = "left"
+color1 = Color(1, 1, 1, 1)
+color2 = Color(1, 1, 1, 1)
+color3 = Color(1, 1, 1, 1)
 
 [node name="ColorRect" type="ColorRect" parent="."]
 material = SubResource("ShaderMaterial_w0u3w")

--- a/components/apps/app_scenes/broke_rage.tscn
+++ b/components/apps/app_scenes/broke_rage.tscn
@@ -51,6 +51,9 @@ script = ExtResource("2_o2yqo")
 window_title = "BrokeRage"
 window_icon = ExtResource("3_m7phi")
 default_window_size = Vector2(735, 500)
+color1 = Color(0, 0, 0, 1)
+color2 = Color(0.15, 0.15, 0.15, 1)
+color3 = Color(0.25, 0.25, 0.25, 1)
 
 [node name="ColorRect" type="ColorRect" parent="."]
 material = SubResource("ShaderMaterial_o2yqo")

--- a/components/apps/app_scenes/minerr.tscn
+++ b/components/apps/app_scenes/minerr.tscn
@@ -37,6 +37,9 @@ crypto_card_scene = ExtResource("3_ykms3")
 window_title = "Minerr"
 window_icon = ExtResource("4_23boj")
 default_window_size = Vector2(550, 500)
+color1 = Color(0.03, 0.02, 0.02, 1)
+color2 = Color(0.12, 0.08, 0.05, 1)
+color3 = Color(0.35, 0.22, 0.15, 1)
 
 [node name="ColorRect" type="ColorRect" parent="."]
 material = SubResource("ShaderMaterial_wupxk")

--- a/components/apps/app_scenes/settings.tscn
+++ b/components/apps/app_scenes/settings.tscn
@@ -42,6 +42,9 @@ script = ExtResource("1_wlela")
 window_title = "Settings"
 window_icon = ExtResource("2_wlela")
 default_window_size = Vector2(720, 510)
+color1 = Color(0, 0, 0, 1)
+color2 = Color(0.15, 0.15, 0.15, 1)
+color3 = Color(0.25, 0.25, 0.25, 1)
 
 [node name="Panel" type="PanelContainer" parent="."]
 layout_mode = 2

--- a/components/apps/daterbase/daterbase.tscn
+++ b/components/apps/daterbase/daterbase.tscn
@@ -42,6 +42,9 @@ theme = ExtResource("1")
 script = ExtResource("2")
 window_title = "Daterbase"
 default_window_size = Vector2(800, 480)
+color1 = Color(0.213765, 0, 0.213765, 1)
+color2 = Color(1, 0.579437, 1, 1)
+color3 = Color(1, 1, 1, 1)
 
 [node name="ColorRect" type="ColorRect" parent="."]
 material = SubResource("ShaderMaterial_j8wav")

--- a/components/apps/fumble/fumble.tscn
+++ b/components/apps/fumble/fumble.tscn
@@ -72,6 +72,9 @@ script = ExtResource("1_v4fb6")
 window_title = "Fumble"
 default_window_size = Vector2(660, 720)
 upgrade_pane = ExtResource("2_hf3uq")
+color1 = Color(0.05, 0.1, 0.05, 1)
+color2 = Color(0.1, 0.4, 0.15, 1)
+color3 = Color(0.25, 0.65, 0.3, 1)
 
 [node name="ColorRect" type="ColorRect" parent="."]
 material = SubResource("ShaderMaterial_jh1fk")

--- a/components/apps/new_you/new_you.tscn
+++ b/components/apps/new_you/new_you.tscn
@@ -32,6 +32,9 @@ window_title = "NewYou"
 window_icon = ExtResource("2_73mvd")
 default_window_size = Vector2(340, 305)
 show_in_taskbar = false
+color1 = Color(0.6, 0.65, 1, 1)
+color2 = Color(0.3, 0.55, 1, 1)
+color3 = Color(0.2, 0.25, 0.9, 1)
 
 [node name="ColorRect" type="ColorRect" parent="."]
 material = SubResource("ShaderMaterial_73mvd")

--- a/components/popups/ex_factor_view.tscn
+++ b/components/popups/ex_factor_view.tscn
@@ -41,9 +41,9 @@ script = ExtResource("2")
 window_title = "e[sup]x[/sup] Factor"
 default_window_size = Vector2(400, 500)
 is_popup = true
-color1 = Color(0.774734, 0.000462633, 0.774729, 1)
-color2 = Color(0.710983, 0.236749, 0.982591, 1)
-color3 = Color(0.992747, 0.58839, 1, 1)
+color1 = Color(1, 0, 0.941176, 1)
+color2 = Color(0.463319, 0.00196373, 0.715449, 1)
+color3 = Color(1, 1, 1, 1)
 
 [node name="ColorRect" type="ColorRect" parent="."]
 material = SubResource("ShaderMaterial_78wgo")


### PR DESCRIPTION
## Summary
- Assign color1-3 exports in pane scenes based on their shader palettes
- Ensure each pane carries a distinct color scheme

## Testing
- `godot --headless -s tests/test_runner.gd` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a7f52d293083258d2104f8de2e26e1