### PR TITLE
Add auto action checkboxes for battle UI

### DIFF
--- a/components/apps/fumble/fumble_battle/battle_ui.gd
+++ b/components/apps/fumble/fumble_battle/battle_ui.gd
@@ -68,6 +68,8 @@ var battle_stats := {
 
 var is_animating: bool = false
 
+var auto_timer: Timer
+
 
 const REACTION_EMOJI = {
 	"heart": preload("res://assets/emojis/red_heart_emoji_x32.png"),
@@ -116,9 +118,16 @@ func _ready():
 	end_battle_screen_container.hide()
 	blocked_container.hide()
 
-	StatManager.connect_to_stat("dime_status", self, "_on_dime_status_changed")
-	StatManager.connect_to_stat("confidence", self, "_on_confidence_changed")
-	_update_player_attractiveness_label()
+        StatManager.connect_to_stat("dime_status", self, "_on_dime_status_changed")
+        StatManager.connect_to_stat("confidence", self, "_on_confidence_changed")
+        _update_player_attractiveness_label()
+
+        auto_timer = Timer.new()
+        auto_timer.wait_time = 0.1
+        auto_timer.one_shot = false
+        auto_timer.autostart = true
+        add_child(auto_timer)
+        auto_timer.timeout.connect(_on_auto_timer_timeout)
 
 	no_confidence_container.hide()
 
@@ -322,8 +331,8 @@ func _on_catch_button_pressed():
 	await do_move("catch")
 
 func _on_ghost_button_pressed():
-	if is_animating:
-		return
+        if is_animating:
+                return
 	if blocked:
 		FumbleManager.save_battle_state(battle_id, chatlog, battle_stats, move_usage_counts, "blocked")
 		DBManager.save_fumble_relationship(npc_idx, FumbleManager.FumbleStatus.BLOCKED_PLAYER)
@@ -336,8 +345,22 @@ func _on_ghost_button_pressed():
 	FumbleManager.save_battle_state(battle_id, chatlog, battle_stats, move_usage_counts, "ghosted")
 	DBManager.save_fumble_relationship(npc_idx, FumbleManager.FumbleStatus.ACTIVE_CHAT)
 	persist_battle_stats_to_npc()
-	chat_closed.emit()
-	queue_free()
+        chat_closed.emit()
+        queue_free()
+
+
+func _on_auto_timer_timeout() -> void:
+        if is_animating:
+                return
+        var options: Array = []
+        for btn in action_buttons:
+                if btn.is_auto_selected():
+                        options.append(btn.action)
+        if options.is_empty():
+                return
+        var rng = RNGManager.fumble_battle_ui.get_rng()
+        var action = options[rng.randi_range(0, options.size() - 1)]
+        await do_move(action.name)
 
 
 

--- a/components/apps/fumble/fumble_battle/chat_battle_action_button.gd
+++ b/components/apps/fumble/fumble_battle/chat_battle_action_button.gd
@@ -4,8 +4,22 @@ class_name ChatBattleActionButton
 var action: ChatBattleAction
 signal action_pressed(action: ChatBattleAction)
 
+@onready var auto_checkbox: CheckBox = get_node_or_null("MarginContainer/CheckBox")
+
 func _ready() -> void:
     pressed.connect(_on_pressed)
+
+    if auto_checkbox == null:
+        auto_checkbox = CheckBox.new()
+        auto_checkbox.name = "CheckBox"
+        auto_checkbox.text = ""
+        auto_checkbox.focus_mode = Control.FOCUS_NONE
+        auto_checkbox.mouse_filter = Control.MOUSE_FILTER_STOP
+        auto_checkbox.set_anchors_preset(Control.PRESET_TOP_LEFT)
+        auto_checkbox.position = Vector2(4, 4)
+        add_child(auto_checkbox)
+
+    auto_checkbox.visible = true
 
 func load_action(new_action: ChatBattleAction, display_text: String) -> void:
     action = new_action
@@ -14,3 +28,6 @@ func load_action(new_action: ChatBattleAction, display_text: String) -> void:
 func _on_pressed() -> void:
     if action:
         action_pressed.emit(action)
+
+func is_auto_selected() -> bool:
+    return auto_checkbox.button_pressed if auto_checkbox else false


### PR DESCRIPTION
## Summary
- add checkboxes to chat battle action buttons
- loop a random checked line when available using a timer

## Testing
- ⚠️ `godot --headless -s tests/test_runner.gd` *(Godot command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68abae0e557c8325a4be4537987dfe82