### PR TITLE
Add quip speech bubbles to ExFactor interactions

### DIFF
--- a/components/popups/ex_factor_view.gd
+++ b/components/popups/ex_factor_view.gd
@@ -32,6 +32,11 @@ const PROGRESS_MIN_DELTA: float = 0.01
 @onready var exclusivity_label: Label = %ExclusivityLabel
 @onready var exclusivity_button: Button = %ExclusivityButton
 
+const SPEECH_BUBBLE_SCENE := preload("res://components/ui/speech_bubble.tscn")
+const QUIPS_PATH := "res://data/npc_data/exfactor/eXFactorQuips.json"
+
+var _quips: Array = []
+
 var npc: NPC
 var logic: ExFactorLogic = ExFactorLogic.new()
 var npc_idx: int = -1
@@ -291,20 +296,23 @@ func _update_exclusivity_button() -> void:
 # ---------------------------- Button handlers ----------------------------
 
 func _on_gift_pressed() -> void:
-	if logic.try_gift():
-		_update_affinity_bar()
-		_update_buttons_text()
+        if logic.try_gift():
+                _update_affinity_bar()
+                _update_buttons_text()
+                _show_quip("gift")
 
 func _on_date_pressed() -> void:
-	if logic.try_date():
-		_update_relationship_bar()
-		_update_buttons_text()
+        if logic.try_date():
+                _update_relationship_bar()
+                _update_buttons_text()
+                _show_quip("date")
 
 func _on_love_pressed() -> void:
-	var now_m: int = TimeManager.get_now_minutes()
-	logic.apply_love(now_m)
-	_update_affinity_bar()
-	_update_love_button()
+        var now_m: int = TimeManager.get_now_minutes()
+        logic.apply_love(now_m)
+        _update_affinity_bar()
+        _update_love_button()
+        _show_quip("love")
 
 func _on_breakup_pressed() -> void:
 	breakup_preview = logic.preview_breakup_reward()
@@ -315,9 +323,10 @@ func _on_breakup_pressed() -> void:
 	breakup_confirm.visible = true
 
 func _on_breakup_confirm_yes_pressed() -> void:
-	breakup_confirm.visible = false
-	logic.confirm_breakup()
-	_refresh_all()
+        breakup_confirm.visible = false
+        logic.confirm_breakup()
+        _refresh_all()
+        _show_quip("breakup")
 
 func _on_breakup_confirm_no_pressed() -> void:
 	breakup_confirm.visible = false
@@ -353,24 +362,76 @@ func _prepare_next_stage_confirm() -> void:
 		next_stage_confirm_primary_button.text = "Transition to %s" % next_name
 
 func _on_next_stage_confirm_primary_pressed() -> void:
-	next_stage_confirm.visible = false
-	logic.request_next_stage_primary()
-	_refresh_all()
+        next_stage_confirm.visible = false
+        logic.request_next_stage_primary()
+        _refresh_all()
+        _show_quip("next level")
 
 func _on_next_stage_confirm_alt_pressed() -> void:
-	next_stage_confirm.visible = false
-	logic.request_next_stage_alt_for_dating()
-	_refresh_all()
+        next_stage_confirm.visible = false
+        logic.request_next_stage_alt_for_dating()
+        _refresh_all()
+        _show_quip("next level")
 
 func _on_next_stage_confirm_no_pressed() -> void:
 	next_stage_confirm.visible = false
 	next_stage_button.visible = true
 
 func _on_exclusivity_button_pressed() -> void:
-	logic.toggle_exclusivity()
-	_update_exclusivity_label()
-	_update_exclusivity_button()
-	_update_affinity_bar()
+        logic.toggle_exclusivity()
+        _update_exclusivity_label()
+        _update_exclusivity_button()
+        _update_affinity_bar()
+
+func _load_quips() -> void:
+        if _quips.size() == 0:
+                var file = FileAccess.open(QUIPS_PATH, FileAccess.READ)
+                if file:
+                        _quips = JSON.parse_string(file.get_as_text())
+
+func _pick_variant(text: String, rng: RandomNumberGenerator) -> String:
+        if text.is_empty():
+                return ""
+        var parts = text.split(";;")
+        return parts[rng.randi_range(0, parts.size() - 1)]
+
+func _select_quip(action: String) -> String:
+        _load_quips()
+        if npc == null:
+                return ""
+        var stage_str = STAGE_NAMES[npc.relationship_stage].to_lower()
+        var exclusivity_str = npc.exclusivity_core == NPCManager.ExclusivityCore.POLY ? "poly" : "monog"
+        var rng = RNGManager.npc_manager.get_rng()
+        var candidates: Array = []
+        for entry in _quips:
+                if entry.get("action", "") not in [action, "any"]:
+                        continue
+                if entry.get("stage", "any") not in [stage_str, "any"]:
+                        continue
+                if entry.get("exclusivity", "any") not in [exclusivity_str, "any"]:
+                        continue
+                candidates.append(entry)
+        if candidates.is_empty():
+                return ""
+        var chosen: Dictionary = candidates[rng.randi_range(0, candidates.size() - 1)]
+        var prefix = _pick_variant(chosen.get("prefix", ""), rng)
+        var core = _pick_variant(chosen.get("core", ""), rng)
+        var suffix = _pick_variant(chosen.get("suffix", ""), rng)
+        var line = prefix + core + suffix
+        line = line.replace("{random first_name}", "{random_first_name}")
+        return MarkupParser.parse(line, npc)
+
+func _show_quip(action: String) -> void:
+        var text = _select_quip(action)
+        if text == "":
+                return
+        var bubble: SpeechBubble = SPEECH_BUBBLE_SCENE.instantiate()
+        add_child(bubble)
+        bubble.set_text(text)
+        var rect = portrait_view.get_global_rect()
+        var pos = Vector2(rect.position.x - bubble.size.x - 10, rect.position.y + (rect.size.y - bubble.size.y) * 0.5)
+        bubble.global_position = pos
+        bubble.pop_and_fade()
 
 # ---------------------------- Logic signal sinks ----------------------------
 

--- a/components/siggy/siggy.tscn
+++ b/components/siggy/siggy.tscn
@@ -2,7 +2,7 @@
 
 [ext_resource type="Texture2D" uid="uid://xm8tdrmlmymx" path="res://assets/siggy.png" id="1_qdwsr"]
 [ext_resource type="Script" uid="uid://3bhjirdktw5e" path="res://components/siggy/siggy.gd" id="1_v5hgp"]
-[ext_resource type="Texture2D" uid="uid://d1wp0emq6hqk6" path="res://assets/ui/buttons/speechbubble.png" id="4_lgbmc"]
+[ext_resource type="PackedScene" path="res://components/ui/speech_bubble.tscn" id="2_jm7ka"]
 
 [node name="Siggy" type="Control"]
 layout_mode = 3
@@ -34,9 +34,8 @@ offset_bottom = 113.0
 theme_override_font_sizes/font_size = 10
 text = "talk 4 me"
 
-[node name="SpeechBubble" type="NinePatchRect" parent="."]
+[node name="SpeechBubble" parent="." instance=ExtResource("2_jm7ka")]
 unique_name_in_owner = true
-custom_minimum_size = Vector2(145, 50)
 layout_mode = 1
 anchors_preset = 3
 anchor_left = 1.0
@@ -49,33 +48,6 @@ offset_right = -10.0
 offset_bottom = -41.0
 grow_horizontal = 0
 grow_vertical = 0
-texture = ExtResource("4_lgbmc")
-patch_margin_left = 20
-patch_margin_top = 20
-patch_margin_right = 20
-patch_margin_bottom = 20
-axis_stretch_horizontal = 2
-
-[node name="MarginContainer" type="MarginContainer" parent="SpeechBubble"]
-layout_mode = 1
-anchors_preset = 15
-anchor_right = 1.0
-anchor_bottom = 1.0
-grow_horizontal = 2
-grow_vertical = 2
-theme_override_constants/margin_left = 10
-theme_override_constants/margin_top = 5
-theme_override_constants/margin_right = 2
-theme_override_constants/margin_bottom = 2
-
-[node name="SpeechLabel" type="Label" parent="SpeechBubble/MarginContainer"]
-unique_name_in_owner = true
-layout_mode = 2
-size_flags_vertical = 1
-theme_override_colors/font_color = Color(0, 0, 0, 1)
-theme_override_font_sizes/font_size = 10
-text = "Hi! I'm Siggy the Sigma !!!"
-autowrap_mode = 2
 
 [node name="CheckButton" type="CheckButton" parent="."]
 layout_mode = 0

--- a/components/ui/speech_bubble.gd
+++ b/components/ui/speech_bubble.gd
@@ -1,0 +1,40 @@
+extends NinePatchRect
+class_name SpeechBubble
+
+@onready var speech_label: Label = %SpeechLabel
+
+func _ready() -> void:
+    visible = false
+    mouse_filter = Control.MOUSE_FILTER_IGNORE
+    z_index = 1000
+
+func set_text(text: String) -> void:
+    speech_label.text = text
+    speech_label.visible_ratio = 1.0
+    speech_label.autowrap_mode = TextServer.AUTOWRAP_OFF
+    var label_size = speech_label.get_combined_minimum_size()
+    var max_width = 260
+    var target_width = clamp(label_size.x, 80, max_width)
+    speech_label.custom_minimum_size.x = target_width
+    speech_label.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+    label_size = speech_label.get_combined_minimum_size()
+    var padding = Vector2(20, 20)
+    var target_size = label_size + padding
+    custom_minimum_size = target_size
+    size = target_size
+    pivot_offset = target_size
+
+func pop_and_fade(lifetime: float = 3.0) -> void:
+    scale = Vector2.ZERO
+    modulate.a = 0.0
+    visible = true
+    var tween = create_tween()
+    tween.tween_property(self, "scale", Vector2.ONE, 0.35).set_trans(Tween.TRANS_BACK).set_ease(Tween.EASE_OUT)
+    tween.parallel().tween_property(self, "modulate:a", 1.0, 0.2)
+    var fade = create_tween()
+    fade.tween_interval(lifetime)
+    fade.tween_property(self, "modulate:a", 0.0, 0.2)
+    fade.tween_callback(queue_free)
+
+func get_label() -> Label:
+    return speech_label

--- a/components/ui/speech_bubble.tscn
+++ b/components/ui/speech_bubble.tscn
@@ -1,0 +1,35 @@
+[gd_scene load_steps=3 format=3 uid="uid://speechbubble"]
+
+[ext_resource type="Texture2D" path="res://assets/ui/buttons/speechbubble.png" id="1"]
+[ext_resource type="Script" path="res://components/ui/speech_bubble.gd" id="2"]
+
+[node name="SpeechBubble" type="NinePatchRect"]
+unique_name_in_owner = true
+custom_minimum_size = Vector2(145, 50)
+texture = ExtResource("1")
+patch_margin_left = 20
+patch_margin_top = 20
+patch_margin_right = 20
+patch_margin_bottom = 20
+axis_stretch_horizontal = 2
+script = ExtResource("2")
+
+[node name="MarginContainer" type="MarginContainer" parent="."]
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_constants/margin_left = 10
+theme_override_constants/margin_top = 5
+theme_override_constants/margin_right = 2
+theme_override_constants/margin_bottom = 2
+
+[node name="SpeechLabel" type="Label" parent="MarginContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_vertical = 1
+theme_override_colors/font_color = Color(0, 0, 0, 1)
+theme_override_font_sizes/font_size = 10
+text = ""
+autowrap_mode = 2


### PR DESCRIPTION
## Summary
- reuse Siggy's speech bubble as a standalone `SpeechBubble` class
- display NPC quips from `eXFactorQuips` JSON after love, gift, date, breakup, and next-level actions
- position quip bubbles beside the NPC portrait in the ExFactor view

## Testing
- `godot --headless tests/test_runner.tscn` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ad0039add8832585a4b1907d10e753