### PR TITLE
Persist stock, crypto, ex-factor, and bill popups

### DIFF
--- a/autoloads/bill_manager.gd
+++ b/autoloads/bill_manager.gd
@@ -262,27 +262,6 @@ func get_daily_lifestyle_cost() -> int:
 	return total
 
 
-func get_popup_save_data() -> Array:
-	var popup_data := []
-	for date_key in active_bills.keys():
-		for popup in active_bills[date_key]:
-			if is_instance_valid(popup):
-				popup_data.append({
-					"type": "BillPopupUI",
-					"bill_name": popup.bill_name,
-					"amount": popup.amount,
-					"date_key": date_key
-				})
-
-	for date_key in pending_bill_data.keys():
-		for bill_dict in pending_bill_data[date_key]:
-			popup_data.append({
-				"type": "BillPopupUI",
-				"bill_name": bill_dict.get("bill_name", ""),
-				"amount": bill_dict.get("amount", 0.0),
-				"date_key": date_key
-			})
-	return popup_data
 
 func add_debt_resource(resource: Dictionary) -> void:
 	debt_resources.append(resource)
@@ -340,103 +319,54 @@ func reset() -> void:
 
 
 func get_save_data() -> Dictionary:
-	return {
-		"autopay_enabled": autopay_enabled,
-		"lifestyle_categories": lifestyle_categories.duplicate(),
-		"lifestyle_indices": lifestyle_indices.duplicate(),
-		"pane_data": get_pane_save_data(),
-		"debt_resources": debt_resources.duplicate(true)
-	}
+       return {
+               "autopay_enabled": autopay_enabled,
+               "lifestyle_categories": lifestyle_categories.duplicate(),
+               "lifestyle_indices": lifestyle_indices.duplicate(),
+               "debt_resources": debt_resources.duplicate(true)
+       }
 
 func load_from_data(data: Dictionary) -> void:
-	autopay_enabled = data.get("autopay_enabled", false)
-	lifestyle_categories = data.get("lifestyle_categories", {}).duplicate()
-	lifestyle_indices = data.get("lifestyle_indices", {}).duplicate()
-	active_bills.clear()
-	pending_bill_data.clear()
+       autopay_enabled = data.get("autopay_enabled", false)
+       lifestyle_categories = data.get("lifestyle_categories", {}).duplicate()
+       lifestyle_indices = data.get("lifestyle_indices", {}).duplicate()
+       active_bills.clear()
+       pending_bill_data.clear()
 	var temp: Array = data.get("debt_resources", []).duplicate(true)
 	debt_resources.clear()
 	for entry in temp:
 		if typeof(entry) == TYPE_DICTIONARY:
 			debt_resources.append(entry as Dictionary)
 
-	emit_signal("lifestyle_updated")
-	debt_resources_changed.emit()
+       emit_signal("lifestyle_updated")
+       debt_resources_changed.emit()
 
-	if data.has("pane_data"):
-			for pane_dict in data["pane_data"]:
-					if typeof(pane_dict) != TYPE_DICTIONARY:
-							continue
 
-					var date_key = pane_dict.get("date_key", TimeManager.get_formatted_date())
-					var popup_date_parts = date_key.split("/")
-					if popup_date_parts.size() != 3:
-							continue  # Skip invalid dates
-
-					var popup_date = {
-							"day": int(popup_date_parts[0]),
-							"month": int(popup_date_parts[1]),
-							"year": int(popup_date_parts[2])
-					}
-
-					if TimeManager.date_is_before(popup_date, TimeManager.get_today()):
-							continue  # Skip old bills
-
-					if not pending_bill_data.has(date_key):
-							pending_bill_data[date_key] = []
-					pending_bill_data[date_key].append({
-							"bill_name": pane_dict.get("bill_name", ""),
-							"amount": pane_dict.get("amount", 0.0)
-					})
+func register_popup(popup: BillPopupUI, date_key: String) -> void:
+       if not active_bills.has(date_key):
+               active_bills[date_key] = []
+       active_bills[date_key].append(popup)
 
 
 func show_due_popups() -> void:
-	for date_key in pending_bill_data.keys():
-		for bill_dict in pending_bill_data[date_key]:
-			var pane = preload("res://components/popups/bill_popup_ui.tscn").instantiate()
-			pane.init(bill_dict.get("bill_name", ""))
-			pane.amount = bill_dict.get("amount", 0.0)
+       for date_key in pending_bill_data.keys():
+               for bill_dict in pending_bill_data[date_key]:
+                       var pane = preload("res://components/popups/bill_popup_ui.tscn").instantiate()
+                       pane.init(bill_dict.get("bill_name", ""))
+                       pane.amount = bill_dict.get("amount", 0.0)
+                       pane.date_key = date_key
 
-			var win = WindowFrame.instantiate_for_pane(pane)
-			win.window_can_close = false
-			win.window_can_minimize = false
-			win.default_size = Vector2(360, 550)
+                       var win = WindowFrame.instantiate_for_pane(pane)
+                       win.window_can_close = false
+                       win.window_can_minimize = false
+                       win.default_size = Vector2(360, 550)
 
-			WindowManager.register_window(win, false)
-			call_deferred("center_bill_window", win)
+                       WindowManager.register_window(win, false)
+                       call_deferred("center_bill_window", win)
 
-			if not active_bills.has(date_key):
-					active_bills[date_key] = []
-			active_bills[date_key].append(pane)
+                       register_popup(pane, date_key)
 
-	pending_bill_data.clear()
-
-
-
-
-
-
-func get_pane_save_data() -> Array:
-	var pane_data := []
-	for date_key in active_bills.keys():
-			for pane in active_bills[date_key]:
-					if is_instance_valid(pane):
-							pane_data.append({
-									"type": "BillPopupUI",
-									"bill_name": pane.bill_name,
-									"amount": pane.amount,
-									"date_key": date_key
-							})
-
-	for date_key in pending_bill_data.keys():
-			for bill_dict in pending_bill_data[date_key]:
-					pane_data.append({
-							"type": "BillPopupUI",
-							"bill_name": bill_dict.get("bill_name", ""),
-							"amount": bill_dict.get("amount", 0.0),
-							"date_key": date_key
-					})
-	return pane_data
+       pending_bill_data.clear()
 
 
 

--- a/autoloads/save_manager.gd
+++ b/autoloads/save_manager.gd
@@ -223,13 +223,12 @@ func load_from_slot(slot_id: int) -> void:
 			GPUManager.load_from_data(data["gpus"])
 	if data.has("bills"):
 			BillManager.load_from_data(data["bills"])
-	if data.has("desktop"):
-			DesktopLayoutManager.load_from_data(data["desktop"])
-	if data.has("windows"):  # Always load windows last
-		WindowManager.load_from_data(data["windows"])
-	BillManager.is_loading = false
-	BillManager.show_due_popups()
-	NPCManager.restore_encountered_from_db()
+        if data.has("desktop"):
+                        DesktopLayoutManager.load_from_data(data["desktop"])
+        if data.has("windows"):  # Always load windows last
+                WindowManager.load_from_data(data["windows"])
+        BillManager.is_loading = false
+        NPCManager.restore_encountered_from_db()
 
 
 func reset_game_state() -> void:

--- a/autoloads/window_manager.gd
+++ b/autoloads/window_manager.gd
@@ -340,16 +340,16 @@ func reset() -> void:
 
 # --- Save / Load ---
 func get_save_data() -> Array:
-	var window_data = []
-	for win in open_windows.keys():
-		var pane = win.pane
-		if not pane or pane.is_popup:
-			continue  # Bill popups handled by BillManager separately
+        var window_data = []
+        for win in open_windows.keys():
+                var pane = win.pane
+               if not pane or (pane.is_popup and not pane.persist_on_save):
+                       continue  # Skip transient popups
 
-		var scene_path = pane.scene_file_path if pane.has_method("get_scene_file_path") else pane.get_script().resource_path
+                var scene_path = pane.scene_file_path if pane.has_method("get_scene_file_path") else pane.get_script().resource_path
 
-		window_data.append({
-			"scene_path": scene_path,
+                window_data.append({
+                        "scene_path": scene_path,
 			"position": SaveManager.vector2_to_dict(win.position),
 			"size": SaveManager.vector2_to_dict(win.size),
 			"minimized": not win.visible,

--- a/components/popups/bill_popup_ui.gd
+++ b/components/popups/bill_popup_ui.gd
@@ -5,6 +5,7 @@ var bill_name: String = ""
 var amount: float = 0.0
 var interest_rate: float = 0.0
 var total_with_interest: float = 0.0
+var date_key: String = ""
 
 var popup_type := "BillPopupUI"
 
@@ -68,20 +69,24 @@ func _on_autopay_changed(enabled: bool) -> void:
 # --- SAVE SUPPORT ---
 
 func get_custom_save_data() -> Dictionary:
-	return {
-		"bill_name": bill_name,
-		"amount": amount
-	}
+       return {
+               "bill_name": bill_name,
+               "amount": amount,
+               "date_key": date_key
+       }
 
 func load_custom_save_data(data: Dictionary) -> void:
-	bill_name = data.get("bill_name", "")
-	amount = data.get("amount", 0.0)
-	interest_rate = PortfolioManager.credit_interest_rate
-	total_with_interest = amount * (1.0 + interest_rate)
-	_update_display()
+       bill_name = data.get("bill_name", "")
+       amount = data.get("amount", 0.0)
+       date_key = data.get("date_key", TimeManager.get_formatted_date())
+       interest_rate = PortfolioManager.credit_interest_rate
+       total_with_interest = amount * (1.0 + interest_rate)
+       _update_display()
 
-	var window = get_parent().get_parent().get_parent() as WindowFrame
-	if window:
-		window.window_can_close = false
-		window.refresh_window_controls()
-		window.set_size(Vector2(400,480))
+       BillManager.register_popup(self, date_key)
+
+       var window = get_parent().get_parent().get_parent() as WindowFrame
+       if window:
+               window.window_can_close = false
+               window.refresh_window_controls()
+               window.set_size(Vector2(400,480))

--- a/components/popups/bill_popup_ui.tscn
+++ b/components/popups/bill_popup_ui.tscn
@@ -21,6 +21,7 @@ script = ExtResource("2_2jqea")
 window_title = "Bill"
 default_window_size = Vector2(400, 500)
 is_popup = true
+persist_on_save = true
 window_can_close = false
 window_can_minimize = false
 window_can_maximize = false

--- a/components/popups/stock_popup_ui.gd
+++ b/components/popups/stock_popup_ui.gd
@@ -1,6 +1,8 @@
 extends Pane
 class_name StockPopupUI
 
+@export var persist_on_save := true
+
 @onready var label_symbol = %LabelSymbol
 @onready var label_price = %LabelPrice
 @onready var label_intrinsic = %LabelIntrinsic
@@ -20,14 +22,15 @@ func setup_custom(args) -> void:
 		setup(args)
 
 func setup(_stock: Stock) -> void:
-	stock = _stock
-	HistoryManager.add_sample(stock.symbol, TimeManager.get_now_minutes(), stock.price)
-	price_chart.clear_series()
-	price_chart.add_series(stock.symbol, "Price", Color.GREEN)
-	_update_ui()
-	window_title = str(stock.symbol) + " " + str(stock.price)
-	# Connect signal
-	MarketManager.stock_price_updated.connect(_on_stock_price_updated)
+       stock = _stock
+       unique_popup_key = "stock_%s" % stock.symbol
+       HistoryManager.add_sample(stock.symbol, TimeManager.get_now_minutes(), stock.price)
+       price_chart.clear_series()
+       price_chart.add_series(stock.symbol, "Price", Color.GREEN)
+       _update_ui()
+       window_title = str(stock.symbol) + " " + str(stock.price)
+       # Connect signal
+       MarketManager.stock_price_updated.connect(_on_stock_price_updated)
 
 func _ready() -> void:
 	super._ready()
@@ -56,5 +59,18 @@ func _on_buy_pressed() -> void:
 								_update_ui()
 
 func _on_sell_pressed() -> void:
-				if stock and PortfolioManager.sell_stock(stock.symbol):
-								_update_ui()
+                               if stock and PortfolioManager.sell_stock(stock.symbol):
+                                                               _update_ui()
+
+
+func get_custom_save_data() -> Dictionary:
+       if stock:
+               return {"symbol": stock.symbol}
+       return {}
+
+func load_custom_save_data(data: Dictionary) -> void:
+       var symbol: String = data.get("symbol", "")
+       if symbol != "":
+               var s: Stock = MarketManager.get_stock(symbol)
+               if s:
+                       setup(s)

--- a/components/windows/pane.gd
+++ b/components/windows/pane.gd
@@ -24,6 +24,7 @@ signal window_icon_changed(new_icon)
 @export var allow_multiple: bool = false
 @export var unique_popup_key: String = ""
 @export var is_popup: bool = false
+@export var persist_on_save: bool = false
 
 @export var window_can_close: bool = true
 @export var window_can_minimize: bool = true

--- a/tests/bill_manager_popup_test.gd
+++ b/tests/bill_manager_popup_test.gd
@@ -1,26 +1,17 @@
 extends SceneTree
 
 func _ready():
-	var bm = Engine.get_singleton("BillManager")
-	var tm = Engine.get_singleton("TimeManager")
-	var date_key = "%d/%d/%d" % [tm.current_day, tm.current_month, tm.current_year]
-	var data = {
-		"autopay_enabled": false,
-		"lifestyle_categories": {},
-		"lifestyle_indices": {},
-		"pane_data": [
-			{
-				"type": "BillPopupUI",
-				"bill_name": "Rent",
-				"amount": 1000.0,
-				"date_key": date_key
-			}
-		]
-	}
-	bm.load_from_data(data)
-	assert(bm.active_bills.is_empty())
-	bm.show_due_popups()
-	assert(bm.active_bills.has(date_key))
-	assert(bm.active_bills[date_key].size() == 1)
-	print("bill_manager_popup_test passed")
-	quit()
+       var bm = Engine.get_singleton("BillManager")
+       bm.reset()
+       var tm = Engine.get_singleton("TimeManager")
+       var date_key = "%d/%d/%d" % [tm.current_day, tm.current_month, tm.current_year]
+       var popup = preload("res://components/popups/bill_popup_ui.tscn").instantiate()
+       popup.load_custom_save_data({
+               "bill_name": "Rent",
+               "amount": 1000.0,
+               "date_key": date_key
+       })
+       assert(bm.active_bills.has(date_key))
+       assert(bm.active_bills[date_key].size() == 1)
+       print("bill_manager_popup_test passed")
+       quit()


### PR DESCRIPTION
## Summary
- refactor BillManager to drop bespoke pane saving and register bill popups for window persistence
- serialize bill popup due date and mark the scene persistent so open bills restore after reload
- stop SaveManager from respawning bill popups and add a test covering registration

## Testing
- `/tmp/godot/Godot_v4.2.1-stable_linux.x86_64 --headless -s tests/test_runner.gd` *(fails: Can't load the script "tests/test_runner.gd" as it doesn't inherit from SceneTree or MainLoop)*

------
https://chatgpt.com/codex/tasks/task_e_68ab78a5b12483258a33aa24db554e7f