### PR TITLE
Generalize market events with deterministic HAWK variants

### DIFF
--- a/autoloads/market_manager.gd
+++ b/autoloads/market_manager.gd
@@ -23,10 +23,10 @@ var STOCK_RESOURCES = {
 }
 
 var CRYPTO_RESOURCES = {
-        "BITC": preload("res://resources/crypto/bitc_crypto.tres"),
-        "HAWK1": preload("res://resources/crypto/hawk1_crypto.tres"),
-        "HAWK2": preload("res://resources/crypto/hawk2_crypto.tres"),
-        "WORM": preload("res://resources/crypto/worm_crypto.tres"),
+	"BITC": preload("res://resources/crypto/bitc_crypto.tres"),
+	"HAWK1": preload("res://resources/crypto/hawk1_crypto.tres"),
+	"HAWK2": preload("res://resources/crypto/hawk2_crypto.tres"),
+	"WORM": preload("res://resources/crypto/worm_crypto.tres"),
 }
 
 func _ready() -> void:
@@ -65,22 +65,22 @@ func register_crypto(crypto: Cryptocurrency) -> void:
 		push_warning("register_crypto: symbol '" + crypto.symbol + "' already registered; skipping")
 		return
 
-        crypto_market[crypto.symbol] = crypto
-        emit_signal("crypto_price_updated", crypto.symbol, crypto)
+	crypto_market[crypto.symbol] = crypto
+	emit_signal("crypto_price_updated", crypto.symbol, crypto)
 
 func schedule_market_event(event: MarketEvent) -> void:
-        if event == null:
-                return
-        var asset = crypto_market.get(event.symbol)
-        if asset == null:
-                asset = stock_market.get(event.symbol)
-        if asset == null:
-                push_warning("schedule_market_event: unknown symbol '" + event.symbol + "'")
-                return
-        event.schedule(asset)
-        if not market_events.has(event.symbol):
-                market_events[event.symbol] = []
-        market_events[event.symbol].append(event)
+	if event == null:
+		return
+	var asset = crypto_market.get(event.symbol)
+	if asset == null:
+		asset = stock_market.get(event.symbol)
+	if asset == null:
+		push_warning("schedule_market_event: unknown symbol '" + event.symbol + "'")
+		return
+	event.schedule(asset)
+	if not market_events.has(event.symbol):
+		market_events[event.symbol] = []
+	market_events[event.symbol].append(event)
 func _on_minute_passed(current_time_minutes: int) -> void:
 	# Alternate stock and crypto ticks every minute
 	if current_time_minutes % 2 == 0:
@@ -191,34 +191,34 @@ func _init_crypto_market() -> void:
 			c.symbol = str(key_symbol)
 
 		print("registering crypto: '" + str(c.symbol) + "' from key '" + str(key_symbol) + "', resource_name='" + str(c.resource_name) + "'")
-                register_crypto(c)
-                if crypto_market.has(c.symbol):
-                        inserted_count += 1
+		register_crypto(c)
+		if crypto_market.has(c.symbol):
+			inserted_count += 1
 
-        debug_dump_crypto("post_init_loop")
+	debug_dump_crypto("post_init_loop")
 
-        # Randomly choose which HAWK crypto will receive the pump-and-dump event
-        var hawk_symbols := ["HAWK1", "HAWK2"]
-        var rng := RNGManager.market_event.get_rng()
-        var chosen_hawk := hawk_symbols[rng.randi_range(0, hawk_symbols.size() - 1)]
-        var event_res: Resource = ResourceLoader.load("res://resources/crypto/events/hawk_pump_and_dump.tres")
-        if event_res is MarketEvent:
-                var event_instance: MarketEvent = event_res.duplicate(true)
-                event_instance.symbol = chosen_hawk
-                schedule_market_event(event_instance)
+	# Randomly choose which HAWK crypto will receive the pump-and-dump event
+	var hawk_symbols := ["HAWK1", "HAWK2"]
+	var rng := RNGManager.market_event.get_rng()
+	var chosen_hawk := hawk_symbols[rng.randi_range(0, hawk_symbols.size() - 1)]
+	var event_res: Resource = ResourceLoader.load("res://resources/crypto/events/hawk_pump_and_dump.tres")
+	if event_res is MarketEvent:
+		var event_instance: MarketEvent = event_res.duplicate(true)
+		event_instance.symbol = chosen_hawk
+		schedule_market_event(event_instance)
 
-        var expected: Array = CRYPTO_RESOURCES.keys()
-        var actual: Array = crypto_market.keys()
-        expected.sort()
-        actual.sort()
-        if expected != actual:
-                push_warning("_init_crypto_market: expected symbols " + str(expected) + ", got " + str(actual))
+	var expected: Array = CRYPTO_RESOURCES.keys()
+	var actual: Array = crypto_market.keys()
+	expected.sort()
+	actual.sort()
+	if expected != actual:
+		push_warning("_init_crypto_market: expected symbols " + str(expected) + ", got " + str(actual))
 
-        debug_dump_crypto("post_init")
-        emit_signal("crypto_market_ready")
-        print("crypto market initialized; inserted count=", str(inserted_count))
-        print("crypto market keys: " + str(crypto_market.keys()))
-        print("crypto market state: " + JSON.stringify(crypto_market, "  "))
+	debug_dump_crypto("post_init")
+	emit_signal("crypto_market_ready")
+	print("crypto market initialized; inserted count=", str(inserted_count))
+	print("crypto market keys: " + str(crypto_market.keys()))
+	print("crypto market state: " + JSON.stringify(crypto_market, "  "))
 func _init_stock_market() -> void:
 		for symbol in STOCK_RESOURCES.keys():
 				var stock = STOCK_RESOURCES[symbol].duplicate(true)

--- a/autoloads/market_manager.gd
+++ b/autoloads/market_manager.gd
@@ -3,6 +3,7 @@ extends Node
 
 var stock_market: Dictionary = {}  # symbol: Stock
 var crypto_market: Dictionary = {}  # symbol: Crypto
+var market_events: Dictionary = {}  # symbol: Array[MarketEvent]
 
 signal crypto_market_ready
 
@@ -22,9 +23,10 @@ var STOCK_RESOURCES = {
 }
 
 var CRYPTO_RESOURCES = {
-	"BITC": preload("res://resources/crypto/bitc_crypto.tres"),
-	"HAWK": preload("res://resources/crypto/hawk_crypto.tres"),
-	"WORM": preload("res://resources/crypto/worm_crypto.tres"),
+        "BITC": preload("res://resources/crypto/bitc_crypto.tres"),
+        "HAWK1": preload("res://resources/crypto/hawk1_crypto.tres"),
+        "HAWK2": preload("res://resources/crypto/hawk2_crypto.tres"),
+        "WORM": preload("res://resources/crypto/worm_crypto.tres"),
 }
 
 func _ready() -> void:
@@ -63,8 +65,22 @@ func register_crypto(crypto: Cryptocurrency) -> void:
 		push_warning("register_crypto: symbol '" + crypto.symbol + "' already registered; skipping")
 		return
 
-	crypto_market[crypto.symbol] = crypto
-	emit_signal("crypto_price_updated", crypto.symbol, crypto)
+        crypto_market[crypto.symbol] = crypto
+        emit_signal("crypto_price_updated", crypto.symbol, crypto)
+
+func schedule_market_event(event: MarketEvent) -> void:
+        if event == null:
+                return
+        var asset = crypto_market.get(event.symbol)
+        if asset == null:
+                asset = stock_market.get(event.symbol)
+        if asset == null:
+                push_warning("schedule_market_event: unknown symbol '" + event.symbol + "'")
+                return
+        event.schedule(asset)
+        if not market_events.has(event.symbol):
+                market_events[event.symbol] = []
+        market_events[event.symbol].append(event)
 func _on_minute_passed(current_time_minutes: int) -> void:
 	# Alternate stock and crypto ticks every minute
 	if current_time_minutes % 2 == 0:
@@ -175,24 +191,34 @@ func _init_crypto_market() -> void:
 			c.symbol = str(key_symbol)
 
 		print("registering crypto: '" + str(c.symbol) + "' from key '" + str(key_symbol) + "', resource_name='" + str(c.resource_name) + "'")
-		register_crypto(c)
-		if crypto_market.has(c.symbol):
-			inserted_count += 1
+                register_crypto(c)
+                if crypto_market.has(c.symbol):
+                        inserted_count += 1
 
-	debug_dump_crypto("post_init_loop")
+        debug_dump_crypto("post_init_loop")
 
-	var expected: Array = CRYPTO_RESOURCES.keys()
-	var actual: Array = crypto_market.keys()
-	expected.sort()
-	actual.sort()
-	if expected != actual:
-		push_warning("_init_crypto_market: expected symbols " + str(expected) + ", got " + str(actual))
+        # Randomly choose which HAWK crypto will receive the pump-and-dump event
+        var hawk_symbols := ["HAWK1", "HAWK2"]
+        var rng := RNGManager.market_event.get_rng()
+        var chosen_hawk := hawk_symbols[rng.randi_range(0, hawk_symbols.size() - 1)]
+        var event_res: Resource = ResourceLoader.load("res://resources/crypto/events/hawk_pump_and_dump.tres")
+        if event_res is MarketEvent:
+                var event_instance: MarketEvent = event_res.duplicate(true)
+                event_instance.symbol = chosen_hawk
+                schedule_market_event(event_instance)
 
-	debug_dump_crypto("post_init")
-	emit_signal("crypto_market_ready")
-	print("crypto market initialized; inserted count=", str(inserted_count))
-	print("crypto market keys: " + str(crypto_market.keys()))
-	print("crypto market state: " + JSON.stringify(crypto_market, "  "))
+        var expected: Array = CRYPTO_RESOURCES.keys()
+        var actual: Array = crypto_market.keys()
+        expected.sort()
+        actual.sort()
+        if expected != actual:
+                push_warning("_init_crypto_market: expected symbols " + str(expected) + ", got " + str(actual))
+
+        debug_dump_crypto("post_init")
+        emit_signal("crypto_market_ready")
+        print("crypto market initialized; inserted count=", str(inserted_count))
+        print("crypto market keys: " + str(crypto_market.keys()))
+        print("crypto market state: " + JSON.stringify(crypto_market, "  "))
 func _init_stock_market() -> void:
 		for symbol in STOCK_RESOURCES.keys():
 				var stock = STOCK_RESOURCES[symbol].duplicate(true)

--- a/autoloads/rng_manager.gd
+++ b/autoloads/rng_manager.gd
@@ -41,10 +41,13 @@ class WorkerManagerRNG extends RNGStream:
 	pass
 
 class MarketManagerRNG extends RNGStream:
-	pass
+        pass
+
+class MarketEventRNG extends RNGStream:
+        pass
 
 class SiggyRNG extends RNGStream:
-	pass
+        pass
 
 class TickerRNG extends RNGStream:
 	pass
@@ -80,6 +83,7 @@ var fumble_manager := FumbleManagerRNG.new()
 var fumble_profile_stack := FumbleProfileStackRNG.new()
 var worker_manager := WorkerManagerRNG.new()
 var market_manager := MarketManagerRNG.new()
+var market_event := MarketEventRNG.new()
 var siggy := SiggyRNG.new()
 var ticker := TickerRNG.new()
 var early_bird := EarlyBirdRNG.new()
@@ -103,9 +107,10 @@ func init_seed(seed_value: int) -> void:
 	NameManager.set_name_seed(_derive_seed("name_manager"))
 	fumble_manager.init_seed(_derive_seed("fumble_manager"))
 	fumble_profile_stack.init_seed(_derive_seed("fumble_profile_stack"))
-	worker_manager.init_seed(_derive_seed("worker_manager"))
-	market_manager.init_seed(_derive_seed("market_manager"))
-	siggy.init_seed(_derive_seed("siggy"))
+        worker_manager.init_seed(_derive_seed("worker_manager"))
+        market_manager.init_seed(_derive_seed("market_manager"))
+        market_event.init_seed(_derive_seed("market_event"))
+        siggy.init_seed(_derive_seed("siggy"))
 	ticker.init_seed(_derive_seed("ticker"))
 	early_bird.init_seed(_derive_seed("early_bird"))
 	crypto.init_seed(_derive_seed("crypto"))

--- a/autoloads/rng_manager.gd
+++ b/autoloads/rng_manager.gd
@@ -41,13 +41,13 @@ class WorkerManagerRNG extends RNGStream:
 	pass
 
 class MarketManagerRNG extends RNGStream:
-        pass
+	pass
 
 class MarketEventRNG extends RNGStream:
-        pass
+	pass
 
 class SiggyRNG extends RNGStream:
-        pass
+	pass
 
 class TickerRNG extends RNGStream:
 	pass
@@ -107,10 +107,10 @@ func init_seed(seed_value: int) -> void:
 	NameManager.set_name_seed(_derive_seed("name_manager"))
 	fumble_manager.init_seed(_derive_seed("fumble_manager"))
 	fumble_profile_stack.init_seed(_derive_seed("fumble_profile_stack"))
-        worker_manager.init_seed(_derive_seed("worker_manager"))
-        market_manager.init_seed(_derive_seed("market_manager"))
-        market_event.init_seed(_derive_seed("market_event"))
-        siggy.init_seed(_derive_seed("siggy"))
+	worker_manager.init_seed(_derive_seed("worker_manager"))
+	market_manager.init_seed(_derive_seed("market_manager"))
+	market_event.init_seed(_derive_seed("market_event"))
+	siggy.init_seed(_derive_seed("siggy"))
 	ticker.init_seed(_derive_seed("ticker"))
 	early_bird.init_seed(_derive_seed("early_bird"))
 	crypto.init_seed(_derive_seed("crypto"))

--- a/resources/crypto/events/hawk_pump_and_dump.tres
+++ b/resources/crypto/events/hawk_pump_and_dump.tres
@@ -1,0 +1,13 @@
+[gd_resource type="Resource" load_steps=4 format=3]
+[ext_resource path="res://resources/markets/market_event.gd" type="Script" id=1]
+[sub_resource type="Resource" id=1 script="res://resources/markets/market_event_stage.gd"]
+duration_range = Vector2i(10, 60)
+target_multiplier_range = Vector2(20.0, 20.0)
+[sub_resource type="Resource" id=2 script="res://resources/markets/market_event_stage.gd"]
+duration_range = Vector2i(5, 30)
+target_multiplier_range = Vector2(0.01, 0.04)
+[resource]
+script = ExtResource("1")
+symbol = "HAWK"
+start_delay_range = Vector2i(10, 60)
+stages = [SubResource("1"), SubResource("2")]

--- a/resources/crypto/hawk1_crypto.tres
+++ b/resources/crypto/hawk1_crypto.tres
@@ -1,0 +1,18 @@
+[gd_resource type="Resource" script_class="Cryptocurrency" load_steps=3 format=3 uid="uid://bjah3mncmmb8"]
+
+[ext_resource type="Script" uid="uid://llcvncktu5" path="res://resources/crypto/cryptocurrency.gd" id="1_kuior"]
+[ext_resource type="Texture2D" uid="uid://bw7dnfkddu22m" path="res://assets/moneytoburn.png" id="1_m5feu"]
+
+[resource]
+script = ExtResource("1_kuior")
+symbol = "HAWK1"
+display_name = "HAWK1A"
+icon = ExtResource("1_m5feu")
+price = 69.0
+volatility = 1.0
+power_required = 1000
+block_size = 1.0
+block_time = 9.0
+price_history = Array[float]([])
+all_time_high = 1.0
+metadata/_custom_type_script = "uid://llcvncktu5"

--- a/resources/crypto/hawk2_crypto.tres
+++ b/resources/crypto/hawk2_crypto.tres
@@ -5,8 +5,8 @@
 
 [resource]
 script = ExtResource("1_kuior")
-symbol = "HAWK"
-display_name = "Hawk2A"
+symbol = "HAWK2"
+display_name = "HAWK2A"
 icon = ExtResource("1_m5feu")
 price = 69.0
 volatility = 1.0

--- a/resources/markets/market_event.gd
+++ b/resources/markets/market_event.gd
@@ -1,0 +1,51 @@
+extends Resource
+class_name MarketEvent
+
+signal finished(event: MarketEvent)
+
+@export var symbol: String = ""
+@export var start_delay_range: Vector2i = Vector2i.ZERO
+@export var stages: Array[MarketEventStage] = []
+
+var _rng: RandomNumberGenerator
+var _asset
+var _start_minute: int = -1
+var _stage_index: int = -1
+var _stage_start_minute: int = 0
+var _stage_duration: int = 0
+var _stage_start_price: float = 0.0
+var _stage_target_price: float = 0.0
+
+func schedule(asset) -> void:
+        _asset = asset
+        _rng = RNGManager.market_event.get_rng()
+        _start_minute = TimeManager.get_now_minutes() + _rng.randi_range(start_delay_range.x, start_delay_range.y)
+        TimeManager.minute_passed.connect(_on_minute_passed)
+
+func _on_minute_passed(current_minute: int) -> void:
+        if current_minute < _start_minute:
+                return
+        if _stage_index == -1:
+                _advance_stage()
+        if _stage_index >= stages.size():
+                TimeManager.minute_passed.disconnect(_on_minute_passed)
+                emit_signal("finished", self)
+                return
+        var elapsed := current_minute - _stage_start_minute
+        var t := float(elapsed) / float(_stage_duration)
+        _asset.price = lerp(_stage_start_price, _stage_target_price, t)
+        if elapsed >= _stage_duration:
+                _asset.price = _stage_target_price
+                _advance_stage()
+
+func _advance_stage() -> void:
+        _stage_index += 1
+        if _stage_index >= stages.size():
+                return
+        var stage: MarketEventStage = stages[_stage_index]
+        _stage_duration = _rng.randi_range(stage.duration_range.x, stage.duration_range.y)
+        var mult := _rng.randf_range(stage.target_multiplier_range.x, stage.target_multiplier_range.y)
+        var noise := _rng.randf_range(stage.price_noise_range.x, stage.price_noise_range.y)
+        _stage_start_price = _asset.price
+        _stage_target_price = _asset.price * mult * (1.0 + noise)
+        _stage_start_minute = TimeManager.get_now_minutes()

--- a/resources/markets/market_event.gd
+++ b/resources/markets/market_event.gd
@@ -17,35 +17,35 @@ var _stage_start_price: float = 0.0
 var _stage_target_price: float = 0.0
 
 func schedule(asset) -> void:
-        _asset = asset
-        _rng = RNGManager.market_event.get_rng()
-        _start_minute = TimeManager.get_now_minutes() + _rng.randi_range(start_delay_range.x, start_delay_range.y)
-        TimeManager.minute_passed.connect(_on_minute_passed)
+	_asset = asset
+	_rng = RNGManager.market_event.get_rng()
+	_start_minute = TimeManager.get_now_minutes() + _rng.randi_range(start_delay_range.x, start_delay_range.y)
+	TimeManager.minute_passed.connect(_on_minute_passed)
 
 func _on_minute_passed(current_minute: int) -> void:
-        if current_minute < _start_minute:
-                return
-        if _stage_index == -1:
-                _advance_stage()
-        if _stage_index >= stages.size():
-                TimeManager.minute_passed.disconnect(_on_minute_passed)
-                emit_signal("finished", self)
-                return
-        var elapsed := current_minute - _stage_start_minute
-        var t := float(elapsed) / float(_stage_duration)
-        _asset.price = lerp(_stage_start_price, _stage_target_price, t)
-        if elapsed >= _stage_duration:
-                _asset.price = _stage_target_price
-                _advance_stage()
+	if current_minute < _start_minute:
+		return
+	if _stage_index == -1:
+		_advance_stage()
+	if _stage_index >= stages.size():
+		TimeManager.minute_passed.disconnect(_on_minute_passed)
+		emit_signal("finished", self)
+		return
+	var elapsed := current_minute - _stage_start_minute
+	var t := float(elapsed) / float(_stage_duration)
+	_asset.price = lerp(_stage_start_price, _stage_target_price, t)
+	if elapsed >= _stage_duration:
+		_asset.price = _stage_target_price
+		_advance_stage()
 
 func _advance_stage() -> void:
-        _stage_index += 1
-        if _stage_index >= stages.size():
-                return
-        var stage: MarketEventStage = stages[_stage_index]
-        _stage_duration = _rng.randi_range(stage.duration_range.x, stage.duration_range.y)
-        var mult := _rng.randf_range(stage.target_multiplier_range.x, stage.target_multiplier_range.y)
-        var noise := _rng.randf_range(stage.price_noise_range.x, stage.price_noise_range.y)
-        _stage_start_price = _asset.price
-        _stage_target_price = _asset.price * mult * (1.0 + noise)
-        _stage_start_minute = TimeManager.get_now_minutes()
+	_stage_index += 1
+	if _stage_index >= stages.size():
+		return
+	var stage: MarketEventStage = stages[_stage_index]
+	_stage_duration = _rng.randi_range(stage.duration_range.x, stage.duration_range.y)
+	var mult := _rng.randf_range(stage.target_multiplier_range.x, stage.target_multiplier_range.y)
+	var noise := _rng.randf_range(stage.price_noise_range.x, stage.price_noise_range.y)
+	_stage_start_price = _asset.price
+	_stage_target_price = _asset.price * mult * (1.0 + noise)
+	_stage_start_minute = TimeManager.get_now_minutes()

--- a/resources/markets/market_event_stage.gd
+++ b/resources/markets/market_event_stage.gd
@@ -1,0 +1,6 @@
+extends Resource
+class_name MarketEventStage
+
+@export var duration_range: Vector2i = Vector2i(1, 1)
+@export var target_multiplier_range: Vector2 = Vector2.ONE
+@export var price_noise_range: Vector2 = Vector2.ZERO


### PR DESCRIPTION
## Summary
- allow `MarketEvent` to drive stocks or cryptos via dedicated `market_event` RNG stream
- split HAWK into HAWK1/HAWK2 resources and randomly schedule pump-and-dump on one variant at startup
- track market events generically in `MarketManager`

## Testing
- ⚠️ `godot --headless tests/test_runner.tscn` (command not found: godot)


------
https://chatgpt.com/codex/tasks/task_e_68a8953d69fc8325b31d6ecb7c7f54b7