### PR TITLE
Allow swiping last profile card

### DIFF
--- a/components/apps/fumble/profile_card_stack.gd
+++ b/components/apps/fumble/profile_card_stack.gd
@@ -63,7 +63,7 @@ func _update_card_positions() -> void:
 
 
 func swipe_left() -> void:
-	if is_animating or cards.size() < 2:
+	if is_animating or cards.size() < 1:
 		return
 	is_animating = true
 	var card = cards[cards.size() - 1]
@@ -80,7 +80,7 @@ func swipe_left() -> void:
 
 
 func swipe_right() -> void:
-	if is_animating or cards.size() < 2:
+	if is_animating or cards.size() < 1:
 		return
 	is_animating = true
 	var card = cards[cards.size() - 1]


### PR DESCRIPTION
## Summary
- Prevent infinite loop when applying filters that leave only one Fumble profile
- Allow swiping the final profile card so the stack can empty gracefully

## Testing
- `godot --headless --run tests/test_runner.tscn` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab49c8fedc832599f475658d1fdb33