### PR TITLE
Emit breakup signal to update NPC cheating status

### DIFF
--- a/components/npc/npc.gd
+++ b/components/npc/npc.gd
@@ -2,6 +2,8 @@
 class_name NPC
 extends Resource
 
+signal player_broke_up
+
 const BASE_GIFT_COST: float = 10.0
 const BASE_DATE_COST: float = 100.0
 

--- a/components/npc/npc_manager.gd
+++ b/components/npc/npc_manager.gd
@@ -7,6 +7,7 @@ signal exclusivity_core_changed(idx: int, old_core: int, new_core: int)
 signal relationship_stage_changed(idx: int, old_stage: int, new_stage: int)
 signal cheating_detected(primary_idx: int, other_idx: int)
 signal affinity_equilibrium_changed(idx: int, value: float)
+signal breakup_occurred(idx: int)
 
 enum RelationshipStage { STRANGER, TALKING, DATING, SERIOUS, ENGAGED, MARRIED, DIVORCED, EX }
 enum ExclusivityCore { MONOG, POLY, CHEATING }
@@ -466,8 +467,8 @@ func come_clean_from_cheating(npc_idx: int) -> void:
 		print("NPC %d: come clean from cheating core %d -> %d affinity %.2f -> %.2f" % [npc_idx, old_core, npc.exclusivity_core, old_affinity, npc.affinity])
 
 func _mark_npc_as_cheating(npc_idx: int, other_idx: int) -> void:
-		var npc: NPC = get_npc_by_index(npc_idx)
-		var old_stage: int = npc.relationship_stage
+                var npc: NPC = get_npc_by_index(npc_idx)
+                var old_stage: int = npc.relationship_stage
 		var old_core: int = npc.exclusivity_core
 		var old_affinity: float = npc.affinity
 		var old_equilibrium: float = npc.affinity_equilibrium
@@ -483,8 +484,29 @@ func _mark_npc_as_cheating(npc_idx: int, other_idx: int) -> void:
 		emit_signal("affinity_changed", npc_idx, npc.affinity)
 		if old_equilibrium != npc.affinity_equilibrium:
 				emit_signal("affinity_equilibrium_changed", npc_idx, npc.affinity_equilibrium)
-		emit_signal("cheating_detected", npc_idx, other_idx)
-		print("NPC %d: stage %d -> %d core %d -> %d affinity %.2f -> %.2f eq %.2f -> %.2f" % [npc_idx, old_stage, npc.relationship_stage, old_core, npc.exclusivity_core, old_affinity, npc.affinity, old_equilibrium, npc.affinity_equilibrium])
+                emit_signal("cheating_detected", npc_idx, other_idx)
+                print("NPC %d: stage %d -> %d core %d -> %d affinity %.2f -> %.2f eq %.2f -> %.2f" % [npc_idx, old_stage, npc.relationship_stage, old_core, npc.exclusivity_core, old_affinity, npc.affinity, old_equilibrium, npc.affinity_equilibrium])
+
+func player_broke_up_with(npc_idx: int) -> void:
+        emit_signal("breakup_occurred", npc_idx)
+        _check_cheating_after_breakup()
+
+func _check_cheating_after_breakup() -> void:
+        for idx in encountered_npcs:
+                var check_idx: int = int(idx)
+                var npc: NPC = get_npc_by_index(check_idx)
+                if npc.exclusivity_core == ExclusivityCore.CHEATING:
+                        var still_cheating: bool = false
+                        for other in encountered_npcs:
+                                var other_idx: int = int(other)
+                                if other_idx == check_idx:
+                                        continue
+                                var other_npc: NPC = get_npc_by_index(other_idx)
+                                if other_npc.relationship_stage >= RelationshipStage.DATING and other_npc.relationship_stage <= RelationshipStage.MARRIED:
+                                        still_cheating = true
+                                        break
+                        if not still_cheating:
+                                come_clean_from_cheating(check_idx)
 
 func notify_player_advanced_someone_to_dating(other_idx: int) -> void:
 	for idx in encountered_npcs:

--- a/components/popups/ex_factor_view.gd
+++ b/components/popups/ex_factor_view.gd
@@ -513,16 +513,18 @@ func _on_breakup_confirm_yes_pressed() -> void:
 	npc.affinity *= 0.2
 	logic.change_state(npc.relationship_stage)
 	logic.progress_paused = true
-	next_stage_button.visible = false
-	gift_button.disabled = true
-	date_button.disabled = true
-	breakup_button.disabled = true
-	if npc_idx != -1:
-		NPCManager.promote_to_persistent(npc_idx)
-		NPCManager.set_relationship_stage(npc_idx, npc.relationship_stage)
-		NPCManager.set_npc_field(npc_idx, "relationship_progress", npc.relationship_progress)
-		NPCManager.set_npc_field(npc_idx, "affinity", npc.affinity)
-	_update_all()
+        next_stage_button.visible = false
+        gift_button.disabled = true
+        date_button.disabled = true
+        breakup_button.disabled = true
+        npc.emit_signal("player_broke_up")
+        if npc_idx != -1:
+                NPCManager.promote_to_persistent(npc_idx)
+                NPCManager.set_relationship_stage(npc_idx, npc.relationship_stage)
+                NPCManager.set_npc_field(npc_idx, "relationship_progress", npc.relationship_progress)
+                NPCManager.set_npc_field(npc_idx, "affinity", npc.affinity)
+                NPCManager.player_broke_up_with(npc_idx)
+        _update_all()
 
 func _on_breakup_confirm_no_pressed() -> void:
 	breakup_confirm.visible = false


### PR DESCRIPTION
## Summary
- emit `player_broke_up` signal when the user breaks up with an NPC
- broadcast breakup via NPCManager and update cheating status for remaining NPCs
- ex factor view triggers breakup signal and manager logic

## Testing
- `godot3 -s tests/test_runner.gd` *(fails: Can't open project, config_version 5 is incompatible with engine and X11 display not available)*

------
https://chatgpt.com/codex/tasks/task_e_68a8eb3349988325b2cc7dcbe989e906