### PR TITLE
Persist autosave preference across sessions

### DIFF
--- a/components/apps/app_scenes/settings.tscn
+++ b/components/apps/app_scenes/settings.tscn
@@ -796,6 +796,7 @@ file_mode = 0
 access = 2
 
 [connection signal="toggled" from="Panel/MarginContainer/TabContainer/General/HBoxContainer/VBoxContainer2/SiggyButton" to="." method="_on_siggy_button_toggled"]
+[connection signal="toggled" from="Panel/MarginContainer/TabContainer/General/HBoxContainer/VBoxContainer/AutosaveRow/AutosaveCheckBox" to="." method="_on_autosave_check_box_toggled"]
 [connection signal="pressed" from="Panel/MarginContainer/TabContainer/General/HBoxContainer/VBoxContainer2/CreateAppsFolderButton" to="." method="_on_create_apps_folder_button_pressed"]
 [connection signal="toggled" from="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/WavesContainer/MarginContainer/VBoxContainer/WavesButton" to="." method="_on_waves_button_toggled"]
 [connection signal="color_changed" from="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/WavesContainer/MarginContainer/VBoxContainer/HBoxContainer/BottomColorPicker" to="." method="_on_bottom_color_picker_color_changed"]

--- a/components/settings_window.gd
+++ b/components/settings_window.gd
@@ -117,8 +117,9 @@ func _on_siggy_button_toggled(toggled_on: bool) -> void:
 		%SiggyButton.text = "Siggy. Please come back. I miss you"
 
 func _on_autosave_check_box_toggled(toggled_on: bool) -> void:
-	TimeManager.autosave_enabled = toggled_on
-	_update_autosave_timer_label()
+        TimeManager.autosave_enabled = toggled_on
+        TimeManager.save_autosave_setting()
+        _update_autosave_timer_label()
 
 func _on_create_apps_folder_button_pressed() -> void:
 	var desktop_env = get_tree().root.get_node("Main/DesktopEnv")


### PR DESCRIPTION
## Summary
- ensure autosave checkbox toggles TimeManager and saves to config
- load autosave preference on startup and when resetting
- wire Autosave checkbox signal in Settings scene

## Testing
- `godot --headless --path . tests/test_runner.tscn` *(fails: resources missing / project not imported)*

------
https://chatgpt.com/codex/tasks/task_e_68a8f28a04b48325969c83c80ec55bcf