### PR TITLE
Add Predictive Text upgrade for Fumble

### DIFF
--- a/components/apps/fumble/fumble_battle/chat_battle_action_button.gd
+++ b/components/apps/fumble/fumble_battle/chat_battle_action_button.gd
@@ -19,7 +19,12 @@ func _ready() -> void:
         auto_checkbox.position = Vector2(4, 4)
         add_child(auto_checkbox)
 
-    auto_checkbox.visible = true
+    auto_checkbox.visible = UpgradeManager.get_level("fumble_predictive_text") > 0
+    UpgradeManager.upgrade_purchased.connect(_on_upgrade_purchased)
+
+func _on_upgrade_purchased(id: String, _level: int) -> void:
+    if id == "fumble_predictive_text":
+        auto_checkbox.visible = true
 
 func load_action(new_action: ChatBattleAction, display_text: String) -> void:
     action = new_action

--- a/data/upgrades/fumble_predictive_text.json
+++ b/data/upgrades/fumble_predictive_text.json
@@ -1,0 +1,16 @@
+{
+  "id": "fumble_predictive_text",
+  "name": "Predictive Text",
+  "description": "Unlocks auto-select checkboxes for action moves.",
+  "effects": [],
+  "systems": [
+    "fumble"
+  ],
+  "dependencies": [],
+  "cost_per_level": {
+    "cash": 5
+  },
+  "max_level": 1,
+  "repeatable": false,
+  "scale_by_formula": false
+}


### PR DESCRIPTION
## Summary
- add Predictive Text upgrade that unlocks auto-action checkboxes for Fumble battles
- show checkbox on action buttons only after purchasing the upgrade

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ac0d7ff00483259be26e9d6800e8ab