### PR TITLE
Implement relationship exclusivity management

### DIFF
--- a/autoloads/db_manager.gd
+++ b/autoloads/db_manager.gd
@@ -17,6 +17,9 @@ const SCHEMA: Dictionary = {
 		"relationship_status": {"data_type": "text"},
 		"relationship_stage": {"data_type": "int"},
 		"relationship_progress": {"data_type": "real"},
+		"exclusivity_core": {"data_type": "int"},
+		"claimed_exclusive_boost": {"data_type": "int"},
+		"claimed_serious_monog_boost": {"data_type": "int"},
 "affinity": {"data_type": "real"},
 "affinity_equilibrium": {"data_type": "real"},
 "rizz": {"data_type": "int"},
@@ -117,6 +120,14 @@ func save_npc(idx: int, npc: NPC, slot_id: int = SaveManager.current_slot_id):
 	var dict = npc.to_dict()
 	dict["id"] = idx
 	dict["slot_id"] = slot_id
+       if npc.claimed_exclusive_boost:
+	       dict["claimed_exclusive_boost"] = 1
+       else:
+	       dict["claimed_exclusive_boost"] = 0
+       if npc.claimed_serious_monog_boost:
+	       dict["claimed_serious_monog_boost"] = 1
+       else:
+	       dict["claimed_serious_monog_boost"] = 0
 	# Serialize all complex fields as JSON
 	dict["gender_vector"] = to_json(dict.get("gender_vector", {"x":0,"y":0,"z":1}))
 	dict["tags"] = to_json(dict.get("tags", []))

--- a/components/apps/daterbase/daterbase.gd
+++ b/components/apps/daterbase/daterbase.gd
@@ -267,9 +267,9 @@ func _load_default_entries() -> void:
 	daterbase_entries = DBManager.get_daterbase_entries()
 	for entry_dictionary in daterbase_entries:
 		var npc_object: NPC = NPCManager.get_npc_by_index(entry_dictionary.npc_id)
-		if npc_object.relationship_stage == NPC.RelationshipStage.STRANGER:
-			NPCManager.set_npc_field(entry_dictionary.npc_id, "relationship_stage", NPC.RelationshipStage.TALKING)
-			npc_object.relationship_stage = NPC.RelationshipStage.TALKING
+	   if npc_object.relationship_stage == NPCManager.RelationshipStage.STRANGER:
+		   NPCManager.set_relationship_stage(entry_dictionary.npc_id, NPCManager.RelationshipStage.TALKING)
+		   npc_object.relationship_stage = NPCManager.RelationshipStage.TALKING
 			npc_object.affinity += 1
 		var row := HBoxContainer.new()
 		row.mouse_filter = Control.MOUSE_FILTER_STOP

--- a/components/popups/ex_factor_view.gd
+++ b/components/popups/ex_factor_view.gd
@@ -63,7 +63,7 @@ func _ready() -> void:
 
 
 func _process(delta: float) -> void:
-	if npc == null or npc.relationship_stage >= NPC.RelationshipStage.DIVORCED:
+    if npc == null or npc.relationship_stage >= NPCManager.RelationshipStage.DIVORCED:
 		return
 	var prev_progress: float = npc.relationship_progress
 	logic.process(delta)
@@ -72,7 +72,7 @@ func _process(delta: float) -> void:
 		NPCManager.set_npc_field(npc_idx, "relationship_progress", npc.relationship_progress)
 		last_saved_progress = npc.relationship_progress
 	var bounds: Vector2 = SuitorLogic.get_stage_bounds(npc.relationship_stage, npc.relationship_progress)
-	if npc.relationship_stage < NPC.RelationshipStage.MARRIED and npc.relationship_progress >= bounds.y:
+    if npc.relationship_stage < NPCManager.RelationshipStage.MARRIED and npc.relationship_progress >= bounds.y:
 		next_stage_button.visible = true
 	_update_relationship_bar()
 	_update_breakup_button_text()
@@ -83,16 +83,16 @@ func _update_all() -> void:
 	_update_breakup_button_text()
 	_update_action_buttons_text()
 	_update_love_button()
-	var blocked: bool = npc.relationship_stage >= NPC.RelationshipStage.DIVORCED
+    var blocked: bool = npc.relationship_stage >= NPCManager.RelationshipStage.DIVORCED
 	gift_button.disabled = blocked
 	date_button.disabled = blocked
-	apologize_button.visible = UpgradeManager.get_level("fumble_talk_therapy") > 0 and npc.relationship_stage in [NPC.RelationshipStage.DIVORCED, NPC.RelationshipStage.EX]
+    apologize_button.visible = UpgradeManager.get_level("fumble_talk_therapy") > 0 and npc.relationship_stage in [NPCManager.RelationshipStage.DIVORCED, NPCManager.RelationshipStage.EX]
 func _update_relationship_bar() -> void:
 	var current_stage: int = npc.relationship_stage
-	if current_stage == NPC.RelationshipStage.MARRIED:
+    if current_stage == NPCManager.RelationshipStage.MARRIED:
 			var level: int = npc.get_marriage_level()
 			relationship_stage_label.text = "Level %d Marriage" % level
-	elif current_stage in [NPC.RelationshipStage.DIVORCED, NPC.RelationshipStage.EX]:
+    elif current_stage in [NPCManager.RelationshipStage.DIVORCED, NPCManager.RelationshipStage.EX]:
 		relationship_stage_label.text = STAGE_NAMES[current_stage]
 	else:
 		var next_stage: int = current_stage + 1
@@ -104,7 +104,7 @@ func _update_relationship_bar() -> void:
 				NumberFormatter.format_commas(npc.relationship_progress - bounds.x, 2),
 				NumberFormatter.format_commas(bounds.y - bounds.x, 2)
 		]
-		if current_stage < NPC.RelationshipStage.MARRIED:
+	    if current_stage < NPCManager.RelationshipStage.MARRIED:
 				relationship_bar.set_mark_fractions(logic.get_stop_marks())
 		else:
 				relationship_bar.set_mark_fractions([])
@@ -114,7 +114,7 @@ func _update_affinity_bar() -> void:
 		affinity_value_label.text = "%s / 100" % NumberFormatter.format_commas(npc.affinity, 0)
 
 func _update_breakup_button_text() -> void:
-	if npc.relationship_stage >= NPC.RelationshipStage.DIVORCED:
+    if npc.relationship_stage >= NPCManager.RelationshipStage.DIVORCED:
 		breakup_button.disabled = true
 		return
 	breakup_button.disabled = false
@@ -122,7 +122,7 @@ func _update_breakup_button_text() -> void:
 	var fraction: float = (npc.relationship_progress - bounds.x) / (bounds.y - bounds.x)
 	var stage_idx: int = max(1, npc.relationship_stage)
 	var base: float
-	if npc.relationship_stage < NPC.RelationshipStage.MARRIED:
+    if npc.relationship_stage < NPCManager.RelationshipStage.MARRIED:
 		base = pow(10.0, float(stage_idx - 1))
 	else:
 		var level: int = npc.get_marriage_level()
@@ -137,7 +137,7 @@ func _update_action_buttons_text() -> void:
 func _update_love_button() -> void:
 	if npc == null:
 			return
-	if npc.relationship_stage < NPC.RelationshipStage.DATING:
+    if npc.relationship_stage < NPCManager.RelationshipStage.DATING:
 			love_button.visible = false
 			love_cooldown_label.visible = false
 			return
@@ -162,7 +162,7 @@ func _on_npc_affinity_changed(idx: int, value: float) -> void:
 func _on_next_stage_pressed() -> void:
 	next_stage_button.visible = false
 	logic.progress_paused = false
-	if npc.relationship_stage < NPC.RelationshipStage.MARRIED:
+    if npc.relationship_stage < NPCManager.RelationshipStage.MARRIED:
 		npc.relationship_stage += 1
 	logic.change_state(npc.relationship_stage)
 	_update_all()
@@ -195,7 +195,7 @@ func _on_date_pressed() -> void:
 				return
 	logic.on_date_paid()
 	var bounds: Vector2 = SuitorLogic.get_stage_bounds(npc.relationship_stage, npc.relationship_progress)
-	#if npc.relationship_stage == NPC.RelationshipStage.TALKING and npc.relationship_progress < bounds.y - 1.0:
+    #if npc.relationship_stage == NPCManager.RelationshipStage.TALKING and npc.relationship_progress < bounds.y - 1.0:
 	#	npc.relationship_progress = bounds.y - 1.0
 	#	logic.progress_paused = true
 	#	next_stage_button.visible = true
@@ -203,7 +203,7 @@ func _on_date_pressed() -> void:
 	var date_progress_boost = npc.date_cost/10
 	npc.relationship_progress = min(npc.relationship_progress + date_progress_boost, bounds.y)
 	
-	if npc.relationship_stage < NPC.RelationshipStage.MARRIED and npc.relationship_progress >= bounds.y:
+    if npc.relationship_stage < NPCManager.RelationshipStage.MARRIED and npc.relationship_progress >= bounds.y:
 		logic.progress_paused = true
 		next_stage_button.visible = true
 	_update_relationship_bar()
@@ -219,14 +219,14 @@ func _on_breakup_pressed() -> void:
 	var fraction: float = (npc.relationship_progress - bounds.x) / (bounds.y - bounds.x)
 	var stage_idx: int = max(1, npc.relationship_stage)
 	var base: float
-	if npc.relationship_stage < NPC.RelationshipStage.MARRIED:
+    if npc.relationship_stage < NPCManager.RelationshipStage.MARRIED:
 		base = pow(10.0, float(stage_idx - 1))
 	else:
 		var level: int = npc.get_marriage_level()
 		base = 10000.0 * pow(1.5, float(level - 1))
 	breakup_reward = (0.1 + fraction * 0.9) * base
 	var text: String = "Are you sure you want to break up with %s and gain %.2f EX?" % [npc.first_name, breakup_reward]
-	if npc.relationship_stage == NPC.RelationshipStage.MARRIED:
+    if npc.relationship_stage == NPCManager.RelationshipStage.MARRIED:
 		text += "\n\n%s will get half of all of your assets" % npc.first_name
 	breakup_confirm_label.text = text
 	breakup_confirm.visible = true
@@ -234,11 +234,11 @@ func _on_breakup_confirm_yes_pressed() -> void:
 	breakup_confirm.visible = false
 	var current_ex: float = StatManager.get_stat("ex", 0.0)
 	StatManager.set_base_stat("ex", current_ex + breakup_reward)
-	if npc.relationship_stage == NPC.RelationshipStage.MARRIED:
-		npc.relationship_stage = NPC.RelationshipStage.DIVORCED
+    if npc.relationship_stage == NPCManager.RelationshipStage.MARRIED:
+	    npc.relationship_stage = NPCManager.RelationshipStage.DIVORCED
 		PortfolioManager.halve_assets()
 	else:
-		npc.relationship_stage = NPC.RelationshipStage.EX
+	    npc.relationship_stage = NPCManager.RelationshipStage.EX
 	npc.relationship_progress = 0.0
 	npc.affinity *= 0.2
 	logic.change_state(npc.relationship_stage)
@@ -249,7 +249,7 @@ func _on_breakup_confirm_yes_pressed() -> void:
 	breakup_button.disabled = true
 	if npc_idx != -1:
 		NPCManager.promote_to_persistent(npc_idx)
-		NPCManager.set_npc_field(npc_idx, "relationship_stage", npc.relationship_stage)
+		NPCManager.set_relationship_stage(npc_idx, npc.relationship_stage)
 		NPCManager.set_npc_field(npc_idx, "relationship_progress", npc.relationship_progress)
 		NPCManager.set_npc_field(npc_idx, "affinity", npc.affinity)
 	_update_all()
@@ -264,7 +264,7 @@ func _on_apologize_pressed() -> void:
 	if current_ex < apologize_cost:
 		return
 	StatManager.set_base_stat("ex", current_ex - apologize_cost)
-	npc.relationship_stage = NPC.RelationshipStage.TALKING
+    npc.relationship_stage = NPCManager.RelationshipStage.TALKING
 	npc.relationship_progress = 0.0
 	npc.affinity = 1.0
 	logic.progress_paused = false
@@ -279,7 +279,7 @@ func _on_apologize_pressed() -> void:
 	breakup_button.disabled = false
 	if npc_idx != -1:
 		NPCManager.promote_to_persistent(npc_idx)
-		NPCManager.set_npc_field(npc_idx, "relationship_stage", npc.relationship_stage)
+		NPCManager.set_relationship_stage(npc_idx, npc.relationship_stage)
 		NPCManager.set_npc_field(npc_idx, "relationship_progress", npc.relationship_progress)
 		NPCManager.set_npc_field(npc_idx, "affinity", npc.affinity)
 	_update_all()
@@ -287,5 +287,5 @@ func _on_apologize_pressed() -> void:
 func _on_talk_therapy_purchased(level: int) -> void:
 	if npc == null:
 		return
-	if npc.relationship_stage in [NPC.RelationshipStage.DIVORCED, NPC.RelationshipStage.EX]:
+    if npc.relationship_stage in [NPCManager.RelationshipStage.DIVORCED, NPCManager.RelationshipStage.EX]:
 		apologize_button.visible = true

--- a/components/popups/suitor_logic.gd
+++ b/components/popups/suitor_logic.gd
@@ -10,7 +10,7 @@ const LN10: float = 2.302585092994046  # natural log of 10
 const LOVE_AFFINITY_GAIN: float = 5.0
 
 static func get_stage_bounds(stage: int, progress: float) -> Vector2:
-	if stage < NPC.RelationshipStage.MARRIED:
+       if stage < NPCManager.RelationshipStage.MARRIED:
 		var lower: float = STAGE_THRESHOLDS[stage]
 		var upper: float = STAGE_THRESHOLDS[stage + 1]
 		return Vector2(lower, upper)
@@ -37,23 +37,23 @@ func setup(npc_instance: NPC) -> void:
 func change_state(stage: int) -> void:
 	if state != null:
 		state.exit()
-	match stage:
-		NPC.RelationshipStage.STRANGER:
-			state = StrangerState.new(self)
-		NPC.RelationshipStage.TALKING:
-			state = TalkingState.new(self)
-		NPC.RelationshipStage.DATING:
-			state = DatingState.new(self)
-		NPC.RelationshipStage.SERIOUS:
-			state = SeriousState.new(self)
-		NPC.RelationshipStage.ENGAGED:
-			state = EngagedState.new(self)
-		NPC.RelationshipStage.MARRIED:
-			state = MarriedState.new(self)
-		NPC.RelationshipStage.DIVORCED:
-			state = DivorcedState.new(self)
-		NPC.RelationshipStage.EX:
-			state = ExState.new(self)
+       match stage:
+	       NPCManager.RelationshipStage.STRANGER:
+		       state = StrangerState.new(self)
+	       NPCManager.RelationshipStage.TALKING:
+		       state = TalkingState.new(self)
+	       NPCManager.RelationshipStage.DATING:
+		       state = DatingState.new(self)
+	       NPCManager.RelationshipStage.SERIOUS:
+		       state = SeriousState.new(self)
+	       NPCManager.RelationshipStage.ENGAGED:
+		       state = EngagedState.new(self)
+	       NPCManager.RelationshipStage.MARRIED:
+		       state = MarriedState.new(self)
+	       NPCManager.RelationshipStage.DIVORCED:
+		       state = DivorcedState.new(self)
+	       NPCManager.RelationshipStage.EX:
+		       state = ExState.new(self)
 	state.enter()
 
 func process(delta: float) -> void:
@@ -77,7 +77,7 @@ func get_stop_marks() -> Array[float]:
 	return []
 
 static func get_stop_points(stage: int) -> Array:
-	if stage >= NPC.RelationshipStage.MARRIED:
+       if stage >= NPCManager.RelationshipStage.MARRIED:
 		return []
 	var points: Array = []
 	var prev_required: int = (stage - 1) * stage / 2
@@ -130,7 +130,7 @@ class PreMarriageState extends SuitorState:
 				npc.relationship_progress = bounds.x + fraction * stage_range
 				machine.progress_paused = true
 				break
-		if stage < NPC.RelationshipStage.MARRIED and npc.relationship_progress >= bounds.y:
+	       if stage < NPCManager.RelationshipStage.MARRIED and npc.relationship_progress >= bounds.y:
 			npc.relationship_progress = bounds.y
 			machine.progress_paused = true
 
@@ -145,24 +145,24 @@ class PreMarriageState extends SuitorState:
 		return marks
 
 class StrangerState extends PreMarriageState:
-	func _init(machine: SuitorLogic) -> void:
-		super._init(machine, NPC.RelationshipStage.STRANGER)
+       func _init(machine: SuitorLogic) -> void:
+	       super._init(machine, NPCManager.RelationshipStage.STRANGER)
 
 class TalkingState extends PreMarriageState:
-	func _init(machine: SuitorLogic) -> void:
-		super._init(machine, NPC.RelationshipStage.TALKING)
+       func _init(machine: SuitorLogic) -> void:
+	       super._init(machine, NPCManager.RelationshipStage.TALKING)
 
 class DatingState extends PreMarriageState:
-	func _init(machine: SuitorLogic) -> void:
-		super._init(machine, NPC.RelationshipStage.DATING)
+       func _init(machine: SuitorLogic) -> void:
+	       super._init(machine, NPCManager.RelationshipStage.DATING)
 
 class SeriousState extends PreMarriageState:
-	func _init(machine: SuitorLogic) -> void:
-		super._init(machine, NPC.RelationshipStage.SERIOUS)
+       func _init(machine: SuitorLogic) -> void:
+	       super._init(machine, NPCManager.RelationshipStage.SERIOUS)
 
 class EngagedState extends PreMarriageState:
-	func _init(machine: SuitorLogic) -> void:
-		super._init(machine, NPC.RelationshipStage.ENGAGED)
+       func _init(machine: SuitorLogic) -> void:
+	       super._init(machine, NPCManager.RelationshipStage.ENGAGED)
 
 class MarriedState extends SuitorState:
 	func update(delta: float) -> void:


### PR DESCRIPTION
## Summary
- add relationship and exclusivity enums to NPCManager and expose signals for stage/core changes and cheating
- persist exclusivity core and one-time boost flags via DBManager
- extend NPC with exclusivity fields, helper methods, and descriptor logic

## Testing
- `godot --headless -s tests/test_runner.gd` *(fails: command not found)*
- `/tmp/godot/Godot_v4.2.1-stable_linux.x86_64 --headless -s tests/test_runner.gd` *(fails: script doesn't inherit from SceneTree/MainLoop)*

------
https://chatgpt.com/codex/tasks/task_e_68a895d7b4c4832584356e0efe4e8a15