### PR TITLE
Add brokerage upgrade and gate stock credit purchases

### DIFF
--- a/components/apps/app_scenes/broke_rage.tscn
+++ b/components/apps/app_scenes/broke_rage.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=14 format=3 uid="uid://1jylhdkewo5k"]
+[gd_scene load_steps=15 format=3 uid="uid://1jylhdkewo5k"]
 
 [ext_resource type="Texture2D" uid="uid://bx8di1m28cktr" path="res://assets/money_pixeled.png" id="1_m7phi"]
 [ext_resource type="Script" uid="uid://dvxyytygay71s" path="res://components/apps/broke_rage/broke_rage_ui.gd" id="2_o2yqo"]
@@ -10,6 +10,7 @@
 [ext_resource type="Texture2D" uid="uid://bsal74mys2v4b" path="res://assets/logos/owerview_logo.png" id="6_m7phi"]
 [ext_resource type="Script" uid="uid://b8wfu5cxh5oyw" path="res://components/ui/chart_component.gd" id="7_t3xq1"]
 [ext_resource type="PackedScene" uid="uid://m61kgxdhy7hc" path="res://components/apps/broke_rage/stock_row.tscn" id="10_htng3"]
+[ext_resource type="PackedScene" uid="uid://brokerageupgrade" path="res://components/upgrade_scenes/brokerage_upgrade_ui.tscn" id="11_broker"]
 
 [sub_resource type="StyleBoxTexture" id="StyleBoxTexture_tcm1f"]
 texture = ExtResource("1_m7phi")
@@ -51,6 +52,7 @@ script = ExtResource("2_o2yqo")
 window_title = "BrokeRage"
 window_icon = ExtResource("3_m7phi")
 default_window_size = Vector2(735, 500)
+upgrade_pane = ExtResource("11_broker")
 color1 = Color(0, 0, 0, 1)
 color2 = Color(0.15, 0.15, 0.15, 1)
 color3 = Color(0.25, 0.25, 0.25, 1)

--- a/components/apps/broke_rage/stock_market.gd
+++ b/components/apps/broke_rage/stock_market.gd
@@ -31,8 +31,12 @@ func refresh_rows_from_market():
 
 
 func _on_buy_button_pressed(symbol: String):
-	if !PortfolioManager.buy_stock(symbol):
-		print("Failed to buy stock:", symbol)
+        var stock = PortfolioManager.stock_data.get(symbol)
+        if stock and PortfolioManager.get_cash() < stock.price and UpgradeManager.get_level("brokerage_pattern_day_trader") <= 0:
+                print("Credit purchase requires Pattern Day Trader upgrade")
+                return
+        if !PortfolioManager.buy_stock(symbol):
+                print("Failed to buy stock:", symbol)
 
 func _on_sell_button_pressed(symbol: String):
 	if !PortfolioManager.sell_stock(symbol):

--- a/components/apps/broke_rage/stock_row.gd
+++ b/components/apps/broke_rage/stock_row.gd
@@ -19,10 +19,14 @@ func setup(_stock: Stock) -> void:
 	last_price = stock.price
 	update_display(stock)
 
-	buy_button.pressed.connect(func():
-		emit_signal("buy_pressed", stock.symbol)
-		update_display(stock)
-	)
+        buy_button.pressed.connect(func():
+                var price := stock.price
+                if PortfolioManager.get_cash() < price and UpgradeManager.get_level("brokerage_pattern_day_trader") <= 0:
+                        print("Credit purchase requires Pattern Day Trader upgrade")
+                        return
+                emit_signal("buy_pressed", stock.symbol)
+                update_display(stock)
+        )
 	sell_button.pressed.connect(func():
 		emit_signal("sell_pressed", stock.symbol)
 		update_display(stock)

--- a/components/popups/stock_popup_ui.gd
+++ b/components/popups/stock_popup_ui.gd
@@ -55,8 +55,14 @@ func _update_ui() -> void:
 	label_owned.text = str(PortfolioManager.stocks_owned.get(stock.symbol, 0))
 
 func _on_buy_pressed() -> void:
-	if stock and PortfolioManager.buy_stock(stock.symbol):
-		_update_ui()
+        if not stock:
+                return
+        var price := stock.price
+        if PortfolioManager.get_cash() < price and UpgradeManager.get_level("brokerage_pattern_day_trader") <= 0:
+                print("Credit purchase requires Pattern Day Trader upgrade")
+                return
+        if PortfolioManager.buy_stock(stock.symbol):
+                _update_ui()
 
 func _on_sell_pressed() -> void:
 	if stock and PortfolioManager.sell_stock(stock.symbol):

--- a/components/upgrade_scenes/brokerage_upgrade_ui.gd
+++ b/components/upgrade_scenes/brokerage_upgrade_ui.gd
@@ -1,0 +1,2 @@
+extends Pane
+class_name BrokerageUpgradeUI

--- a/components/upgrade_scenes/brokerage_upgrade_ui.tscn
+++ b/components/upgrade_scenes/brokerage_upgrade_ui.tscn
@@ -1,0 +1,29 @@
+[gd_scene load_steps=3 format=3 uid="uid://brokerageupgradeui"]
+
+[ext_resource type="Script" uid="uid://brokerageupgradeuigds" path="res://components/upgrade_scenes/brokerage_upgrade_ui.gd" id="1_abcde"]
+[ext_resource type="PackedScene" uid="uid://c12jraubuv28g" path="res://data/upgrades/system_upgrade_ui.tscn" id="2_abcde"]
+
+[node name="BrokerageUpgradeUI" type="PanelContainer"]
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+mouse_filter = 1
+script = ExtResource("1_abcde")
+window_title = "BrokeRage Upgrades"
+default_window_size = Vector2(480, 480)
+
+[node name="MarginContainer" type="MarginContainer" parent="."]
+layout_mode = 2
+theme_override_constants/margin_left = 15
+theme_override_constants/margin_top = 15
+theme_override_constants/margin_right = 15
+theme_override_constants/margin_bottom = 15
+
+[node name="SystemUpgradeUI" parent="MarginContainer" instance=ExtResource("2_abcde")]
+layout_mode = 2
+size_flags_vertical = 3
+system_name = "brokerage"

--- a/data/upgrades/brokerage_pattern_day_trader.json
+++ b/data/upgrades/brokerage_pattern_day_trader.json
@@ -1,0 +1,12 @@
+{
+  "id": "brokerage_pattern_day_trader",
+  "name": "Pattern Day Trader",
+  "description": "Allows purchasing stocks with credit.",
+  "effects": [],
+  "systems": ["brokerage"],
+  "dependencies": [],
+  "cost_per_level": {"cash": 25000},
+  "max_level": 1,
+  "repeatable": false,
+  "scale_by_formula": false
+}

--- a/tests/stock_credit_purchase_test.gd
+++ b/tests/stock_credit_purchase_test.gd
@@ -1,0 +1,27 @@
+extends SceneTree
+
+func _ready():
+        var pm = Engine.get_singleton("PortfolioManager")
+        var mm = Engine.get_singleton("MarketManager")
+        var stock = mm.get_stock("GME_STOCK")
+        pm.stock_data[stock.symbol] = stock
+        var prev_level := UpgradeManager.get_level("brokerage_pattern_day_trader")
+        UpgradeManager.player_levels.erase("brokerage_pattern_day_trader")
+        pm.cash = 0.0
+        pm.credit_used = 0.0
+        pm.credit_limit = 1000.0
+        pm.credit_interest_rate = 0.0
+        pm.credit_score = 800
+        var result := pm.buy_stock(stock.symbol)
+        assert(not result)
+        UpgradeManager.player_levels["brokerage_pattern_day_trader"] = 1
+        result = pm.buy_stock(stock.symbol)
+        assert(result)
+        pm.stocks_owned[stock.symbol] = 0
+        pm.credit_used = 0.0
+        if prev_level > 0:
+                UpgradeManager.player_levels["brokerage_pattern_day_trader"] = prev_level
+        else:
+                UpgradeManager.player_levels.erase("brokerage_pattern_day_trader")
+        print("stock_credit_purchase_test passed")
+        quit()


### PR DESCRIPTION
## Summary
- add BrokeRage upgrade pane and Pattern Day Trader upgrade
- block stock credit purchases unless the new upgrade is owned
- add test for stock credit purchasing

## Testing
- `godot --headless -s tests/stock_credit_purchase_test.gd` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac7e92abc083258496915a834bcc95