### PR TITLE
Refactor Talk Therapy into eXFactor upgrade

### DIFF
--- a/components/popups/ex_factor_view.gd
+++ b/components/popups/ex_factor_view.gd
@@ -84,8 +84,8 @@ func _ready() -> void:
 
 	
 	await get_tree().process_frame
-	if Events.has_signal("fumble_talk_therapy_purchased"):
-		Events.connect("fumble_talk_therapy_purchased", _on_talk_therapy_purchased)
+        if Events.has_signal("ex_factor_talk_therapy_purchased"):
+                Events.connect("ex_factor_talk_therapy_purchased", _on_talk_therapy_purchased)
 
 
 func _process(delta: float) -> void:
@@ -126,7 +126,7 @@ func _update_all() -> void:
 
 	gift_button.disabled = blocked
 	date_button.disabled = blocked
-	apologize_button.visible = UpgradeManager.get_level("fumble_talk_therapy") > 0 and npc.relationship_stage in [NPCManager.RelationshipStage.DIVORCED, NPCManager.RelationshipStage.EX]
+        apologize_button.visible = UpgradeManager.get_level("ex_factor_talk_therapy") > 0 and npc.relationship_stage in [NPCManager.RelationshipStage.DIVORCED, NPCManager.RelationshipStage.EX]
 func _update_relationship_bar() -> void:
 	var current_stage: int = npc.relationship_stage
 	if current_stage == NPCManager.RelationshipStage.MARRIED:

--- a/data/upgrades/ex_factor_talk_therapy.json
+++ b/data/upgrades/ex_factor_talk_therapy.json
@@ -1,10 +1,10 @@
 {
-  "id": "fumble_talk_therapy",
+  "id": "ex_factor_talk_therapy",
   "name": "Talk Therapy",
   "description": "Unlocks the ability to apologize to exes, letting you restart at the talking stage.",
   "effects": [],
   "systems": [
-	"fumble"
+        "eXFactor"
   ],
   "dependencies": [],
   "cost_per_level": {


### PR DESCRIPTION
## Summary
- Move Talk Therapy upgrade from fumble to eXFactor system
- Update eXFactor view to listen for new Talk Therapy purchase event and check upgraded level

## Testing
- `godot -s tests/test_runner.gd` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8e015b2748325bbc3d76986f3291a