### PR TITLE
Expose Balala shader parameters in settings

### DIFF
--- a/autoloads/events.gd
+++ b/autoloads/events.gd
@@ -4,13 +4,14 @@ signal desktop_background_toggled(name: String, visible: bool)
 signal upgrade_purchased(id: String, level: int)
 
 var desktop_backgrounds: Dictionary = {
-		"BlueWarp": true,
-		"ComicDots1": false,
-		"ComicDots2": false,
-		"Waves": false,
-		"Electric": false,
-		"Background": false,
-		"FlatColor": false,
+	"BlueWarp": true,
+	"ComicDots1": false,
+	"ComicDots2": false,
+	"Waves": false,
+	"Electric": false,
+	"Balala": false,
+	"Background": false,
+	"FlatColor": false,
 }
 
 func set_desktop_background_visible(name: String, visible: bool) -> void:

--- a/autoloads/player_manager.gd
+++ b/autoloads/player_manager.gd
@@ -41,6 +41,14 @@ const DEFAULT_BACKGROUND_SHADERS := {
 "scale_x": 3.25,
 "scale_y": 15.43,
 },
+"Balala": {
+"color_one": {"r": 0.4, "g": 0.2, "b": 0.6, "a": 1.0},
+"color_two": {"r": 0.0, "g": 0.0, "b": 0.0, "a": 1.0},
+"angle": 20.0,
+"line_count": 20.0,
+"speed": 10.0,
+"blur": 0.0,
+},
 "FlatColor": {
 "color": {"r": 0.0, "g": 0.0, "b": 0.0, "a": 1.0},
 },

--- a/components/apps/app_scenes/settings.tscn
+++ b/components/apps/app_scenes/settings.tscn
@@ -574,6 +574,118 @@ value = 15.43
 layout_mode = 2
 text = "Reset"
 
+[node name="BalalaContainer" type="PanelContainer" parent="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer"]
+layout_mode = 2
+size_flags_horizontal = 6
+mouse_filter = 1
+script = ExtResource("5_p2fk4")
+shader_name = "Balala"
+shader_node_paths = Array[String](["Main/DesktopEnv/ShaderBackgroundsContainer/Balala"])
+color_picker_nodes = Array[NodePath]([NodePath("MarginContainer/VBoxContainer/HBoxContainer/BalalaColorOnePicker"), NodePath("MarginContainer/VBoxContainer/HBoxContainer/BalalaColorTwoPicker")])
+color_picker_params = Array[StringName]([&"color_one", &"color_two"])
+slider_nodes = Array[NodePath]([NodePath("MarginContainer/VBoxContainer/HBoxContainer2/BalalaAngleSlider"), NodePath("MarginContainer/VBoxContainer/HBoxContainer3/BalalaLineCountSlider"), NodePath("MarginContainer/VBoxContainer/HBoxContainer4/BalalaSpeedSlider"), NodePath("MarginContainer/VBoxContainer/HBoxContainer5/BalalaBlurSlider")])
+slider_params = Array[StringName]([&"angle", &"line_count", &"speed", &"blur"])
+toggle_button_path = NodePath("MarginContainer/VBoxContainer/BalalaButton")
+reset_button_path = NodePath("MarginContainer/VBoxContainer/BalalaResetButton")
+
+[node name="MarginContainer" type="MarginContainer" parent="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/BalalaContainer"]
+layout_mode = 2
+theme_override_constants/margin_left = 15
+theme_override_constants/margin_top = 15
+theme_override_constants/margin_right = 15
+theme_override_constants/margin_bottom = 15
+
+[node name="VBoxContainer" type="VBoxContainer" parent="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/BalalaContainer/MarginContainer"]
+custom_minimum_size = Vector2(180, 0)
+layout_mode = 2
+
+[node name="BalalaButton" type="CheckButton" parent="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/BalalaContainer/MarginContainer/VBoxContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+text = "Balala"
+
+[node name="HBoxContainer" type="HBoxContainer" parent="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/BalalaContainer/MarginContainer/VBoxContainer"]
+layout_mode = 2
+
+[node name="BalalaColorOnePicker" type="ColorPickerButton" parent="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/BalalaContainer/MarginContainer/VBoxContainer/HBoxContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+color = Color(0.4, 0.2, 0.6, 1)
+
+[node name="BalalaColorTwoPicker" type="ColorPickerButton" parent="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/BalalaContainer/MarginContainer/VBoxContainer/HBoxContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+color = Color(0, 0, 0, 1)
+
+[node name="HBoxContainer2" type="HBoxContainer" parent="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/BalalaContainer/MarginContainer/VBoxContainer"]
+layout_mode = 2
+
+[node name="Label" type="Label" parent="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/BalalaContainer/MarginContainer/VBoxContainer/HBoxContainer2"]
+layout_mode = 2
+text = "Angle"
+
+[node name="BalalaAngleSlider" type="HSlider" parent="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/BalalaContainer/MarginContainer/VBoxContainer/HBoxContainer2"]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 3
+min_value = 0.0
+max_value = 360.0
+step = 1.0
+value = 20.0
+
+[node name="HBoxContainer3" type="HBoxContainer" parent="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/BalalaContainer/MarginContainer/VBoxContainer"]
+layout_mode = 2
+
+[node name="Label" type="Label" parent="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/BalalaContainer/MarginContainer/VBoxContainer/HBoxContainer3"]
+layout_mode = 2
+text = "Line Count"
+
+[node name="BalalaLineCountSlider" type="HSlider" parent="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/BalalaContainer/MarginContainer/VBoxContainer/HBoxContainer3"]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 3
+min_value = 1.0
+max_value = 100.0
+step = 1.0
+value = 20.0
+
+[node name="HBoxContainer4" type="HBoxContainer" parent="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/BalalaContainer/MarginContainer/VBoxContainer"]
+layout_mode = 2
+
+[node name="Label" type="Label" parent="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/BalalaContainer/MarginContainer/VBoxContainer/HBoxContainer4"]
+layout_mode = 2
+text = "Speed"
+
+[node name="BalalaSpeedSlider" type="HSlider" parent="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/BalalaContainer/MarginContainer/VBoxContainer/HBoxContainer4"]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 3
+min_value = 0.0
+max_value = 50.0
+step = 0.1
+value = 10.0
+
+[node name="HBoxContainer5" type="HBoxContainer" parent="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/BalalaContainer/MarginContainer/VBoxContainer"]
+layout_mode = 2
+
+[node name="Label" type="Label" parent="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/BalalaContainer/MarginContainer/VBoxContainer/HBoxContainer5"]
+layout_mode = 2
+text = "Blur"
+
+[node name="BalalaBlurSlider" type="HSlider" parent="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/BalalaContainer/MarginContainer/VBoxContainer/HBoxContainer5"]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 3
+min_value = 0.0
+max_value = 2.0
+step = 0.01
+value = 0.0
+
+[node name="BalalaResetButton" type="Button" parent="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/BalalaContainer/MarginContainer/VBoxContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+text = "Reset"
+
 [node name="HBoxContainer2" type="HBoxContainer" parent="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer"]
 layout_mode = 2
 

--- a/components/desktop_env.tscn
+++ b/components/desktop_env.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=53 format=3 uid="uid://dkhodakv1x0h7"]
+[gd_scene load_steps=55 format=3 uid="uid://dkhodakv1x0h7"]
 
 [ext_resource type="Theme" uid="uid://dyhdr7sojcl5h" path="res://assets/windows_xp_theme.tres" id="1_0utxc"]
 [ext_resource type="Script" uid="uid://x031tiyraogl" path="res://scripts/desktop_env.gd" id="1_lpqk7"]
@@ -30,6 +30,7 @@
 [ext_resource type="Script" uid="uid://cmmevgi7d0n3h" path="res://components/start_panel_window.gd" id="23_dik0q"]
 [ext_resource type="Script" uid="uid://c7t01yq8wloqf" path="res://components/desktop_background.gd" id="24_jkb4t"]
 [ext_resource type="Shader" uid="uid://biinvb18hl7lc" path="res://assets/shaders/flat_color_background.gdshader" id="25_flat"]
+[ext_resource type="Shader" uid="uid://cslh8x6hic5cn" path="res://assets/shaders/scrolling_lines_shader.gdshader" id="26_cslh8"]
 
 [sub_resource type="ShaderMaterial" id="ShaderMaterial_flat"]
 shader = ExtResource("25_flat")
@@ -56,6 +57,15 @@ shader_parameter/speed = 0.03
 shader_parameter/color_low = Color(0.02, 0.05, 0.1, 1)
 shader_parameter/color_mid = Color(0.1, 0.3, 0.55, 1)
 shader_parameter/color_high = Color(0.3, 0.6, 0.85, 1)
+
+[sub_resource type="ShaderMaterial" id="ShaderMaterial_cslh8"]
+shader = ExtResource("26_cslh8")
+shader_parameter/color_one = Color(0.4, 0.2, 0.6, 1)
+shader_parameter/color_two = Color(0, 0, 0, 1)
+shader_parameter/angle = 20.0
+shader_parameter/line_count = 20.0
+shader_parameter/speed = 10.0
+shader_parameter/blur = 0.0
 
 [sub_resource type="ShaderMaterial" id="ShaderMaterial_ptlp0"]
 shader = ExtResource("7_ptlp0")
@@ -379,6 +389,19 @@ grow_horizontal = 2
 grow_vertical = 2
 script = ExtResource("24_jkb4t")
 background_name = "Electric"
+
+[node name="Balala" type="ColorRect" parent="ShaderBackgroundsContainer"]
+unique_name_in_owner = true
+visible = false
+material = SubResource("ShaderMaterial_cslh8")
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+script = ExtResource("24_jkb4t")
+background_name = "Balala"
 
 [node name="ComicDotsBlueVert" type="ColorRect" parent="ShaderBackgroundsContainer"]
 unique_name_in_owner = true


### PR DESCRIPTION
## Summary
- Standardize desktop background formatting and add Balala shader defaults
- Hook Balala background to new scrolling lines shader and expose all parameters in Settings

## Testing
- `godot --headless --script tests/test_runner.gd` *(command not found)*
- `apt-get install -y godot4` *(package not found)*
- `godot4 --headless --script tests/test_runner.gd` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a7f8ad425c83259ab1d7cd28fd47f2