### PR TITLE
feat: add performance enhancers upgrade

### DIFF
--- a/components/popups/suitor_logic.gd
+++ b/components/popups/suitor_logic.gd
@@ -7,7 +7,7 @@ var state: SuitorState
 
 const STAGE_THRESHOLDS: Array[float] = [0.0, 0.0, 100.0, 1000.0, 10000.0, 100000.0]
 const LN10: float = 2.302585092994046  # natural log of 10
-const LOVE_AFFINITY_GAIN: float = 5.0
+const DEFAULT_LOVE_AFFINITY_GAIN: float = 5.0
 
 static func get_stage_bounds(stage: int, progress: float) -> Vector2:
 	if stage < NPCManager.RelationshipStage.MARRIED:
@@ -68,7 +68,8 @@ func on_date_paid() -> void:
 	progress_paused = false
 
 func apply_love() -> void:
-	npc.affinity = min(npc.affinity + LOVE_AFFINITY_GAIN, 100.0)
+        var gain: float = StatManager.get_stat("love_affinity_gain", DEFAULT_LOVE_AFFINITY_GAIN)
+        npc.affinity = min(npc.affinity + gain, 100.0)
 
 
 func get_stop_marks() -> Array[float]:

--- a/data/stats/base_stats.json
+++ b/data/stats/base_stats.json
@@ -8,6 +8,7 @@
   "cash_per_score": 0.01,
   "autopilot_cost": 1.0,
   "affinity_drift_rate": 1.0,
+  "love_affinity_gain": 5.0,
   "worm_yield": 1.0,
   "upgrade_cooldown_multiplier": 1.0
 }

--- a/data/upgrades/ex_factor_performance_enhancers.json
+++ b/data/upgrades/ex_factor_performance_enhancers.json
@@ -1,0 +1,21 @@
+{
+  "id": "ex_factor_performance_enhancers",
+  "name": "Performance Enhancers",
+  "description": "Each level increases affinity gained from Love by 1.",
+  "effects": [
+    {
+      "target": "love_affinity_gain",
+      "operation": "add",
+      "value": 1.0
+    }
+  ],
+  "systems": [
+    "e[sup]x[/sup] Factor"
+  ],
+  "dependencies": [],
+  "cost_per_level": {
+    "ex": 100
+  },
+  "max_level": 20,
+  "repeatable": false
+}

--- a/tests/performance_enhancers_upgrade_test.gd
+++ b/tests/performance_enhancers_upgrade_test.gd
@@ -1,0 +1,16 @@
+extends SceneTree
+
+func _ready() -> void:
+        var prev_level := UpgradeManager.get_level("ex_factor_performance_enhancers")
+        UpgradeManager.player_levels["ex_factor_performance_enhancers"] = 2
+        StatManager.recalculate_all_stats_once()
+        var npc := NPC.new()
+        npc.affinity = 0.0
+        var logic := SuitorLogic.new()
+        logic.setup(npc)
+        logic.apply_love()
+        assert(npc.affinity == 7.0)
+        UpgradeManager.player_levels["ex_factor_performance_enhancers"] = prev_level
+        StatManager.recalculate_all_stats_once()
+        print("performance_enhancers_upgrade_test passed")
+        quit()


### PR DESCRIPTION
## Summary
- add love_affinity_gain stat and use it in SuitorLogic
- introduce Performance Enhancers upgrade for e[sup]x[/sup] Factor
- cover upgrade behavior with unit test

## Testing
- `godot3 --headless --script tests/test_runner.gd` *(fails: Can't open project at '/workspace/SigmaSim/project.godot', config_version 5 requires newer engine)*

------
https://chatgpt.com/codex/tasks/task_e_68a8a3207798832591f5dbc4245f30c9