### PR TITLE
Persist price history

### DIFF
--- a/autoloads/save_manager.gd
+++ b/autoloads/save_manager.gd
@@ -133,9 +133,10 @@ func save_to_slot(slot_id: int) -> void:
 		"bills": BillManager.get_save_data(),
 		"gpus": GPUManager.get_save_data(),
 		"upgrades": UpgradeManager.get_save_data(),
+		"history": HistoryManager.get_save_data(),
 		"windows": WindowManager.get_save_data(),
 		"desktop": DesktopLayoutManager.get_save_data(),
-	}
+        }
 
 	var file := FileAccess.open(get_slot_path(slot_id), FileAccess.WRITE)
 	file.store_string(JSON.stringify(data, "\t"))
@@ -215,11 +216,14 @@ func load_from_slot(slot_id: int) -> void:
 			UpgradeManager.load_from_data(data["upgrades"])
 	if data.has("tasks"):
 			TaskManager.load_from_data(data["tasks"])
-	if data.has("market"):
-			MarketManager.load_from_data(data["market"])
+        if data.has("market"):
+                        MarketManager.load_from_data(data["market"])
 
-	if data.has("workers"):
-			WorkerManager.load_from_data(data["workers"])
+        if data.has("history"):
+                        HistoryManager.load_from_data(data["history"])
+
+        if data.has("workers"):
+                        WorkerManager.load_from_data(data["workers"])
 	if data.has("gpus"):
 			GPUManager.load_from_data(data["gpus"])
 	if data.has("bills"):


### PR DESCRIPTION
## Summary
- Save HistoryManager state with game slots to preserve asset price charts across sessions
- Restore history data when loading a slot so stock and crypto popups show full price movement

## Testing
- ⚠️ `godot3 --headless -s tests/test_runner.gd` *(incompatible engine version)*
- ⚠️ `/tmp/godot/Godot_v4.2.2-stable_linux.x86_64 --headless --path . tests/test_runner.tscn` *(missing project imports and script errors)*

------
https://chatgpt.com/codex/tasks/task_e_68ac7f6d13f88325b33f38bb73f5e2b8