### PR TITLE
Hide upgrade button when pane lacks upgrade pane

### DIFF
--- a/components/ui/window_frame.gd
+++ b/components/ui/window_frame.gd
@@ -137,12 +137,21 @@ func animate_resize_y(target_y: float, duration: float = 0.4):
 	tween.tween_property(self, "size:y", target_y, duration).set_trans(Tween.TRANS_CUBIC).set_ease(Tween.EASE_OUT)
 
 func _set_content(new_content: Control) -> void:
-	for child in content_panel.get_children():
-		child.queue_free()
-	content_panel.add_child(new_content)
-	_update_upgrade_button_state()
-	if windowless_mode:
-		call_deferred("_setup_windowless_drag")
+        for child in content_panel.get_children():
+                child.queue_free()
+        content_panel.add_child(new_content)
+
+        # Only expose the upgrade button when the child pane actually
+        # provides an upgrade pane.  This ensures windows that do not
+        # support upgrades do not show an empty or misleading button.
+        if new_content is Pane and new_content.upgrade_pane:
+                upgrade_button.show()
+                _update_upgrade_button_state()
+        else:
+                upgrade_button.hide()
+
+        if windowless_mode:
+                call_deferred("_setup_windowless_drag")
 
 func _set_windowless_mode(enabled: bool) -> void:
 	_windowless_mode = enabled

--- a/components/ui/window_frame.tscn
+++ b/components/ui/window_frame.tscn
@@ -176,6 +176,7 @@ layout_mode = 2
 unique_name_in_owner = true
 custom_minimum_size = Vector2(20, 0)
 layout_mode = 2
+visible = false
 focus_mode = 0
 theme_override_styles/hover_pressed = SubResource("StyleBoxTexture_f5uc2")
 theme_override_styles/hover = SubResource("StyleBoxTexture_74cm5")


### PR DESCRIPTION
## Summary
- Show upgrade button only when the loaded pane exposes an upgrade pane
- Hide upgrade button by default in the window frame scene

## Testing
- `godot3 --headless -s tests/test_runner.gd` *(fails: Can't open project at '/workspace/SigmaSim/project.godot', its `config_version` (5) is from a more recent and incompatible version of the engine)*

------
https://chatgpt.com/codex/tasks/task_e_68a8b90ec63083259a1ca5fc2b66ac5f