### PR TITLE
fix: sync crypto popup to stock pattern

### DIFF
--- a/components/popups/crypto_popup_ui.gd
+++ b/components/popups/crypto_popup_ui.gd
@@ -23,17 +23,14 @@ func setup_custom(args) -> void:
 				setup(args)
 
 func setup(_crypto: Cryptocurrency) -> void:
-	crypto = _crypto
-	unique_popup_key = "crypto_%s" % crypto.symbol
-	HistoryManager.add_sample(crypto.symbol, TimeManager.get_now_minutes(), crypto.price)
-	
-	await ready
-	
-	price_chart.clear_series()
-	price_chart.add_series(crypto.symbol, "Price", Color(1, 0.6, 0.2))
-	_update_ui()
-	window_title = str(crypto.symbol) + " " + str(crypto.price)
-	MarketManager.crypto_price_updated.connect(_on_crypto_price_updated)
+        crypto = _crypto
+        unique_popup_key = "crypto_%s" % crypto.symbol
+        HistoryManager.add_sample(crypto.symbol, TimeManager.get_now_minutes(), crypto.price)
+        price_chart.clear_series()
+        price_chart.add_series(crypto.symbol, "Price", Color(1, 0.6, 0.2))
+        _update_ui()
+        window_title = str(crypto.symbol) + " " + str(crypto.price)
+        MarketManager.crypto_price_updated.connect(_on_crypto_price_updated)
 
 func _ready() -> void:
 	super._ready()
@@ -74,8 +71,9 @@ func get_custom_save_data() -> Dictionary:
 	return {}
 
 func load_custom_save_data(data: Dictionary) -> void:
-	var symbol: String = data.get("symbol", "")
-	if symbol != "":
-			var c: Cryptocurrency = MarketManager.crypto_market.get(symbol)
-			if c:
-					setup(c)
+        var symbol: String = data.get("symbol", "")
+        if symbol != "":
+                        var c: Cryptocurrency = MarketManager.crypto_market.get(symbol)
+                        if c:
+                                        await ready   # or call_deferred("setup", c)
+                                        setup(c)


### PR DESCRIPTION
## Summary
- Initialize Crypto popup chart and data the same way as stock popup
- Defer setup during save load until popup is ready

## Testing
- `godot --version` *(fails: command not found)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ac0a4f90ac83258e89e494764ceec5