### PR TITLE
Ensure history buffers initialize Packed arrays correctly

### DIFF
--- a/autoloads/history_manager.gd
+++ b/autoloads/history_manager.gd
@@ -566,32 +566,50 @@ func _load_from_disk_safe() -> void:
 
 # -------------- helpers: build/flatten ring buffers ------------
 func _make_empty_line(cap: int) -> Dictionary:
-	var line: Dictionary = {
-		"times": PackedInt32Array(),
-		"values": PackedFloat32Array(),
-		"head": 0, "size": 0, "capacity": cap
-	}
-	(line["times"] as PackedInt32Array).resize(cap)
-	(line["values"] as PackedFloat32Array).resize(cap)
-	return line
+        var line: Dictionary = {
+                "times": PackedInt32Array(),
+                "values": PackedFloat32Array(),
+                "head": 0, "size": 0, "capacity": cap
+        }
+
+        var times: PackedInt32Array = line["times"]
+        var values: PackedFloat32Array = line["values"]
+        times.resize(cap)
+        values.resize(cap)
+        line["times"] = times
+        line["values"] = values
+        return line
 
 func _make_empty_candles(cap: int) -> Dictionary:
-	var c: Dictionary = {
-		"t_open": PackedInt32Array(),
-		"t_close": PackedInt32Array(),
-		"open": PackedFloat32Array(),
-		"high": PackedFloat32Array(),
-		"low": PackedFloat32Array(),
-		"close": PackedFloat32Array(),
-		"head": 0, "size": 0, "capacity": cap
-	}
-	(c["t_open"] as PackedInt32Array).resize(cap)
-	(c["t_close"] as PackedInt32Array).resize(cap)
-	(c["open"] as PackedFloat32Array).resize(cap)
-	(c["high"] as PackedFloat32Array).resize(cap)
-	(c["low"] as PackedFloat32Array).resize(cap)
-	(c["close"] as PackedFloat32Array).resize(cap)
-	return c
+        var c: Dictionary = {
+                "t_open": PackedInt32Array(),
+                "t_close": PackedInt32Array(),
+                "open": PackedFloat32Array(),
+                "high": PackedFloat32Array(),
+                "low": PackedFloat32Array(),
+                "close": PackedFloat32Array(),
+                "head": 0, "size": 0, "capacity": cap
+        }
+
+        var t_open: PackedInt32Array = c["t_open"]
+        var t_close: PackedInt32Array = c["t_close"]
+        var open: PackedFloat32Array = c["open"]
+        var high: PackedFloat32Array = c["high"]
+        var low: PackedFloat32Array = c["low"]
+        var close: PackedFloat32Array = c["close"]
+        t_open.resize(cap)
+        t_close.resize(cap)
+        open.resize(cap)
+        high.resize(cap)
+        low.resize(cap)
+        close.resize(cap)
+        c["t_open"] = t_open
+        c["t_close"] = t_close
+        c["open"] = open
+        c["high"] = high
+        c["low"] = low
+        c["close"] = close
+        return c
 
 func _export_line(line: Dictionary) -> Dictionary:
 	var size_i: int = int(line["size"])


### PR DESCRIPTION
## Summary
- Fix initialization of PackedInt32Array and PackedFloat32Array when creating empty history buffers
- Prevent invalid index errors by resizing arrays and reassigning them to the line and candle dictionaries

## Testing
- `godot3-server --headless --path . -s tests/test_runner.gd` *(fails: project requires newer config_version)*

------
https://chatgpt.com/codex/tasks/task_e_68ac886165c083259ea0957c02787142