### PR TITLE
Fix speech bubble layout in ExFactorView

### DIFF
--- a/components/popups/ex_factor_view.gd
+++ b/components/popups/ex_factor_view.gd
@@ -427,9 +427,13 @@ func _show_quip(action: String) -> void:
                 return
         var bubble: SpeechBubble = SPEECH_BUBBLE_SCENE.instantiate()
         add_child(bubble)
+        bubble.set_as_top_level(true)
         bubble.set_text(text)
         var rect = portrait_view.get_global_rect()
-        var pos = Vector2(rect.position.x - bubble.size.x - 10, rect.position.y + (rect.size.y - bubble.size.y) * 0.5)
+        var pos = Vector2(
+                rect.position.x - bubble.size.x - 10,
+                rect.position.y + (rect.size.y - bubble.size.y) * 0.5,
+        )
         bubble.global_position = pos
         bubble.pop_and_fade()
 


### PR DESCRIPTION
## Summary
- ensure ExFactorView speech bubble doesn't fill the screen
- position bubble to the left of the portrait view and size to text

## Testing
- `godot --headless --script tests/test_runner.gd` *(fails: command not found)*
- `apt-get install -y godot` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ad032bc3288325881f8bd1b2dfcaa3