### PR TITLE
Ensure attempt_spend enforces credit requirements

### DIFF
--- a/autoloads/portfolio_manager.gd
+++ b/autoloads/portfolio_manager.gd
@@ -53,10 +53,7 @@ const CREDIT_REQUIREMENTS := {
 		
 }
 # attempt_spend without credit argument:
-# autoloads/upgrade_manager.gd -> _deduct_currency
-# components/popups/ex_factor_view.gd -> _on_gift_pressed, _on_date_pressed
 # components/ui/hire_popup.gd -> worker hire in _populate_hire_tab
-# components/apps/early_bird/early_bird.gd -> _on_autopilot_button_pressed
 
 
 

--- a/autoloads/upgrade_manager.gd
+++ b/autoloads/upgrade_manager.gd
@@ -278,8 +278,8 @@ func _get_currency_amount(currency: String) -> float:
 	return PortfolioManager.get_crypto_amount(currency)
 
 func _deduct_currency(currency: String, amount: float) -> bool:
-	if currency == "cash":
-		return PortfolioManager.attempt_spend(amount)
+    if currency == "cash":
+            return PortfolioManager.attempt_spend(amount, PortfolioManager.CREDIT_REQUIREMENTS["upgrades"])
 	if currency == "ex":
 		if StatManager.get_stat("ex") < amount:
 			return false

--- a/components/apps/early_bird/early_bird.gd
+++ b/components/apps/early_bird/early_bird.gd
@@ -167,16 +167,16 @@ func _on_quit_pressed() -> void:
 		window_frame.queue_free()
 
 func _on_autopilot_button_pressed() -> void:
-		if autopilot == null:
-				return
-		var cost := _get_autopilot_cost()
-		if not autopilot.enabled:
-				if cost > 0.0 and not PortfolioManager.attempt_spend(cost):
-						autopilot_button.button_pressed = false
-						return
-				autopilot.enabled = true
-				if cost > 0.0:
-						autopilot_cost = snapped(autopilot_cost + 0.01, 0.01)
+                if autopilot == null:
+                                return
+                var cost := _get_autopilot_cost()
+                if not autopilot.enabled:
+                                if cost > 0.0 and not PortfolioManager.attempt_spend(cost, PortfolioManager.CREDIT_REQUIREMENTS["EarlyBird"]):
+                                                autopilot_button.button_pressed = false
+                                                return
+                                autopilot.enabled = true
+                                if cost > 0.0:
+                                                autopilot_cost = snapped(autopilot_cost + 0.01, 0.01)
 						StatManager.set_base_stat("autopilot_cost", autopilot_cost)
 		else:
 				autopilot.enabled = false

--- a/components/popups/ex_factor_view.gd
+++ b/components/popups/ex_factor_view.gd
@@ -167,7 +167,7 @@ func _on_next_stage_pressed() -> void:
 	logic.change_state(npc.relationship_stage)
 	_update_all()
 func _on_gift_pressed() -> void:
-	if PortfolioManager.attempt_spend(npc.gift_cost):
+    if PortfolioManager.attempt_spend(npc.gift_cost, PortfolioManager.CREDIT_REQUIREMENTS["gift"]):
 		npc.affinity = min(npc.affinity + 5.0, 100.0)
 		npc.gift_cost *= 2.0
 		if npc_idx != -1:
@@ -191,8 +191,8 @@ func _on_love_pressed() -> void:
 	_update_love_button()
 
 func _on_date_pressed() -> void:
-	if not PortfolioManager.attempt_spend(npc.date_cost):
-		return
+    if not PortfolioManager.attempt_spend(npc.date_cost, PortfolioManager.CREDIT_REQUIREMENTS["date"]):
+                return
 	logic.on_date_paid()
 	var bounds: Vector2 = SuitorLogic.get_stage_bounds(npc.relationship_stage, npc.relationship_progress)
 	if npc.relationship_stage == NPC.RelationshipStage.TALKING and npc.relationship_progress < bounds.y - 1.0:


### PR DESCRIPTION
## Summary
- Apply credit score checks for upgrade purchases, gifts, dates, and EarlyBird autopilot
- Note remaining hire popup spend without credit requirement

## Testing
- `godot3 --headless --script tests/test_runner.gd` *(fails: config_version mismatch)*
- `/tmp/Godot_v4.2.2-stable_linux.x86_64 --headless --path /workspace/SigmaSim tests/test_runner.tscn` *(fails: project resources missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a81cb864e88325ac434922fdba27a2