### PR TITLE
Initialize DBManager earlier to avoid null DB access

### DIFF
--- a/autoloads/db_manager.gd
+++ b/autoloads/db_manager.gd
@@ -74,11 +74,11 @@ const SCHEMA: Dictionary = {
 		}
 }
 
-func _ready():
-	db = SQLite.new()
-	db.path = "user://sigmasim.db"
-	db.open_db()
-	_init_schema()
+func _enter_tree():
+        db = SQLite.new()
+        db.path = "user://sigmasim.db"
+        db.open_db()
+        _init_schema()
 
 func _init_schema():
 	for table_name in SCHEMA.keys():


### PR DESCRIPTION
## Summary
- initialize DBManager's SQLite connection in `_enter_tree`

## Testing
- `godot3 --headless -s tests/test_runner.gd` *(fails: project uses newer config version; Godot 4 required)*

------
https://chatgpt.com/codex/tasks/task_e_68abfeaca9608325879f4aae28d3f837