### PR TITLE
Fix relationship exclusivity after reload

### DIFF
--- a/autoloads/db_manager.gd
+++ b/autoloads/db_manager.gd
@@ -167,19 +167,26 @@ func load_npc(idx: int, slot_id: int = SaveManager.current_slot_id) -> NPC:
 	return NPC.from_dict(row)
 
 func get_all_npcs_for_slot(slot_id: int = SaveManager.current_slot_id) -> Array:
-	var raw_rows = db.select_rows("npc", "slot_id = %d" % slot_id, ["*"])
-	var out: Array = []
-	for row in raw_rows:
-		row["gender_vector"] = _safe_from_json(row.get("gender_vector", null), '{"x":0,"y":0,"z":1}')
-		row["tags"] = _safe_from_json(row.get("tags", null), "[]")
+        var raw_rows = db.select_rows("npc", "slot_id = %d" % slot_id, ["*"])
+        var out: Array = []
+        for row in raw_rows:
+                row["gender_vector"] = _safe_from_json(row.get("gender_vector", null), '{"x":0,"y":0,"z":1}')
+                row["tags"] = _safe_from_json(row.get("tags", null), "[]")
 		row["likes"] = _safe_from_json(row.get("likes", null), "[]")
 		row["preferred_pet_names"] = _safe_from_json(row.get("preferred_pet_names", null), "[]")
 		row["player_pet_names"] = _safe_from_json(row.get("player_pet_names", null), "[]")
 		row["ocean"] = _safe_from_json(row.get("ocean", null), "{}")
 		row["wall_posts"] = _safe_from_json(row.get("wall_posts", null), "[]")
-		row["portrait_config"] = _safe_from_json(row.get("portrait_config", null), "{}")
-		out.append(NPC.from_dict(row))
-	return out
+                row["portrait_config"] = _safe_from_json(row.get("portrait_config", null), "{}")
+                out.append(NPC.from_dict(row))
+        return out
+
+func get_all_npc_ids(slot_id: int = SaveManager.current_slot_id) -> Array[int]:
+        var rows = db.select_rows("npc", "slot_id = %d" % slot_id, ["id"])
+        var ids: Array[int] = []
+        for r in rows:
+                ids.append(int(r.id))
+        return ids
 
 func _safe_from_json(value, fallback: String) -> Variant:
 	if value == null:

--- a/autoloads/save_manager.gd
+++ b/autoloads/save_manager.gd
@@ -224,10 +224,11 @@ func load_from_slot(slot_id: int) -> void:
 			BillManager.load_from_data(data["bills"])
 	if data.has("desktop"):
 			DesktopLayoutManager.load_from_data(data["desktop"])
-	if data.has("windows"):  # Always load windows last
-			WindowManager.load_from_data(data["windows"])
-	BillManager.is_loading = false
-	BillManager.show_due_popups()
+        if data.has("windows"):  # Always load windows last
+                        WindowManager.load_from_data(data["windows"])
+        BillManager.is_loading = false
+        BillManager.show_due_popups()
+        NPCManager.restore_encountered_from_db()
 
 
 func reset_game_state() -> void:

--- a/components/npc/npc_manager.gd
+++ b/components/npc/npc_manager.gd
@@ -609,14 +609,22 @@ func get_fumble_matches_with_times() -> Array:
 
 # Returns true if a battle is active with this NPC (FumbleManager sets this flag)
 func is_fumble_battle_active(npc_idx: int) -> bool:
-	return FumbleManager.has_active_battle(npc_idx)
+        return FumbleManager.has_active_battle(npc_idx)
+
+
+func restore_encountered_from_db() -> void:
+        encountered_npcs.clear()
+        for idx in DBManager.get_all_npc_ids():
+                var id: int = int(idx)
+                if not encountered_npcs.has(id):
+                        encountered_npcs.append(id)
 
 
 func reset() -> void:
-	encounter_count = 0
-	encountered_npcs = []
-	encountered_npcs_by_app = {}
-	active_npcs_by_app = {}
+        encounter_count = 0
+        encountered_npcs = []
+        encountered_npcs_by_app = {}
+        active_npcs_by_app = {}
 
 	relationship_status = {}
 	persistent_npcs = {}

--- a/tests/npc_encounter_reload_test.gd
+++ b/tests/npc_encounter_reload_test.gd
@@ -1,0 +1,28 @@
+extends SceneTree
+
+func _ready() -> void:
+    var save_mgr = Engine.get_singleton("SaveManager")
+    var db_mgr = Engine.get_singleton("DBManager")
+    var npc_mgr = Engine.get_singleton("NPCManager")
+
+    save_mgr.reset_managers()
+    save_mgr.current_slot_id = 1
+    # clear existing NPC rows for slot
+    db_mgr.db.query("DELETE FROM npc WHERE slot_id = %d" % save_mgr.current_slot_id)
+
+    var npc1 := NPC.new()
+    npc1.relationship_stage = NPCManager.RelationshipStage.DATING
+    db_mgr.save_npc(1, npc1, save_mgr.current_slot_id)
+    var npc2 := NPC.new()
+    npc2.relationship_stage = NPCManager.RelationshipStage.DATING
+    db_mgr.save_npc(2, npc2, save_mgr.current_slot_id)
+
+    save_mgr.save_to_slot(save_mgr.current_slot_id)
+    save_mgr.load_from_slot(save_mgr.current_slot_id)
+
+    var encountered := npc_mgr.encountered_npcs
+    assert(encountered.has(1))
+    assert(encountered.has(2))
+    print("npc_encounter_reload_test passed")
+    quit()
+


### PR DESCRIPTION
## Summary
- load all NPC ids from the database when a save is loaded
- rebuild NPCManager's encountered list from those ids to enforce exclusivity checks
- add regression test for reloading encountered NPCs

## Testing
- `godot --headless -s tests/test_runner.gd` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8dfd2fdc0832587cd1aa812eacf13