### PR TITLE
Add affinity equilibrium marker to Affinity bar

### DIFF
--- a/components/npc/npc_manager.gd
+++ b/components/npc/npc_manager.gd
@@ -6,6 +6,7 @@ signal affinity_changed(idx, value)
 signal exclusivity_core_changed(idx: int, old_core: int, new_core: int)
 signal relationship_stage_changed(idx: int, old_stage: int, new_stage: int)
 signal cheating_detected(primary_idx: int, other_idx: int)
+signal affinity_equilibrium_changed(idx: int, value: float)
 
 enum RelationshipStage { STRANGER, TALKING, DATING, SERIOUS, ENGAGED, MARRIED, DIVORCED, EX }
 enum ExclusivityCore { MONOG, POLY, CHEATING }
@@ -78,6 +79,9 @@ func set_npc_field(idx: int, field: String, value) -> void:
 			npcs[idx].affinity_equilibrium = float(value) * 10.0
 			if persistent_npcs.has(idx):
 					persistent_npcs[idx]["affinity_equilibrium"] = npcs[idx].affinity_equilibrium
+			emit_signal("affinity_equilibrium_changed", idx, npcs[idx].affinity_equilibrium)
+	elif field == "affinity_equilibrium":
+			emit_signal("affinity_equilibrium_changed", idx, npcs[idx].affinity_equilibrium)
 
 	if persistent_npcs.has(idx):
 			persistent_npcs[idx][field] = value
@@ -266,6 +270,8 @@ func set_relationship_stage(npc_idx: int, new_stage: int) -> void:
 	persistent_npcs[npc_idx]["affinity_equilibrium"] = npc.affinity_equilibrium
 	DBManager.save_npc(npc_idx, npc)
 	emit_signal("relationship_stage_changed", npc_idx, old_stage, npc.relationship_stage)
+	if old_equilibrium != npc.affinity_equilibrium:
+		emit_signal("affinity_equilibrium_changed", npc_idx, npc.affinity_equilibrium)
 	print("NPC %d: stage %d -> %d core %d -> %d affinity %.2f -> %.2f eq %.2f -> %.2f" % [npc_idx, old_stage, npc.relationship_stage, old_core, npc.exclusivity_core, old_affinity, npc.affinity, old_equilibrium, npc.affinity_equilibrium])
 
 	if new_stage >= RelationshipStage.DATING and old_stage < RelationshipStage.DATING:
@@ -382,6 +388,8 @@ func transition_dating_to_serious_poly(npc_idx: int) -> void:
 		emit_signal("exclusivity_core_changed", npc_idx, old_core, npc.exclusivity_core)
 	if old_affinity != npc.affinity:
 		emit_signal("affinity_changed", npc_idx, npc.affinity)
+	if old_equilibrium != npc.affinity_equilibrium:
+		emit_signal("affinity_equilibrium_changed", npc_idx, npc.affinity_equilibrium)
 	print("NPC %d: stage %d -> %d core %d -> %d affinity %.2f -> %.2f eq %.2f -> %.2f" % [npc_idx, old_stage, npc.relationship_stage, old_core, npc.exclusivity_core, old_affinity, npc.affinity, old_equilibrium, npc.affinity_equilibrium])
 
 func request_poly_at_serious_or_engaged(npc_idx: int) -> void:
@@ -406,6 +414,8 @@ func request_poly_at_serious_or_engaged(npc_idx: int) -> void:
 		emit_signal("exclusivity_core_changed", npc_idx, old_core, npc.exclusivity_core)
 	if old_affinity != npc.affinity:
 		emit_signal("affinity_changed", npc_idx, npc.affinity)
+	if old_equilibrium != npc.affinity_equilibrium:
+		emit_signal("affinity_equilibrium_changed", npc_idx, npc.affinity_equilibrium)
 	print("NPC %d: stage %d -> %d core %d -> %d affinity %.2f -> %.2f eq %.2f -> %.2f" % [npc_idx, old_stage, npc.relationship_stage, old_core, npc.exclusivity_core, old_affinity, npc.affinity, old_equilibrium, npc.affinity_equilibrium])
 
 func return_to_monogamy(npc_idx: int) -> void:
@@ -471,6 +481,8 @@ func _mark_npc_as_cheating(npc_idx: int, other_idx: int) -> void:
 		DBManager.save_npc(npc_idx, npc)
 		emit_signal("exclusivity_core_changed", npc_idx, old_core, npc.exclusivity_core)
 		emit_signal("affinity_changed", npc_idx, npc.affinity)
+		if old_equilibrium != npc.affinity_equilibrium:
+				emit_signal("affinity_equilibrium_changed", npc_idx, npc.affinity_equilibrium)
 		emit_signal("cheating_detected", npc_idx, other_idx)
 		print("NPC %d: stage %d -> %d core %d -> %d affinity %.2f -> %.2f eq %.2f -> %.2f" % [npc_idx, old_stage, npc.relationship_stage, old_core, npc.exclusivity_core, old_affinity, npc.affinity, old_equilibrium, npc.affinity_equilibrium])
 

--- a/components/popups/affinity_bar.gd
+++ b/components/popups/affinity_bar.gd
@@ -1,0 +1,20 @@
+class_name AffinityBar
+extends StatProgressBar
+
+var affinity_equilibrium: float = 0.0
+
+func set_affinity_equilibrium(new_eq: float) -> void:
+	affinity_equilibrium = new_eq
+	queue_redraw()
+
+func _draw() -> void:
+	var bar_rect: Rect2 = Rect2(Vector2.ZERO, size)
+	if max_value != min_value:
+		var fraction: float = clamp((affinity_equilibrium - min_value) / (max_value - min_value), 0.0, 1.0)
+		var x: float = bar_rect.position.x + bar_rect.size.x * fraction
+		draw_line(
+			Vector2(x, bar_rect.position.y),
+			Vector2(x, bar_rect.position.y + bar_rect.size.y),
+			Color.WHITE,
+			1.0
+		)

--- a/components/popups/ex_factor_view.gd
+++ b/components/popups/ex_factor_view.gd
@@ -11,7 +11,7 @@ const PROGRESS_MIN_DELTA: float = 0.01
 @onready var relationship_stage_label: Label = %RelationshipStageLabel
 @onready var relationship_bar: RelationshipBar = %RelationshipBar
 @onready var next_stage_button: Button = %NextStageButton
-@onready var affinity_bar: StatProgressBar = %AffinityBar
+@onready var affinity_bar: AffinityBar = %AffinityBar
 @onready var relationship_value_label: Label = %RelationshipValueLabel
 @onready var affinity_value_label: Label = %AffinityValueLabel
 @onready var love_button: Button = %LoveButton
@@ -76,6 +76,7 @@ func _ready() -> void:
 	love_button.pressed.connect(_on_love_pressed)
 	exclusivity_button.pressed.connect(_on_exclusivity_button_pressed)
 	NPCManager.affinity_changed.connect(_on_npc_affinity_changed)
+	NPCManager.affinity_equilibrium_changed.connect(_on_affinity_equilibrium_changed)
 	NPCManager.exclusivity_core_changed.connect(_on_exclusivity_core_changed)
 	NPCManager.relationship_stage_changed.connect(_on_relationship_stage_changed)
 
@@ -148,6 +149,7 @@ func _update_relationship_bar() -> void:
 func _update_affinity_bar() -> void:
 		affinity_bar.max_value = 100
 		affinity_bar.update_value(npc.affinity)
+		affinity_bar.set_affinity_equilibrium(npc.affinity_equilibrium)
 		affinity_value_label.text = "%s / 100" % NumberFormatter.format_commas(npc.affinity, 0)
 
 func _update_breakup_button_text() -> void:
@@ -258,6 +260,12 @@ func _on_npc_affinity_changed(idx: int, value: float) -> void:
 		npc.affinity = value
 		_update_affinity_bar()
 
+func _on_affinity_equilibrium_changed(idx: int, value: float) -> void:
+		if idx != npc_idx:
+				return
+		npc.affinity_equilibrium = value
+		_update_affinity_bar()
+
 func _on_exclusivity_core_changed(idx: int, _old_core: int, new_core: int) -> void:
 				if idx != npc_idx:
 								return
@@ -268,9 +276,10 @@ func _on_exclusivity_core_changed(idx: int, _old_core: int, new_core: int) -> vo
 func _on_relationship_stage_changed(idx: int, _old_stage: int, new_stage: int) -> void:
 				if idx != npc_idx:
 								return
-				npc.relationship_stage = new_stage
-				_update_exclusivity_label()
-				_update_exclusivity_button()
+		npc.relationship_stage = new_stage
+		_update_exclusivity_label()
+		_update_exclusivity_button()
+		_update_affinity_bar()
 
 func _on_exclusivity_button_pressed() -> void:
 		if npc == null:

--- a/components/popups/ex_factor_view.tscn
+++ b/components/popups/ex_factor_view.tscn
@@ -2,7 +2,7 @@
 
 [ext_resource type="Theme" uid="uid://cesgvqexxaqev" path="res://assets/windows_95_theme.tres" id="1"]
 [ext_resource type="Script" uid="uid://d1rk5ob1oyitb" path="res://components/popups/ex_factor_view.gd" id="2"]
-[ext_resource type="Script" uid="uid://qeyobl0rg2cy" path="res://components/apps/fumble/stat_progress_bar.gd" id="3"]
+[ext_resource type="Script" uid="uid://gajqpv1sacbp" path="res://components/popups/affinity_bar.gd" id="3"]
 [ext_resource type="PackedScene" uid="uid://fna5puejflgh" path="res://components/upgrade_scenes/ex_factor_upgrade_ui.tscn" id="3_n3cpl"]
 [ext_resource type="Shader" uid="uid://n1vlc8cxnun0" path="res://assets/shaders/warp_shader.gdshader" id="3_vl6ok"]
 [ext_resource type="PackedScene" uid="uid://drm1apbdsjj5g" path="res://components/portrait/portrait_view.tscn" id="4"]


### PR DESCRIPTION
## Summary
- draw affinity equilibrium marker via new `AffinityBar`
- use `AffinityBar` in ExFactor view and refresh when NPC equilibrium changes
- emit `affinity_equilibrium_changed` signal from NPCManager to drive UI updates

## Testing
- `godot --headless -s tests/test_runner.gd` *(fails: command not found)*
- `apt-get install -y godot4` *(fails: package not found)*
- `wget https://downloads.tuxfamily.org/godotengine/4.2.2/Godot_v4.2.2-stable_linux.x86_64.zip -O /tmp/godot.zip` *(fails: 503 Service Unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68a8d584f4d08325aa56d22c503d874b