### PR TITLE
Rename SuitorLogic to ExFactorLogic

### DIFF
--- a/components/popups/ex_factor_logic.gd
+++ b/components/popups/ex_factor_logic.gd
@@ -1,4 +1,4 @@
-class_name SuitorLogic
+class_name ExFactorLogic
 extends Node
 
 signal progress_changed(new_progress: float)
@@ -130,7 +130,7 @@ func try_date() -> bool:
 	_recalc_costs()
 
 	# Progress bump from paying for date (kept same formula).
-	var bounds: Vector2 = SuitorLogic.get_stage_bounds(npc.relationship_stage, npc.relationship_progress)
+	var bounds: Vector2 = ExFactorLogic.get_stage_bounds(npc.relationship_stage, npc.relationship_progress)
 	var boost: float = npc.date_cost / 10.0
 	npc.relationship_progress = min(npc.relationship_progress + boost, bounds.y)
 
@@ -168,7 +168,7 @@ func apply_love(now_minutes: int) -> void:
 	emit_signal("request_persist", {"love_cooldown": npc.love_cooldown, "affinity": npc.affinity})
 
 func preview_breakup_reward() -> float:
-	var bounds: Vector2 = SuitorLogic.get_stage_bounds(npc.relationship_stage, npc.relationship_progress)
+	var bounds: Vector2 = ExFactorLogic.get_stage_bounds(npc.relationship_stage, npc.relationship_progress)
 	var denom: float = bounds.y - bounds.x
 	var fraction: float = 0.0
 	if denom > 0.0:
@@ -362,10 +362,10 @@ func _emit_blocked() -> void:
 # ---------------------------- States ----------------------------
 
 class SuitorState:
-	var machine: SuitorLogic
+	var machine: ExFactorLogic
 	var npc: NPC
 
-	func _init(machine_ref: SuitorLogic) -> void:
+	func _init(machine_ref: ExFactorLogic) -> void:
 		machine = machine_ref
 		npc = machine_ref.npc
 
@@ -384,12 +384,12 @@ class SuitorState:
 class PreMarriageState extends SuitorState:
 	var stage: int
 
-	func _init(machine_ref: SuitorLogic, stage_id: int) -> void:
+	func _init(machine_ref: ExFactorLogic, stage_id: int) -> void:
 		super._init(machine_ref)
 		stage = stage_id
 
 	func update(delta: float) -> void:
-		var bounds: Vector2 = SuitorLogic.get_stage_bounds(stage, npc.relationship_progress)
+		var bounds: Vector2 = ExFactorLogic.get_stage_bounds(stage, npc.relationship_progress)
 		var rate: float = max(npc.affinity, 0.0) * 0.1
 		npc.relationship_progress += rate * delta
 
@@ -398,7 +398,7 @@ class PreMarriageState extends SuitorState:
 		if range_size > 0.0:
 			frac = (npc.relationship_progress - bounds.x) / range_size
 
-		var stops: Array = SuitorLogic.get_stop_points(stage)
+		var stops: Array = ExFactorLogic.get_stop_points(stage)
 		for stop in stops:
 			var f: float = stop["fraction"]
 			var req: int = stop["required"]
@@ -415,7 +415,7 @@ class PreMarriageState extends SuitorState:
 
 	func get_stop_marks() -> Array[float]:
 		var marks: Array[float] = []
-		var stops: Array = SuitorLogic.get_stop_points(stage)
+		var stops: Array = ExFactorLogic.get_stop_points(stage)
 		for stop in stops:
 			var f2: float = stop["fraction"]
 			var req2: int = stop["required"]
@@ -424,23 +424,23 @@ class PreMarriageState extends SuitorState:
 		return marks
 
 class StrangerState extends PreMarriageState:
-	func _init(machine_ref: SuitorLogic) -> void:
+	func _init(machine_ref: ExFactorLogic) -> void:
 		super._init(machine_ref, NPCManager.RelationshipStage.STRANGER)
 
 class TalkingState extends PreMarriageState:
-	func _init(machine_ref: SuitorLogic) -> void:
+	func _init(machine_ref: ExFactorLogic) -> void:
 		super._init(machine_ref, NPCManager.RelationshipStage.TALKING)
 
 class DatingState extends PreMarriageState:
-	func _init(machine_ref: SuitorLogic) -> void:
+	func _init(machine_ref: ExFactorLogic) -> void:
 		super._init(machine_ref, NPCManager.RelationshipStage.DATING)
 
 class SeriousState extends PreMarriageState:
-	func _init(machine_ref: SuitorLogic) -> void:
+	func _init(machine_ref: ExFactorLogic) -> void:
 		super._init(machine_ref, NPCManager.RelationshipStage.SERIOUS)
 
 class EngagedState extends PreMarriageState:
-	func _init(machine_ref: SuitorLogic) -> void:
+	func _init(machine_ref: ExFactorLogic) -> void:
 		super._init(machine_ref, NPCManager.RelationshipStage.ENGAGED)
 
 class MarriedState extends SuitorState:

--- a/components/popups/ex_factor_view.gd
+++ b/components/popups/ex_factor_view.gd
@@ -33,7 +33,7 @@ const PROGRESS_MIN_DELTA: float = 0.01
 @onready var exclusivity_button: Button = %ExclusivityButton
 
 var npc: NPC
-var logic: SuitorLogic = SuitorLogic.new()
+var logic: ExFactorLogic = ExFactorLogic.new()
 var npc_idx: int = -1
 var last_saved_progress: float = 0.0
 var progress_save_elapsed: float = 0.0
@@ -175,7 +175,7 @@ func _refresh_all() -> void:
 func _update_relationship_bar() -> void:
 	var stage: int = npc.relationship_stage
 	if stage == NPCManager.RelationshipStage.MARRIED:
-		var level: int = SuitorLogic.get_marriage_level(npc.relationship_progress)
+		var level: int = ExFactorLogic.get_marriage_level(npc.relationship_progress)
 		relationship_stage_label.text = "Level %d Marriage" % level
 		relationship_bar.set_mark_fractions([])
 		relationship_value_label.text = ""
@@ -190,7 +190,7 @@ func _update_relationship_bar() -> void:
 	var next_stage: int = stage + 1
 	relationship_stage_label.text = "%s -> %s" % [STAGE_NAMES[stage], STAGE_NAMES[next_stage]]
 
-	var bounds: Vector2 = SuitorLogic.get_stage_bounds(stage, npc.relationship_progress)
+	var bounds: Vector2 = ExFactorLogic.get_stage_bounds(stage, npc.relationship_progress)
 	var maxv: float = bounds.y - bounds.x
 	var val: float = npc.relationship_progress - bounds.x
 	relationship_bar.max_value = maxv

--- a/tests/ex_factor_love_test.gd
+++ b/tests/ex_factor_love_test.gd
@@ -3,9 +3,9 @@ extends SceneTree
 func _ready() -> void:
 	var npc: NPC = NPC.new()
 	npc.affinity = 0.0
-	var logic: SuitorLogic = SuitorLogic.new()
+	var logic: ExFactorLogic = ExFactorLogic.new()
 	logic.setup(npc)
 	logic.apply_love()
 	assert(npc.affinity == 5.0)
-	print("suitor_love_test passed")
+	print("ex_factor_love_test passed")
 	quit()

--- a/tests/performance_enhancers_upgrade_test.gd
+++ b/tests/performance_enhancers_upgrade_test.gd
@@ -6,7 +6,7 @@ func _ready() -> void:
 		StatManager.recalculate_all_stats_once()
 		var npc := NPC.new()
 		npc.affinity = 0.0
-		var logic := SuitorLogic.new()
+		var logic := ExFactorLogic.new()
 		#logic.setup(npc)
 		#logic.apply_love()
 		assert(npc.affinity == 7.0)


### PR DESCRIPTION
## Summary
- rename suitor_logic.gd to ex_factor_logic.gd and update class to ExFactorLogic
- update ExFactorView and tests to use ExFactorLogic

## Testing
- `godot --headless -s tests/ex_factor_love_test.gd` (fails: command not found)
- `godot --headless -s tests/performance_enhancers_upgrade_test.gd` (fails: command not found)


------
https://chatgpt.com/codex/tasks/task_e_68ac03262c7083258eb725904901691b