### PR TITLE
Enable BlueWarp flat color toggle by default

### DIFF
--- a/autoloads/player_manager.gd
+++ b/autoloads/player_manager.gd
@@ -12,7 +12,7 @@ const DEFAULT_BACKGROUND_SHADERS := {
 "color_mid": {"r": 0.10, "g": 0.30, "b": 0.55, "a": 1.0},
 "color_high": {"r": 0.30, "g": 0.60, "b": 0.85, "a": 1.0},
 "flat_color": {"r": 0.0, "g": 0.0, "b": 0.2, "a": 1.0},
-"flat_visible": false,
+"flat_visible": true,
 },
 "ComicDots1": {
 "circle_color": {"r": 0.00000481308, "g": 0.665883, "b": 0.95733, "a": 1.0},

--- a/components/apps/app_scenes/settings.tscn
+++ b/components/apps/app_scenes/settings.tscn
@@ -271,6 +271,7 @@ color = Color(0, 0, 0.2, 1)
 [node name="BlueWarpFlatToggle" type="CheckButton" parent="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/BlueWarpContainer/MarginContainer/VBoxContainer/ColorRowFlat"]
 unique_name_in_owner = true
 layout_mode = 2
+button_pressed = true
 focus_mode = 0
 text = "Show"
 

--- a/components/shader_controller_module.gd
+++ b/components/shader_controller_module.gd
@@ -53,11 +53,13 @@ func _ready() -> void:
 	if flat_color_toggle_path != NodePath():
 		var toggle = get_node_or_null(flat_color_toggle_path)
 		if toggle and toggle is CheckButton:
-			var visible = PlayerManager.get_shader_param(shader_name, "flat_visible", false)
+			var visible = PlayerManager.get_shader_param(shader_name, "flat_visible", true)
 			toggle.button_pressed = visible
 			if flat_color_rect:
 				flat_color_rect.visible = visible
 			toggle.toggled.connect(_on_flat_toggled)
+			toggle.visible = Events.is_desktop_background_visible(shader_name)
+			Events.desktop_background_toggled.connect(_on_background_toggled)
 	if toggle_button_path != NodePath():
 		var button = get_node_or_null(toggle_button_path)
 		if button and button is CheckButton:
@@ -101,11 +103,17 @@ func _on_flat_toggled(toggled_on: bool) -> void:
 	PlayerManager.set_shader_param(shader_name, "flat_visible", toggled_on)
 
 func _on_toggled(toggled_on: bool) -> void:
-	Events.set_desktop_background_visible(shader_name, toggled_on)
+Events.set_desktop_background_visible(shader_name, toggled_on)
+
+func _on_background_toggled(name: String, visible: bool) -> void:
+	if name == shader_name and flat_color_toggle_path != NodePath():
+		var toggle = get_node_or_null(flat_color_toggle_path)
+		if toggle:
+			toggle.visible = visible
 
 func _get_param(param: StringName):
-	if shader_materials.is_empty():
-		return 0
+if shader_materials.is_empty():
+return 0
 	if param == StringName():
 		return 0
 	if param == "scale_x" or param == "scale_y":


### PR DESCRIPTION
## Summary
- Default BlueWarp flat color overlay to visible and hide toggle when BlueWarp background is disabled
- Set BlueWarp flat toggle pressed by default in settings UI

## Testing
- `apt-get update`
- `apt-get install -y godot3-server` *(fails: project requires newer engine)*
- `/tmp/Godot_v4.2.1-stable_linux.x86_64 --headless --path . -s tests/test_runner.gd` *(fails: missing resources and script not inheriting SceneTree)*

------
https://chatgpt.com/codex/tasks/task_e_68a8906d9f2883258aa47abf15b5f5c5