### PR TITLE
Reload daterbase cache on save load

### DIFF
--- a/autoloads/save_manager.gd
+++ b/autoloads/save_manager.gd
@@ -105,9 +105,11 @@ func initialize_new_profile(slot_id: int, user_data: Dictionary) -> void:
 				"credit_limit": 0.0
 		})
 
-		MarketManager.init_new_save_events()
-		save_to_slot(slot_id)
-		BillManager.is_loading = false
+                MarketManager.init_new_save_events()
+                save_to_slot(slot_id)
+                BillManager.is_loading = false
+
+        NPCManager.load_daterbase_cache()
 
 
 # --- Save/Load Full Game State ---
@@ -228,8 +230,9 @@ func load_from_slot(slot_id: int) -> void:
 					DesktopLayoutManager.load_from_data(data["desktop"])
 	if data.has("windows"):  # Always load windows last
 			WindowManager.load_from_data(data["windows"])
-	BillManager.is_loading = false
-	NPCManager.restore_encountered_from_db()
+        BillManager.is_loading = false
+        NPCManager.restore_encountered_from_db()
+        NPCManager.load_daterbase_cache()
 
 
 func reset_game_state() -> void:

--- a/components/npc/npc_manager.gd
+++ b/components/npc/npc_manager.gd
@@ -686,15 +686,17 @@ func restore_encountered_from_db() -> void:
 
 
 func reset() -> void:
-	encounter_count = 0
-	encountered_npcs = []
-	encountered_npcs_by_app = {}
-	active_npcs_by_app = {}
+        encounter_count = 0
+        encountered_npcs = []
+        encountered_npcs_by_app = {}
+        active_npcs_by_app = {}
 
-	relationship_status = {}
-	persistent_npcs = {}
-	npc_overrides = {}
-	npcs = {}
+        daterbase_npcs = []
+
+        relationship_status = {}
+        persistent_npcs = {}
+        npc_overrides = {}
+        npcs = {}
 
 	persistent_by_gender = {}
 	persistent_by_wealth = {}

--- a/tests/daterbase_persistence_test.gd
+++ b/tests/daterbase_persistence_test.gd
@@ -1,0 +1,24 @@
+extends SceneTree
+
+func _ready() -> void:
+    var save_mgr = Engine.get_singleton("SaveManager")
+    var db_mgr = Engine.get_singleton("DBManager")
+    var npc_mgr = Engine.get_singleton("NPCManager")
+
+    save_mgr.reset_managers()
+    save_mgr.current_slot_id = 1
+
+    var npc_id := 4242
+    db_mgr.db.query("DELETE FROM fumble_battles WHERE npc_id = %d AND slot_id = %d" % [npc_id, save_mgr.current_slot_id])
+    db_mgr.save_fumble_battle("test_%s" % str(Time.get_unix_time_from_system()), npc_id, [], {}, {}, "victory", save_mgr.current_slot_id)
+
+    npc_mgr.load_daterbase_cache()
+    assert(npc_mgr.get_daterbase_npcs().has(npc_id))
+
+    save_mgr.save_to_slot(save_mgr.current_slot_id)
+    save_mgr.reset_managers()
+    save_mgr.load_from_slot(save_mgr.current_slot_id)
+
+    assert(npc_mgr.get_daterbase_npcs().has(npc_id))
+    print("daterbase_persistence_test passed")
+    quit()

--- a/tests/daterbase_persistence_test.gd.uid
+++ b/tests/daterbase_persistence_test.gd.uid
@@ -1,0 +1,1 @@
+uid://drvngl5cyhpfi


### PR DESCRIPTION
## Summary
- clear NPCManager's cached Daterbase entries when resetting
- reload Daterbase cache after creating a new profile or loading a slot
- add regression test for Daterbase persistence across saves

## Testing
- `godot3-server --headless --path . tests/test_runner.tscn` *(fails: Can't open project at '/workspace/SigmaSim/project.godot', config_version 5 is from a more recent engine)*

------
https://chatgpt.com/codex/tasks/task_e_68ac8291fccc83259e2e75dc99b688b3