### PR TITLE
feat: highlight cheating exclusivity

### DIFF
--- a/components/popups/ex_factor_view.gd
+++ b/components/popups/ex_factor_view.gd
@@ -238,6 +238,10 @@ func _update_exclusivity_label() -> void:
 				label_text = "Unmentioned"
 
 	exclusivity_label.text = "Exclusivity: " + label_text
+	if npc.exclusivity_core == NPCManager.ExclusivityCore.CHEATING:
+		exclusivity_label.add_theme_color_override("font_color", Color.RED)
+	else:
+		exclusivity_label.remove_theme_color_override("font_color")
 
 
 func _update_exclusivity_button() -> void:


### PR DESCRIPTION
## Summary
- show "Exclusivity: Cheating" in red on ExFactor screen

## Testing
- `godot --headless --run tests/test_runner.tscn` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8df6194f08325ab05d2a4276d32f0