### PR TITLE
Fix market price reset after reload

### DIFF
--- a/autoloads/market_manager.gd
+++ b/autoloads/market_manager.gd
@@ -272,11 +272,17 @@ func load_from_data(data: Dictionary) -> void:
 	crypto_market.clear()
 
 	# --- Stocks (unchanged) ---
-	for symbol: String in STOCK_RESOURCES.keys():
-		var stock: Stock = STOCK_RESOURCES[symbol].duplicate(true)
-		if data.get("stock_market", {}).has(symbol):
-			stock.from_dict(data["stock_market"][symbol])
-		register_stock(stock)
+        # Stock resources use keys like "ALPH_STOCK" but the actual symbol used in
+        # save data is stored on the resource itself (e.g. "$ALPH"). When loading
+        # we must look up saved values by the stock's symbol instead of the
+        # resource key, otherwise prices revert to their default values.
+        for res_key: String in STOCK_RESOURCES.keys():
+                var stock: Stock = STOCK_RESOURCES[res_key].duplicate(true)
+                var stock_symbol := stock.symbol
+                var saved_stocks: Dictionary = data.get("stock_market", {})
+                if saved_stocks.has(stock_symbol):
+                        stock.from_dict(saved_stocks[stock_symbol])
+                register_stock(stock)
 
 	# --- Cryptos (respect resource-exported symbol/display_name) ---
 	var saved_crypto: Dictionary = data.get("crypto_market", {})

--- a/tests/market_price_persistence_test.gd
+++ b/tests/market_price_persistence_test.gd
@@ -1,0 +1,18 @@
+extends SceneTree
+
+func _ready():
+        var mm = Engine.get_singleton("MarketManager")
+        var stock_symbol: String = mm.stock_market.keys()[0]
+        var crypto_symbol: String = mm.crypto_market.keys()[0]
+        var stock: Stock = mm.stock_market[stock_symbol]
+        var crypto: Cryptocurrency = mm.crypto_market[crypto_symbol]
+        var stock_price := 123.45
+        var crypto_price := 987.65
+        stock.price = stock_price
+        crypto.price = crypto_price
+        var data = mm.get_save_data()
+        mm.load_from_data(data)
+        assert(is_equal_approx(mm.stock_market[stock_symbol].price, stock_price))
+        assert(is_equal_approx(mm.crypto_market[crypto_symbol].price, crypto_price))
+        print("market_price_persistence_test passed")
+        quit()


### PR DESCRIPTION
## Summary
- Ensure stock data loads by symbol rather than resource key to persist prices
- Add regression test covering stock and crypto price persistence

## Testing
- `godot4 --headless -s tests/test_runner.gd` *(fails: command not found)*
- `apt-get install -y godot4` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68ac9288261883259ec4903a00771413