### PR TITLE
Fix flat color overlay path for warp shader module

### DIFF
--- a/components/apps/app_scenes/settings.tscn
+++ b/components/apps/app_scenes/settings.tscn
@@ -197,7 +197,7 @@ reset_button_path = NodePath("MarginContainer/VBoxContainer/BlueWarpResetButton"
 collect_warp_shaders = true
 flat_color_picker_path = NodePath("MarginContainer/VBoxContainer/ColorRowFlat/BlueWarpFlatColorPicker")
 flat_color_toggle_path = NodePath("MarginContainer/VBoxContainer/ColorRowFlat/BlueWarpFlatToggle")
-flat_color_rect_path = NodePath("/root/DesktopEnv/ShaderBackgroundsContainer/BlueWarpFlatColor")
+flat_color_rect_path = NodePath("Main/DesktopEnv/ShaderBackgroundsContainer/BlueWarpFlatColor")
 
 [node name="MarginContainer" type="MarginContainer" parent="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/BlueWarpContainer"]
 layout_mode = 2


### PR DESCRIPTION
## Summary
- fix BlueWarp warp shader module so its flat color overlay toggles correctly

## Testing
- `godot3-server --headless -s tests/test_runner.gd` *(fails: Can't open project because its config_version is 5; expected 4)*

------
https://chatgpt.com/codex/tasks/task_e_68a8182f77908325b27249d5fbb2cee2