### PR TITLE
Reset market state for new profiles

### DIFF
--- a/autoloads/market_manager.gd
+++ b/autoloads/market_manager.gd
@@ -318,7 +318,15 @@ func load_from_data(data: Dictionary) -> void:
 	emit_signal("crypto_market_ready")
 
 func debug_dump_crypto(context: String) -> void:
-	print("-- crypto dump ", context, " --")
-	for symbol: String in crypto_market.keys():
-		var c: Cryptocurrency = crypto_market[symbol]
-		print(symbol, ",", c.display_name, ", price=", c.price, ", power=", c.power_required, ", id=", str(c.get_instance_id()))
+        print("-- crypto dump ", context, " --")
+        for symbol: String in crypto_market.keys():
+                var c: Cryptocurrency = crypto_market[symbol]
+                print(symbol, ",", c.display_name, ", price=", c.price, ", power=", c.power_required, ", id=", str(c.get_instance_id()))
+
+func reset() -> void:
+        stock_market.clear()
+        crypto_market.clear()
+        stock_events.clear()
+        crypto_events.clear()
+        _init_stock_market()
+        _init_crypto_market()


### PR DESCRIPTION
## Summary
- Reset stock and crypto market state when managers are reset
- Ensure new profiles start with default market values

## Testing
- `pytest`
- `godot --headless --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68acc3ac43f08325972cd79683bed16b