### PR TITLE
Broadcast dating signal to reevaluate exclusivity

### DIFF
--- a/components/npc/npc_manager.gd
+++ b/components/npc/npc_manager.gd
@@ -8,6 +8,7 @@ signal relationship_stage_changed(idx: int, old_stage: int, new_stage: int)
 signal cheating_detected(primary_idx: int, other_idx: int)
 signal affinity_equilibrium_changed(idx: int, value: float)
 signal breakup_occurred(idx: int)
+signal player_started_dating(idx: int)
 
 enum RelationshipStage { STRANGER, TALKING, DATING, SERIOUS, ENGAGED, MARRIED, DIVORCED, EX }
 enum ExclusivityCore { MONOG, POLY, CHEATING }
@@ -37,8 +38,9 @@ func _ready() -> void:
 				_save_timer.one_shot = true
 				_save_timer.timeout.connect(_flush_save_queue)
 				add_child(_save_timer)
-				relationship_stage_changed.connect(func(idx, _o, _n): _recheck_daterbase_exclusivity(idx))
-				exclusivity_core_changed.connect(func(idx, _o, _n): _recheck_daterbase_exclusivity(idx))
+                                relationship_stage_changed.connect(func(idx, _o, _n): _recheck_daterbase_exclusivity(idx))
+                                exclusivity_core_changed.connect(func(idx, _o, _n): _recheck_daterbase_exclusivity(idx))
+                                player_started_dating.connect(notify_player_advanced_someone_to_dating)
 				load_daterbase_cache()
 
 func _queue_save(idx: int) -> void:
@@ -293,8 +295,8 @@ func set_relationship_stage(npc_idx: int, new_stage: int) -> void:
 		emit_signal("affinity_equilibrium_changed", npc_idx, npc.affinity_equilibrium)
 	print("NPC %d: stage %d -> %d core %d -> %d affinity %.2f -> %.2f eq %.2f -> %.2f" % [npc_idx, old_stage, npc.relationship_stage, old_core, npc.exclusivity_core, old_affinity, npc.affinity, old_equilibrium, npc.affinity_equilibrium])
 
-	if new_stage >= RelationshipStage.DATING and old_stage < RelationshipStage.DATING:
-		notify_player_advanced_someone_to_dating(npc_idx)
+        if new_stage == RelationshipStage.DATING and old_stage == RelationshipStage.TALKING:
+                emit_signal("player_started_dating", npc_idx)
 	print("NPC %d: stage %d -> %d core %d -> %d affinity %.2f -> %.2f eq %.2f -> %.2f" % [npc_idx, old_stage, npc.relationship_stage, old_core, npc.exclusivity_core, old_affinity, npc.affinity, old_equilibrium, npc.affinity_equilibrium])
 
 func go_exclusive_during_dating(npc_idx: int) -> void:

--- a/tests/dating_stage_signal_test.gd
+++ b/tests/dating_stage_signal_test.gd
@@ -1,0 +1,36 @@
+extends SceneTree
+
+const NPC = preload("res://components/npc/npc.gd")
+
+func _ready() -> void:
+    var save_mgr = Engine.get_singleton("SaveManager")
+    save_mgr.reset_managers()
+    save_mgr.current_slot_id = 1
+    var npc_mgr = Engine.get_singleton("NPCManager")
+
+    var a_idx := 1
+    var b_idx := 2
+    var npc_a := NPC.new()
+    npc_a.relationship_stage = NPCManager.RelationshipStage.TALKING
+    var npc_b := NPC.new()
+    npc_b.relationship_stage = NPCManager.RelationshipStage.DATING
+    npc_b.exclusivity_core = NPCManager.ExclusivityCore.MONOG
+    npc_mgr.npcs[a_idx] = npc_a
+    npc_mgr.persistent_npcs[a_idx] = {}
+    npc_mgr.npcs[b_idx] = npc_b
+    npc_mgr.persistent_npcs[b_idx] = {}
+    npc_mgr.daterbase_npcs = [b_idx]
+    npc_mgr.encountered_npcs = [a_idx, b_idx]
+
+    var triggered := false
+    npc_mgr.player_started_dating.connect(func(idx):
+        if idx == a_idx:
+            triggered = true
+    )
+
+    npc_mgr.set_relationship_stage(a_idx, NPCManager.RelationshipStage.DATING)
+    assert(triggered)
+    var other_npc: NPC = npc_mgr.get_npc_by_index(b_idx)
+    assert(other_npc.exclusivity_core == NPCManager.ExclusivityCore.CHEATING)
+    print("dating_stage_signal_test passed")
+    quit()


### PR DESCRIPTION
## Summary
- emit new `player_started_dating` signal when advancing from talking to dating
- have NPCManager listen to the signal to refresh Daterbase exclusivity
- add test covering dating signal and exclusivity update

## Testing
- `Godot_v4.2.2-stable_linux.x86_64 --headless --run tests/test_runner.tscn` *(fails: missing resources, project not imported)*

------
https://chatgpt.com/codex/tasks/task_e_68ad17e5acfc8325928a9cdb4bd40bf2