### PR TITLE
Cache EarlyBird viewport size when window minimized

### DIFF
--- a/components/apps/early_bird/pipe_manager.gd
+++ b/components/apps/early_bird/pipe_manager.gd
@@ -7,12 +7,16 @@ class_name EarlyBirdPipeManager
 @export var spawn_x_offset: float = 1000.0
 
 var spawn_timer: Timer
+var cached_viewport_size: Vector2
 
 func _ready() -> void:
-	spawn_timer = Timer.new()
-	spawn_timer.wait_time = spawn_interval
-	spawn_timer.timeout.connect(_on_spawn_pipe_pair)
-	add_child(spawn_timer)
+        spawn_timer = Timer.new()
+        spawn_timer.wait_time = spawn_interval
+        spawn_timer.timeout.connect(_on_spawn_pipe_pair)
+        add_child(spawn_timer)
+
+        cached_viewport_size = get_viewport_rect().size
+        get_viewport().size_changed.connect(_on_viewport_size_changed)
 	
 
 func start_spawning() -> void:
@@ -22,22 +26,22 @@ func stop_spawning() -> void:
 	spawn_timer.stop()
 
 func reset() -> void:
-	stop_spawning()
-	for child in get_children():
-		if child is EarlyBirdPipePair:
-			child.queue_free()
+        stop_spawning()
+        for child in get_children():
+                if child is EarlyBirdPipePair:
+                        child.queue_free()
 
 func _on_spawn_pipe_pair() -> void:
 	var pipe_pair = pipe_pair_scene.instantiate()
 	add_child(pipe_pair)
 	
-	pipe_pair.global_position = Vector2(
-	get_viewport_rect().size.x + spawn_x_offset,
-	0
-	)
-	pipe_pair.player = %EarlyBirdPlayer
+        pipe_pair.global_position = Vector2(
+        cached_viewport_size.x + spawn_x_offset,
+        0
+        )
+        pipe_pair.player = %EarlyBirdPlayer
 
-	pipe_pair.randomize_gap_position()
+        pipe_pair.randomize_gap_position(cached_viewport_size.y)
 
 func set_move_speed(new_speed: float) -> void:
 	for child in get_children():
@@ -47,9 +51,14 @@ func set_move_speed(new_speed: float) -> void:
 	# Adjust spawn interval: faster speed = spawn farther apart
 	spawn_interval = clamp(1 + (100.0 / new_speed), 0.25, 2) 
 	if spawn_timer:
-		spawn_timer.wait_time = spawn_interval
+                spawn_timer.wait_time = spawn_interval
 
 
+
+func _on_viewport_size_changed() -> void:
+        var new_size = get_viewport_rect().size
+        if new_size.x > 1 and new_size.y > 1:
+                cached_viewport_size = new_size
 
 
 func get_active_pipe_pairs() -> Array[EarlyBirdPipePair]:

--- a/components/apps/early_bird/pipe_pair.gd
+++ b/components/apps/early_bird/pipe_pair.gd
@@ -13,29 +13,28 @@ var player: Node = null # Reference to player for scoring check
 
 
 func _physics_process(delta: float) -> void:
-	position.x -= move_speed * delta
+        position.x -= move_speed * delta
 
-	# Check for scoring
-	if not scored and player:
-		if player.global_position.x > global_position.x:
-			if player.is_alive:
-				player.add_point()
-			scored = true
+        # Check for scoring
+        if not scored and player:
+                if player.global_position.x > global_position.x:
+                        if player.is_alive:
+                                player.add_point()
+                        scored = true
 
-	if position.x < -300:
-		queue_free()
+        if position.x < -300:
+                queue_free()
 
-func randomize_gap_position() -> void:
-	var viewport_height = get_parent().get_parent().size.y
-	var safe_margin = 50.0
+func randomize_gap_position(viewport_height: float) -> void:
+        var safe_margin = 50.0
 
-	# Randomize center Y position for the GAP
-	var rng = RNGManager.early_bird.get_rng()
-	var gap_center_y = rng.randf_range(
-			safe_margin + gap_size / 2,
-			viewport_height - safe_margin - gap_size / 2
-	)
-	position.y = gap_center_y
+        # Randomize center Y position for the GAP
+        var rng = RNGManager.early_bird.get_rng()
+        var gap_center_y = rng.randf_range(
+                        safe_margin + gap_size / 2,
+                        viewport_height - safe_margin - gap_size / 2
+        )
+        position.y = gap_center_y
 
 
 


### PR DESCRIPTION
## Summary
- Cache viewport dimensions and ignore minimized size updates
- Spawn pipes using cached size and pass height to gap randomizer

## Testing
- `godot --headless -s tests/test_runner.gd` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a7fb2cc0bc8325ab772b9ac457f53e