### PR TITLE
Use stock popups in brokerage charts

### DIFF
--- a/components/apps/broke_rage/broke_rage_ui.gd
+++ b/components/apps/broke_rage/broke_rage_ui.gd
@@ -1,6 +1,8 @@
 extends Pane
 class_name BrokeRage
 
+const StockPopupUIScene := preload("res://components/popups/stock_popup_ui.tscn")
+
 @onready var stock_market: VBoxContainer = %StockMarket
 @onready var cash_label: Label = %CashLabel
 @onready var balance_label: Label = %BalanceLabel
@@ -162,25 +164,25 @@ func _build_charts_view() -> void:
 	for child: Node in charts_content.get_children():
 		child.queue_free()
 
-	var container: Control = null
+        var container: Control = null
 
-	for symbol: String in MarketManager.stock_market.keys():
-		var stock: Stock = MarketManager.get_stock(symbol)
-		var chart: ChartComponent = ChartComponent.new()
-		chart.custom_minimum_size = Vector2(350, 150)
-		chart.size_flags_horizontal = Control.SIZE_EXPAND_FILL
-		chart.size_flags_vertical = Control.SIZE_EXPAND_FILL
-		chart.add_series(symbol, stock.display_name)
+        for symbol: String in MarketManager.stock_market.keys():
+                var stock: Stock = MarketManager.get_stock(symbol)
+                var popup: StockPopupUI = StockPopupUIScene.instantiate()
+                popup.custom_minimum_size = Vector2(350, 150)
+                popup.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+                popup.size_flags_vertical = Control.SIZE_EXPAND_FILL
+                popup.setup(stock)
 
-		if container == null:
-			container = chart
-		else:
-			var split: VSplitContainer = VSplitContainer.new()
-			split.size_flags_horizontal = Control.SIZE_EXPAND_FILL
-			split.size_flags_vertical = Control.SIZE_EXPAND_FILL
-			split.add_child(container)
-			split.add_child(chart)
-			container = split
+                if container == null:
+                        container = popup
+                else:
+                        var split: VSplitContainer = VSplitContainer.new()
+                        split.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+                        split.size_flags_vertical = Control.SIZE_EXPAND_FILL
+                        split.add_child(container)
+                        split.add_child(popup)
+                        container = split
 
 	if container != null:
 		charts_content.add_child(container)

--- a/tests/broke_rage_charts_popup_test.gd
+++ b/tests/broke_rage_charts_popup_test.gd
@@ -1,0 +1,22 @@
+extends SceneTree
+
+func _ready():
+    var mm = Engine.get_singleton("MarketManager")
+    mm.stock_market.clear()
+    var stock = Stock.new()
+    stock.symbol = "TEST"
+    stock.display_name = "Test"
+    mm.register_stock(stock)
+
+    var scene = load("res://components/apps/app_scenes/broke_rage.tscn")
+    var ui = scene.instantiate()
+    get_root().add_child(ui)
+    await get_tree().process_frame
+    await get_tree().process_frame
+    ui._build_charts_view()
+    var content = ui.charts_content
+    assert(content.get_child_count() == 1)
+    var child = content.get_child(0)
+    assert(child.get_class() == "StockPopupUI")
+    print("broke_rage_charts_popup_test passed")
+    quit()


### PR DESCRIPTION
## Summary
- Replace individual chart components in BrokeRage charts tab with `StockPopupUI` instances
- Add test ensuring BrokeRage charts tab builds stock popups

## Testing
- `godot --headless -s tests/test_runner.gd` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a9ebb013b083258218a8142f1b5c98