### PR TITLE
Fix duplicate stat dependents causing upgrade lag

### DIFF
--- a/autoloads/stat_manager.gd
+++ b/autoloads/stat_manager.gd
@@ -354,14 +354,14 @@ func _build_upgrade_cache() -> void:
 
 
 func _build_dependents_map() -> void:
-	_dependents.clear()
-	for derived in stat_dependencies.keys():
-		var deps: Array = stat_dependencies[derived]
-		for dep in deps:
-			if !_dependents.has(dep):
-				_dependents[dep] = []
-			_dependents[dep].append(derived)
-			_dependents[dep].append(derived)
+        _dependents.clear()
+        for derived in stat_dependencies.keys():
+                var deps: Array = stat_dependencies[derived]
+                for dep in deps:
+                        if !_dependents.has(dep):
+                                _dependents[dep] = []
+                        if not _dependents[dep].has(derived):
+                                _dependents[dep].append(derived)
 
 
 func _emit_stat_callbacks(stat: String, value: Variant) -> void:

--- a/tests/stat_manager_dependents_test.gd
+++ b/tests/stat_manager_dependents_test.gd
@@ -1,0 +1,11 @@
+extends SceneTree
+
+func _ready():
+    var sm = Engine.get_singleton("StatManager")
+    sm._build_dependents_map()
+    for dep in sm._dependents.keys():
+        var arr = sm._dependents[dep]
+        for item in arr:
+            assert(arr.count(item) == 1, "%s appears multiple times in dependents for %s" % [item, dep])
+    print("stat_manager_dependents_test passed")
+    quit()


### PR DESCRIPTION
## Summary
- avoid adding duplicate derived stats in `_build_dependents_map`
- add test ensuring dependents map contains unique entries

## Testing
- `godot3-server --headless -s tests/test_runner.gd` *(fails: Can't open project, config_version 5 is too new for Godot v3.5.2)*

------
https://chatgpt.com/codex/tasks/task_e_68a8bc9ee31c8325b0fea474a1db7b80