### PR TITLE
Fix background image loading in settings window

### DIFF
--- a/components/settings_window.gd
+++ b/components/settings_window.gd
@@ -297,12 +297,11 @@ func _on_background_select_image_button_pressed() -> void:
 		background_file_dialog.popup_centered()
 
 func _on_background_file_dialog_file_selected(path: String) -> void:
-	var image := Image.new()
-	var err := image.load(path)
-	if err == OK:
-			var tex: Texture2D = ImageTexture.create_from_image(image)
-			var bg: TextureRect = get_tree().root.get_node("Main/DesktopEnv/Background")
-			bg.texture = tex
-			PlayerManager.set_var("background_path", path)
+	var image: Image = Image.load_from_file(path)
+	if image and image.get_width() > 0:
+		var tex: Texture2D = ImageTexture.create_from_image(image)
+		var bg: TextureRect = get_tree().root.get_node("Main/DesktopEnv/Background")
+		bg.texture = tex
+		PlayerManager.set_var("background_path", path)
 	else:
-			print("❌ Couldn't load texture from path: ", path)
+		push_error("❌ Couldn't load texture from path: %s" % path)


### PR DESCRIPTION
## Summary
- Use `Image.load_from_file` to load arbitrary background images and apply to desktop
- Log an error when the selected image fails to load

## Testing
- `godot --version` *(fails: command not found)*
- `apt-get install -y godot4` *(fails: Unable to locate package godot4)*
- `apt-get install -y godot` *(fails: Unable to locate package godot)*

------
https://chatgpt.com/codex/tasks/task_e_68a8120c0e8883259eaba17d739f47ba