### PR TITLE
Avoid double refresh after purchasing upgrades

### DIFF
--- a/data/upgrades/system_upgrade_ui.gd
+++ b/data/upgrades/system_upgrade_ui.gd
@@ -96,11 +96,17 @@ func _on_sort_option_selected(index: int) -> void:
 	refresh_upgrades()
 
 func _on_purchase_requested(upgrade_id: String):
-	if UpgradeManager.purchase(upgrade_id):
-		_display_message("Upgrade purchased: %s" % upgrade_id)
-		refresh_upgrades()
-	else:
-		_display_message("Cannot purchase upgrade: %s" % upgrade_id)
+        if UpgradeManager.purchase(upgrade_id):
+                _display_message("Upgrade purchased: %s" % upgrade_id)
+                # UpgradeManager emits an `upgrade_purchased` signal on success
+                # which is already connected to `_on_upgrade_changed`. That
+                # handler refreshes the list, so calling `refresh_upgrades()`
+                # here causes the UI to rebuild twice in the same frame. The
+                # duplicate rebuild results in a noticeable frame drop when an
+                # upgrade is purchased. Rely on the signal-driven refresh to
+                # avoid the extra work.
+        else:
+                _display_message("Cannot purchase upgrade: %s" % upgrade_id)
 
 func _on_upgrade_changed(id: String, new_level: int):
 	refresh_upgrades()


### PR DESCRIPTION
## Summary
- Reduce frame drop when purchasing upgrades by avoiding redundant refreshes in `SystemUpgradeUI`

## Testing
- `godot3 --headless --script tests/test_runner.gd` *(fails: Can't open project, requires newer Godot version)*
- `/tmp/godot/Godot_v4.2.2-stable_linux.x86_64 --headless --script tests/test_runner.gd` *(fails: Missing imported resources and script inherits Node)*

------
https://chatgpt.com/codex/tasks/task_e_68a8bc9ee31c8325b0fea474a1db7b80