### PR TITLE
Add configurable market events and HAWK pump-and-dump

### DIFF
--- a/autoloads/market_manager.gd
+++ b/autoloads/market_manager.gd
@@ -3,6 +3,8 @@ extends Node
 
 var stock_market: Dictionary = {}  # symbol: Stock
 var crypto_market: Dictionary = {}  # symbol: Crypto
+var stock_events: Dictionary = {}   # symbol: MarketEvent
+var crypto_events: Dictionary = {}  # symbol: MarketEvent
 
 signal crypto_market_ready
 
@@ -22,19 +24,24 @@ var STOCK_RESOURCES = {
 }
 
 var CRYPTO_RESOURCES = {
-	"BITC": preload("res://resources/crypto/bitc_crypto.tres"),
-	"HAWK": preload("res://resources/crypto/hawk_crypto.tres"),
-	"WORM": preload("res://resources/crypto/worm_crypto.tres"),
+        "BITC": preload("res://resources/crypto/bitc_crypto.tres"),
+        "HAWK": preload("res://resources/crypto/hawk_crypto.tres"),
+        "WORM": preload("res://resources/crypto/worm_crypto.tres"),
+}
+
+var EVENT_RESOURCES = {
+        "HAWK_PUMP": preload("res://resources/market_events/hawk_pump_and_dump.tres"),
 }
 
 func _ready() -> void:
-	TimeManager.minute_passed.connect(_on_minute_passed)
-	if crypto_market.is_empty():
-		print("crypto market was empty")
-		_init_crypto_market()
-	if stock_market.is_empty():
-		_init_stock_market()
-	print("market manager ready, crypto should be initialized")
+        TimeManager.minute_passed.connect(_on_minute_passed)
+        if crypto_market.is_empty():
+                print("crypto market was empty")
+                _init_crypto_market()
+        if stock_market.is_empty():
+                _init_stock_market()
+        _init_market_events()
+        print("market manager ready, crypto should be initialized")
 
 func register_crypto(crypto: Cryptocurrency) -> void:
 	if crypto == null:
@@ -106,40 +113,53 @@ func refresh_prices():
 	_update_stock_prices()
 
 func _update_stock_prices():
-	var rng = RNGManager.market_manager.get_rng()
-	for stock in stock_market.values():
-		stock.intrinsic_value += rng.randf_range(0.0001, 0.001)
+       var rng = RNGManager.market_manager.get_rng()
+       var now = TimeManager.get_now_minutes()
+       for stock in stock_market.values():
+               var event: MarketEvent = stock_events.get(stock.symbol)
+               var old_price = stock.price
+               if event == null or not event.is_active():
+                       stock.intrinsic_value += rng.randf_range(0.0001, 0.001)
 
-		stock.momentum -= 1
-		if stock.momentum <= 0:
-			stock.sentiment = rng.randf_range(-1.0, 1.0)
-			stock.momentum = rng.randi_range(5, 20)
+                       stock.momentum -= 1
+                       if stock.momentum <= 0:
+                               stock.sentiment = rng.randf_range(-1.0, 1.0)
+                               stock.momentum = rng.randi_range(5, 20)
 
-		var deviation = stock.price / stock.intrinsic_value
-		var noise = rng.randf_range(-0.5, 0.5)
-		var directional_bias = stock.sentiment * 0.25
-		var total_factor = clamp(noise + directional_bias, -1.0, 1.0)
-		var max_percent_change = stock.volatility / 100.0
-		var delta = stock.price * max_percent_change * total_factor
+                       var deviation = stock.price / stock.intrinsic_value
+                       var noise = rng.randf_range(-0.5, 0.5)
+                       var directional_bias = stock.sentiment * 0.25
+                       var total_factor = clamp(noise + directional_bias, -1.0, 1.0)
+                       var max_percent_change = stock.volatility / 100.0
+                       var delta = stock.price * max_percent_change * total_factor
 
-		if deviation > 2.0 and rng.randf() < 0.2:
-			delta -= stock.price * rng.randf_range(0.1, 0.3)
-		elif deviation < 0.5 and rng.randf() < 0.2:
-			delta += stock.price * rng.randf_range(0.1, 0.3)
+                       if deviation > 2.0 and rng.randf() < 0.2:
+                               delta -= stock.price * rng.randf_range(0.1, 0.3)
+                       elif deviation < 0.5 and rng.randf() < 0.2:
+                               delta += stock.price * rng.randf_range(0.1, 0.3)
 
-		var old_price = stock.price
-		stock.price = max(snapped(stock.price + delta, 0.01), 0.01)
+                       stock.price = max(snapped(stock.price + delta, 0.01), 0.01)
+               if event != null:
+                       event.process(now, stock)
+                       if event.is_finished():
+                               stock_events.erase(stock.symbol)
 
-		if abs(stock.price - old_price) > 0.001:
-			emit_signal("stock_price_updated", stock.symbol, stock)
+               if abs(stock.price - old_price) > 0.001:
+                       emit_signal("stock_price_updated", stock.symbol, stock)
 
 func _update_crypto_prices():
-	for crypto in crypto_market.values():
-		var old_price = crypto.price
-		crypto.update_from_market()
-
-		if abs(crypto.price - old_price) > 0.001:
-			emit_signal("crypto_price_updated", crypto.symbol, crypto)
+       var now: int = TimeManager.get_now_minutes()
+       for crypto in crypto_market.values():
+               var event: MarketEvent = crypto_events.get(crypto.symbol)
+               var old_price = crypto.price
+               if event == null or not event.is_active():
+                       crypto.update_from_market()
+               if event != null:
+                       event.process(now, crypto)
+                       if event.is_finished():
+                               crypto_events.erase(crypto.symbol)
+               if abs(crypto.price - old_price) > 0.001:
+                       emit_signal("crypto_price_updated", crypto.symbol, crypto)
 
 ## --- Initialization --- ##
 
@@ -194,9 +214,23 @@ func _init_crypto_market() -> void:
 	print("crypto market keys: " + str(crypto_market.keys()))
 	print("crypto market state: " + JSON.stringify(crypto_market, "  "))
 func _init_stock_market() -> void:
-		for symbol in STOCK_RESOURCES.keys():
-				var stock = STOCK_RESOURCES[symbol].duplicate(true)
-				register_stock(stock)
+                for symbol in STOCK_RESOURCES.keys():
+                                var stock = STOCK_RESOURCES[symbol].duplicate(true)
+                                register_stock(stock)
+
+func _init_market_events() -> void:
+       for key in EVENT_RESOURCES.keys():
+               var base_res: Resource = EVENT_RESOURCES[key]
+               if base_res == null:
+                       continue
+               var event_res: Resource = base_res.duplicate(true)
+               if event_res is MarketEvent:
+                       var ev: MarketEvent = event_res
+                       ev.schedule(TimeManager.get_now_minutes(), RNGManager.market_manager.get_rng())
+                       if ev.target_type == "crypto":
+                               crypto_events[ev.target_symbol] = ev
+                       elif ev.target_type == "stock":
+                               stock_events[ev.target_symbol] = ev
 
 ## --- SAVELOAD --- ##
 

--- a/resources/market_events/hawk_pump_and_dump.tres
+++ b/resources/market_events/hawk_pump_and_dump.tres
@@ -1,0 +1,18 @@
+[gd_resource type="Resource" script_class="MarketEvent" load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://resources/market_events/market_event.gd" id="1"]
+
+[resource]
+script = ExtResource("1")
+target_symbol = "HAWK"
+target_type = "crypto"
+start_min_minutes = 10
+start_max_minutes = 60
+pump_duration_min = 10
+pump_duration_max = 60
+pump_multiplier_min = 20.0
+pump_multiplier_max = 20.0
+dump_duration_min = 5
+dump_duration_max = 30
+dump_multiplier_min = 0.1
+dump_multiplier_max = 0.9

--- a/resources/market_events/market_event.gd
+++ b/resources/market_events/market_event.gd
@@ -1,0 +1,93 @@
+extends Resource
+class_name MarketEvent
+
+# Target asset symbol and type ("stock" or "crypto")
+@export var target_symbol: String = ""
+@export var target_type: String = "crypto"
+
+# Randomized start delay in minutes relative to schedule() call
+@export var start_min_minutes: int = 0
+@export var start_max_minutes: int = 0
+
+# Pump phase configuration
+@export var pump_duration_min: int = 0
+@export var pump_duration_max: int = 0
+@export var pump_multiplier_min: float = 1.0
+@export var pump_multiplier_max: float = 1.0
+
+# Dump phase configuration
+@export var dump_duration_min: int = 0
+@export var dump_duration_max: int = 0
+@export var dump_multiplier_min: float = 1.0
+@export var dump_multiplier_max: float = 1.0
+
+# Internal state
+var _start_time: int = -1
+var _pump_end_time: int = -1
+var _dump_end_time: int = -1
+var _starting_price: float = 0.0
+var _pump_multiplier: float = 1.0
+var _dump_multiplier: float = 1.0
+
+enum State { PENDING, PUMPING, DUMPING, FINISHED }
+var _state: State = State.PENDING
+
+# Schedule the event using current time and RNG for randomness
+func schedule(now_minutes: int, rng: RandomNumberGenerator) -> void:
+    var start_delay = rng.randi_range(start_min_minutes, start_max_minutes)
+    _start_time = now_minutes + start_delay
+    var pump_duration = rng.randi_range(pump_duration_min, pump_duration_max)
+    var dump_duration = rng.randi_range(dump_duration_min, dump_duration_max)
+    _pump_end_time = _start_time + pump_duration
+    _dump_end_time = _pump_end_time + dump_duration
+    _pump_multiplier = rng.randf_range(pump_multiplier_min, pump_multiplier_max)
+    _dump_multiplier = rng.randf_range(dump_multiplier_min, dump_multiplier_max)
+    _state = State.PENDING
+
+func is_active() -> bool:
+    return _state == State.PUMPING or _state == State.DUMPING
+
+func is_finished() -> bool:
+    return _state == State.FINISHED
+
+# Process the event, updating the asset price if necessary
+func process(now_minutes: int, asset) -> void:
+    if _state == State.FINISHED:
+        return
+
+    if _state == State.PENDING and now_minutes >= _start_time:
+        _state = State.PUMPING
+        _starting_price = asset.price
+
+    if _state == State.PUMPING:
+        var target_price = _starting_price * _pump_multiplier
+        var t = float(now_minutes - _start_time) / max(1.0, float(_pump_end_time - _start_time))
+        t = clamp(t, 0.0, 1.0)
+        var new_price = lerp(_starting_price, target_price, t)
+        var prev = asset.price
+        asset.price = new_price
+        asset.last_price = prev
+        if asset.price_history.size() > 0:
+            asset.price_history[asset.price_history.size() - 1] = asset.price
+        else:
+            asset.price_history.append(asset.price)
+        asset.all_time_high = max(asset.all_time_high, asset.price)
+        if now_minutes >= _pump_end_time:
+            _state = State.DUMPING
+
+    elif _state == State.DUMPING:
+        var pump_price = _starting_price * _pump_multiplier
+        var target_price = _starting_price * _dump_multiplier
+        var t = float(now_minutes - _pump_end_time) / max(1.0, float(_dump_end_time - _pump_end_time))
+        t = clamp(t, 0.0, 1.0)
+        var new_price = lerp(pump_price, target_price, t)
+        var prev = asset.price
+        asset.price = new_price
+        asset.last_price = prev
+        if asset.price_history.size() > 0:
+            asset.price_history[asset.price_history.size() - 1] = asset.price
+        else:
+            asset.price_history.append(asset.price)
+        asset.all_time_high = max(asset.all_time_high, asset.price)
+        if now_minutes >= _dump_end_time:
+            _state = State.FINISHED


### PR DESCRIPTION
## Summary
- introduce `MarketEvent` resource with configurable randomized phases
- extend `MarketManager` to schedule and process market events for stocks and crypto
- add predefined pump-and-dump event for HAWK cryptocurrency

## Testing
- `godot3 --headless tests/test_runner.tscn` *(fails: Can't open project, expected config version 4)*
- `apt-get install -y godot3`
- `wget -O /tmp/godot4_server.zip https://github.com/godotengine/godot/releases/download/4.2.1-stable/Godot_v4.2.1-stable_linux_server_x86_64.zip` *(404 Not Found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8ec19a0308325bd85fe983acbdc37