### PR TITLE
Recheck daterbase exclusivity

### DIFF
--- a/components/npc/npc_manager.gd
+++ b/components/npc/npc_manager.gd
@@ -37,6 +37,8 @@ func _ready() -> void:
                 _save_timer.one_shot = true
                 _save_timer.timeout.connect(_flush_save_queue)
                 add_child(_save_timer)
+                relationship_stage_changed.connect(func(idx, _o, _n): _recheck_daterbase_exclusivity(idx))
+                exclusivity_core_changed.connect(func(idx, _o, _n): _recheck_daterbase_exclusivity(idx))
                 load_daterbase_cache()
 
 func _queue_save(idx: int) -> void:
@@ -506,33 +508,57 @@ func player_broke_up_with(npc_idx: int) -> void:
 		_check_cheating_after_breakup()
 
 func _check_cheating_after_breakup() -> void:
-	for idx in encountered_npcs:
-		var check_idx: int = int(idx)
-		var npc: NPC = get_npc_by_index(check_idx)
-		if npc.exclusivity_core == ExclusivityCore.CHEATING:
-			var still_cheating: bool = false
-			for other in encountered_npcs:
-				var other_idx: int = int(other)
-				if other_idx == check_idx:
-					continue
-				var other_npc: NPC = get_npc_by_index(other_idx)
-				if other_npc.relationship_stage >= RelationshipStage.DATING and other_npc.relationship_stage <= RelationshipStage.MARRIED:
-					still_cheating = true
-					break
-			if not still_cheating:
-				come_clean_from_cheating(check_idx)
+        for idx in encountered_npcs:
+                var check_idx: int = int(idx)
+                var npc: NPC = get_npc_by_index(check_idx)
+                if npc.exclusivity_core == ExclusivityCore.CHEATING:
+                        var still_cheating: bool = false
+                        for other in encountered_npcs:
+                                var other_idx: int = int(other)
+                                if other_idx == check_idx:
+                                        continue
+                                var other_npc: NPC = get_npc_by_index(other_idx)
+                                if other_npc.relationship_stage >= RelationshipStage.DATING and other_npc.relationship_stage <= RelationshipStage.MARRIED:
+                                        still_cheating = true
+                                        break
+                        if not still_cheating:
+                                come_clean_from_cheating(check_idx)
+
+func _recheck_daterbase_exclusivity(changed_idx: int) -> void:
+       var active: Array[int] = []
+       for idx in daterbase_npcs:
+               var npc = get_npc_by_index(int(idx))
+               if npc.relationship_stage >= RelationshipStage.DATING and npc.relationship_stage <= RelationshipStage.MARRIED:
+                       active.append(int(idx))
+
+       for idx in daterbase_npcs:
+               var npc_idx: int = int(idx)
+               if npc_idx == changed_idx:
+                       continue
+               var npc: NPC = get_npc_by_index(npc_idx)
+               var npc_active: bool = active.has(npc_idx)
+               var other_active_count: int = active.size() - (npc_active ? 1 : 0)
+               if npc.exclusivity_core == ExclusivityCore.MONOG and npc_active and other_active_count > 0:
+                       var other_idx: int = -1
+                       for ai in active:
+                               if ai != npc_idx:
+                                       other_idx = int(ai)
+                                       break
+                       _mark_npc_as_cheating(npc_idx, other_idx)
+               elif npc.exclusivity_core == ExclusivityCore.CHEATING and (not npc_active or other_active_count == 0):
+                       come_clean_from_cheating(npc_idx)
 
 func notify_player_advanced_someone_to_dating(other_idx: int) -> void:
-	for idx in encountered_npcs:
-		var npc_idx: int = int(idx)
-		if npc_idx == other_idx:
-			continue
-		var npc: NPC = get_npc_by_index(npc_idx)
-		if npc.exclusivity_core != ExclusivityCore.MONOG:
-			continue
-		if npc.relationship_stage < RelationshipStage.DATING:
-			continue
-		_mark_npc_as_cheating(npc_idx, other_idx)
+       for idx in daterbase_npcs:
+               var npc_idx: int = int(idx)
+               if npc_idx == other_idx:
+                       continue
+               var npc: NPC = get_npc_by_index(npc_idx)
+               if npc.exclusivity_core != ExclusivityCore.MONOG:
+                       continue
+               if npc.relationship_stage < RelationshipStage.DATING:
+                       continue
+               _mark_npc_as_cheating(npc_idx, other_idx)
 
 
 func can_show_go_exclusive(npc_idx: int) -> bool:


### PR DESCRIPTION
## Summary
- reconnect relationship and exclusivity change signals to recheck dating conflicts
- flag or clear cheating status based only on daterbase NPCs
- look at daterbase NPCs when notifying of new dating partners

## Testing
- `godot3 --headless --path . -s tests/test_runner.gd` *(fails: Can't open project at '/workspace/SigmaSim/project.godot', its `config_version` (5) is from a more recent and incompatible version of the engine. Expected config version: 4.)*

------
https://chatgpt.com/codex/tasks/task_e_68abfb0d1ee88325a7c4b237b9d3409e