### PR TITLE
Persist NPC costs across saves

### DIFF
--- a/components/npc/npc_manager.gd
+++ b/components/npc/npc_manager.gd
@@ -69,28 +69,30 @@ func get_npc_by_index(idx: int) -> NPC:
 	return npc
 
 func set_npc_field(idx: int, field: String, value) -> void:
-	if not npcs.has(idx):
-		push_error("Tried to set a field on a non-existent NPC!")
-		return
-	npcs[idx].set(field, value)
-	if field == "relationship_stage":
-		npcs[idx].affinity_equilibrium = float(value) * 10.0
-		if persistent_npcs.has(idx):
-			persistent_npcs[idx]["affinity_equilibrium"] = npcs[idx].affinity_equilibrium
-		if persistent_npcs.has(idx):
-				persistent_npcs[idx][field] = value
-				_queue_save(idx)
-		else:
-				if not npc_overrides.has(idx):
-						npc_overrides[idx] = {}
-				npc_overrides[idx][field] = value
-				if field == "portrait_config":
-						promote_to_persistent(idx)
+        if not npcs.has(idx):
+                push_error("Tried to set a field on a non-existent NPC!")
+                return
+        npcs[idx].set(field, value)
 
-	if field == "portrait_config":
-		emit_signal("portrait_changed", idx, value)
-	if field == "affinity":
-		emit_signal("affinity_changed", idx, value)
+        if field == "relationship_stage":
+                npcs[idx].affinity_equilibrium = float(value) * 10.0
+                if persistent_npcs.has(idx):
+                        persistent_npcs[idx]["affinity_equilibrium"] = npcs[idx].affinity_equilibrium
+
+        if persistent_npcs.has(idx):
+                persistent_npcs[idx][field] = value
+                _queue_save(idx)
+        else:
+                if not npc_overrides.has(idx):
+                        npc_overrides[idx] = {}
+                npc_overrides[idx][field] = value
+                if field == "portrait_config":
+                        promote_to_persistent(idx)
+
+        if field == "portrait_config":
+                emit_signal("portrait_changed", idx, value)
+        if field == "affinity":
+                emit_signal("affinity_changed", idx, value)
 func promote_to_persistent(idx: int) -> void:
 	if not persistent_npcs.has(idx):
 		var npc = get_npc_by_index(idx)

--- a/tests/npc_cost_persistence_test.gd
+++ b/tests/npc_cost_persistence_test.gd
@@ -1,0 +1,30 @@
+extends SceneTree
+
+func _ready() -> void:
+    var save_mgr = Engine.get_singleton("SaveManager")
+    var db_mgr = Engine.get_singleton("DBManager")
+    var npc_mgr = Engine.get_singleton("NPCManager")
+
+    save_mgr.reset_managers()
+    save_mgr.current_slot_id = 1
+
+    var npc_id := 9999
+    db_mgr.db.query("DELETE FROM npc WHERE id = %d AND slot_id = %d" % [npc_id, save_mgr.current_slot_id])
+
+    var npc := NPC.new()
+    npc.gift_cost = 25.0
+    npc.date_cost = 200.0
+    db_mgr.save_npc(npc_id, npc, save_mgr.current_slot_id)
+
+    npc_mgr.npcs[npc_id] = npc
+    npc_mgr.persistent_npcs[npc_id] = {}
+    npc_mgr.set_npc_field(npc_id, "gift_cost", 50.0)
+    npc_mgr.set_npc_field(npc_id, "date_cost", 400.0)
+    npc_mgr._flush_save_queue()
+
+    npc_mgr.npcs.erase(npc_id)
+    var loaded := db_mgr.load_npc(npc_id, save_mgr.current_slot_id)
+    assert(loaded.gift_cost == 50.0)
+    assert(loaded.date_cost == 400.0)
+    print("npc_cost_persistence_test passed")
+    quit()


### PR DESCRIPTION
## Summary
- ensure NPCManager writes any field changes, including gift_cost and date_cost, to persistent data
- add regression test covering NPC gift and date cost persistence

## Testing
- `godot --headless --path . -s tests/npc_cost_persistence_test.gd` *(fails: Identifier "NPC" not declared in the current scope)*

------
https://chatgpt.com/codex/tasks/task_e_68a8bb2e4a9c8325b7ec1ac4d4240595