### PR TITLE
Persist paid bill state in BillManager

### DIFF
--- a/components/popups/bill_popup_ui.gd
+++ b/components/popups/bill_popup_ui.gd
@@ -47,18 +47,20 @@ func close() -> void:
 	WindowManager.close_window(get_parent().get_parent().get_parent())
 
 func _on_pay_now_button_pressed() -> void:
-	if PortfolioManager.pay_with_cash(amount):
-		close()
-	else:
-		print("❌ Not enough cash")
+        if PortfolioManager.pay_with_cash(amount):
+                BillManager.mark_bill_paid(bill_name, date_key)
+                close()
+        else:
+                print("❌ Not enough cash")
 
 func _on_pay_by_credit_button_pressed() -> void:
-	if PortfolioManager.pay_with_credit(amount):
-		close()
-	else:
-		print("❌ Not enough credit")
-	WindowManager.focus_window(get_parent().get_parent().get_parent())
-	WindowManager.launch_app_by_name("OwerView")
+        if PortfolioManager.pay_with_credit(amount):
+                BillManager.mark_bill_paid(bill_name, date_key)
+                close()
+        else:
+                print("❌ Not enough credit")
+        WindowManager.focus_window(get_parent().get_parent().get_parent())
+        WindowManager.launch_app_by_name("OwerView")
 
 func _on_autopay_check_box_toggled(toggled_on: bool) -> void:
 		BillManager.autopay_enabled = toggled_on

--- a/tests/bill_manager_paid_persistence_test.gd
+++ b/tests/bill_manager_paid_persistence_test.gd
@@ -1,0 +1,14 @@
+extends SceneTree
+
+func _ready():
+        var bm = Engine.get_singleton("BillManager")
+        var tm = Engine.get_singleton("TimeManager")
+        bm.reset()
+        var date_key = "%d/%d/%d" % [tm.current_day, tm.current_month, tm.current_year]
+        bm.mark_bill_paid("Rent", date_key)
+        var data = bm.get_save_data()
+        bm.reset()
+        bm.load_from_data(data)
+        assert(bm.is_bill_paid("Rent", date_key))
+        print("bill_manager_paid_persistence_test passed")
+        quit()


### PR DESCRIPTION
## Summary
- Record paid bills with a persistent `paid_bills` store in BillManager
- Mark bills as paid on successful cash/credit payments and skip reopening them
- Save and load paid bill data; add test for persistence

## Testing
- `apt-get update`
- `apt-get install -y godot3` (fails to run tests: project requires Godot4)
- `godot3 --headless -s tests/test_runner.gd` (engine version mismatch)


------
https://chatgpt.com/codex/tasks/task_e_68abbfca26c0832593a32fb89c55f1da