### PR TITLE
Ensure BlueWarp flat overlay respects background toggle

### DIFF
--- a/components/shader_controller_module.gd
+++ b/components/shader_controller_module.gd
@@ -40,31 +40,30 @@ func _ready() -> void:
 			var param = color_picker_params[i]
 			node.color = _get_param(param)
 			node.color_changed.connect(_on_color_changed.bind(param))
-	if flat_color_rect_path != NodePath():
-		flat_color_rect = get_tree().root.get_node_or_null(flat_color_rect_path)
-	if flat_color_picker_path != NodePath():
-		var picker = get_node_or_null(flat_color_picker_path)
-		if picker and picker is ColorPickerButton:
-			var color = PlayerManager.get_shader_param(shader_name, "flat_color", Color(0, 0, 0.2))
-			picker.color = color
-			if flat_color_rect:
-				flat_color_rect.color = color
-			picker.color_changed.connect(_on_flat_color_changed)
-	if flat_color_toggle_path != NodePath():
-		var toggle = get_node_or_null(flat_color_toggle_path)
-		if toggle and toggle is CheckButton:
-			var visible = PlayerManager.get_shader_param(shader_name, "flat_visible", true)
-			toggle.button_pressed = visible
-			if flat_color_rect:
-				flat_color_rect.visible = visible
-			toggle.toggled.connect(_on_flat_toggled)
-			toggle.visible = Events.is_desktop_background_visible(shader_name)
-			Events.desktop_background_toggled.connect(_on_background_toggled)
-	if toggle_button_path != NodePath():
-		var button = get_node_or_null(toggle_button_path)
-		if button and button is CheckButton:
-			button.button_pressed = Events.is_desktop_background_visible(shader_name)
-			button.toggled.connect(_on_toggled)
+        if flat_color_rect_path != NodePath():
+                flat_color_rect = get_tree().root.get_node_or_null(flat_color_rect_path)
+        if flat_color_picker_path != NodePath():
+                var picker = get_node_or_null(flat_color_picker_path)
+                if picker and picker is ColorPickerButton:
+                        var color = PlayerManager.get_shader_param(shader_name, "flat_color", Color(0, 0, 0.2))
+                        picker.color = color
+                        if flat_color_rect:
+                                flat_color_rect.color = color
+                        picker.color_changed.connect(_on_flat_color_changed)
+        if flat_color_toggle_path != NodePath():
+                var toggle = get_node_or_null(flat_color_toggle_path)
+                if toggle and toggle is CheckButton:
+                        var visible = PlayerManager.get_shader_param(shader_name, "flat_visible", true)
+                        toggle.button_pressed = visible
+                        if flat_color_rect:
+                                flat_color_rect.visible = visible and Events.is_desktop_background_visible(shader_name)
+                        toggle.toggled.connect(_on_flat_toggled)
+                        Events.desktop_background_toggled.connect(_on_background_toggled)
+        if toggle_button_path != NodePath():
+                var button = get_node_or_null(toggle_button_path)
+                if button and button is CheckButton:
+                        button.button_pressed = Events.is_desktop_background_visible(shader_name)
+                        button.toggled.connect(_on_toggled)
 	if reset_button_path != NodePath():
 		var reset = get_node_or_null(reset_button_path)
 		if reset and reset is Button:
@@ -98,18 +97,20 @@ func _on_flat_color_changed(color: Color) -> void:
 	PlayerManager.set_shader_param(shader_name, "flat_color", color)
 
 func _on_flat_toggled(toggled_on: bool) -> void:
-	if flat_color_rect:
-		flat_color_rect.visible = toggled_on
-	PlayerManager.set_shader_param(shader_name, "flat_visible", toggled_on)
+        if flat_color_rect:
+                flat_color_rect.visible = toggled_on and Events.is_desktop_background_visible(shader_name)
+        PlayerManager.set_shader_param(shader_name, "flat_visible", toggled_on)
 
 func _on_toggled(toggled_on: bool) -> void:
 	Events.set_desktop_background_visible(shader_name, toggled_on)
 
 func _on_background_toggled(name: String, visible: bool) -> void:
-	if name == shader_name and flat_color_toggle_path != NodePath():
-		var toggle = get_node_or_null(flat_color_toggle_path)
-		if toggle:
-			toggle.visible = visible
+        if name == shader_name and flat_color_rect:
+                var toggle: CheckButton = null
+                if flat_color_toggle_path != NodePath():
+                        toggle = get_node_or_null(flat_color_toggle_path)
+                var toggled_on: bool = toggle.button_pressed if toggle else false
+                flat_color_rect.visible = visible and toggled_on
 
 func _get_param(param: StringName):
 	if shader_materials.is_empty():

--- a/scripts/desktop_env.gd
+++ b/scripts/desktop_env.gd
@@ -83,10 +83,10 @@ func _apply_shader_settings() -> void:
 	blue_warp_shader_material.set_shader_parameter("color_low", PlayerManager.get_shader_param("BlueWarp", "color_low", PlayerManager.dict_to_color(bw_def["color_low"])))
 	blue_warp_shader_material.set_shader_parameter("color_mid", PlayerManager.get_shader_param("BlueWarp", "color_mid", PlayerManager.dict_to_color(bw_def["color_mid"])))
 	blue_warp_shader_material.set_shader_parameter("color_high", PlayerManager.get_shader_param("BlueWarp", "color_high", PlayerManager.dict_to_color(bw_def["color_high"])))
-	var flat_color = PlayerManager.get_shader_param("BlueWarp", "flat_color", PlayerManager.dict_to_color(bw_def.get("flat_color", {"r": 0.0, "g": 0.0, "b": 0.2, "a": 1.0})))
-	var flat_visible = PlayerManager.get_shader_param("BlueWarp", "flat_visible", bw_def.get("flat_visible", false))
-	blue_warp_flat_color_rect.color = flat_color
-	blue_warp_flat_color_rect.visible = flat_visible
+        var flat_color = PlayerManager.get_shader_param("BlueWarp", "flat_color", PlayerManager.dict_to_color(bw_def.get("flat_color", {"r": 0.0, "g": 0.0, "b": 0.2, "a": 1.0})))
+        var flat_visible = PlayerManager.get_shader_param("BlueWarp", "flat_visible", bw_def.get("flat_visible", false))
+        blue_warp_flat_color_rect.color = flat_color
+        blue_warp_flat_color_rect.visible = flat_visible and Events.is_desktop_background_visible("BlueWarp")
 
 	var cd1_def = defaults["ComicDots1"]
 	var cd1_color = PlayerManager.get_shader_param("ComicDots1", "circle_color", PlayerManager.dict_to_color(cd1_def["circle_color"]))


### PR DESCRIPTION
## Summary
- Show BlueWarp flat color toggle at all times and link overlay visibility to BlueWarp background state
- Initialize BlueWarp flat color visibility based on background and user toggle

## Testing
- `godot --headless --run-tests tests/test_runner.tscn` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8a4e7632883259d2faaa8b873847a