### PR TITLE
Fix credit payment in bill popup

### DIFF
--- a/autoloads/portfolio_manager.gd
+++ b/autoloads/portfolio_manager.gd
@@ -247,12 +247,14 @@ func can_pay_with_credit(amount: float) -> bool:
 
 
 func pay_with_credit(amount: float) -> bool:
-	if can_pay_with_credit(amount):
-		var total_with_interest := amount * (1.0 + get_credit_interest_rate())
-		set_credit_used(get_credit_used() + total_with_interest)
-		WindowManager.launch_app_by_name("OwerView")
-		return true
-	return false
+        if can_pay_with_credit(amount):
+                var total_with_interest := amount * (1.0 + get_credit_interest_rate())
+                set_credit_used(get_credit_used() + total_with_interest)
+                emit_signal("credit_updated", get_credit_used(), get_credit_limit())
+                emit_signal("resource_changed", "credit_used", get_credit_used())
+                WindowManager.launch_app_by_name("OwerView")
+                return true
+        return false
 
 func get_credit_remaining() -> float:
 		return get_credit_limit() - get_credit_used()

--- a/components/popups/bill_popup_ui.gd
+++ b/components/popups/bill_popup_ui.gd
@@ -54,13 +54,13 @@ func _on_pay_now_button_pressed() -> void:
 				print("❌ Not enough cash")
 
 func _on_pay_by_credit_button_pressed() -> void:
-		if PortfolioManager.pay_with_credit(amount):
-				BillManager.mark_bill_paid(bill_name, date_key)
-				close()
-		else:
-				print("❌ Not enough credit")
-		WindowManager.focus_window(get_parent().get_parent().get_parent())
-		WindowManager.launch_app_by_name("OwerView")
+                if PortfolioManager.pay_with_credit(amount):
+                                BillManager.mark_bill_paid(bill_name, date_key)
+                                close()
+                else:
+                                print("❌ Not enough credit")
+                                WindowManager.focus_window(get_parent().get_parent().get_parent())
+                                WindowManager.launch_app_by_name("OwerView")
 
 func _on_autopay_check_box_toggled(toggled_on: bool) -> void:
 		BillManager.autopay_enabled = toggled_on

--- a/tests/pay_with_credit_bill_test.gd
+++ b/tests/pay_with_credit_bill_test.gd
@@ -1,0 +1,19 @@
+extends SceneTree
+
+func _ready():
+        var pm = Engine.get_singleton("PortfolioManager")
+        pm.credit_used = 0.0
+        pm.credit_limit = 1000.0
+        pm.credit_interest_rate = 0.0
+        pm.cash = 0.0
+        var bm = Engine.get_singleton("BillManager")
+        bm.reset()
+        var popup = preload("res://components/popups/bill_popup_ui.tscn").instantiate()
+        popup.bill_name = "TestBill"
+        popup.amount = 100.0
+        popup.date_key = "1/1/2000"
+        add_child(popup)
+        popup._on_pay_by_credit_button_pressed()
+        assert(pm.credit_used == 100.0)
+        print("pay_with_credit_bill_test passed")
+        quit()


### PR DESCRIPTION
## Summary
- fix Pay with Credit button to only refocus when payment fails
- emit credit change signals when paying with credit
- add test covering paying bills with credit

## Testing
- `godot3-server --headless -s tests/test_runner.gd` *(fails: Can't open project; engine version mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_68ad0a9a5b288325ae87ac488a6ab96f