### PR TITLE
Add persistent tag selectors to Fumble profile

### DIFF
--- a/autoloads/player_manager.gd
+++ b/autoloads/player_manager.gd
@@ -89,9 +89,12 @@ var default_user_data: Dictionary = {
 # Fumble preferences
 	"fumble_pref_x": 0.0,
 	"fumble_pref_y": 0.0,
-	"fumble_pref_z": 0.0,
-	"fumble_curiosity": 50.0,
-	"fumble_fugly_filter_threshold": 0,
+        "fumble_pref_z": 0.0,
+        "fumble_curiosity": 50.0,
+        "fumble_fugly_filter_threshold": 0,
+       "fumble_tag1": "",
+       "fumble_tag2": "",
+       "fumble_tag3": "",
 
 	# Flags and progression
 	"unlocked_perks": [],

--- a/components/apps/fumble/fumble.tscn
+++ b/components/apps/fumble/fumble.tscn
@@ -149,6 +149,24 @@ layout_mode = 2
 [node name="HBoxContainer2" type="HBoxContainer" parent="MarginContainer/VBoxContainer/SelfTab/MarginContainer/ScrollContainer/VBoxContainer2/VBoxContainer3"]
 layout_mode = 2
 
+[node name="TagOption1" type="OptionButton" parent="MarginContainer/VBoxContainer/SelfTab/MarginContainer/ScrollContainer/VBoxContainer2/VBoxContainer3/HBoxContainer2"]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 3
+text = "--"
+
+[node name="TagOption2" type="OptionButton" parent="MarginContainer/VBoxContainer/SelfTab/MarginContainer/ScrollContainer/VBoxContainer2/VBoxContainer3/HBoxContainer2"]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 3
+text = "--"
+
+[node name="TagOption3" type="OptionButton" parent="MarginContainer/VBoxContainer/SelfTab/MarginContainer/ScrollContainer/VBoxContainer2/VBoxContainer3/HBoxContainer2"]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 3
+text = "--"
+
 [node name="HBoxContainer" type="HBoxContainer" parent="MarginContainer/VBoxContainer/SelfTab/MarginContainer/ScrollContainer/VBoxContainer2/VBoxContainer3"]
 layout_mode = 2
 size_flags_vertical = 3


### PR DESCRIPTION
## Summary
- Add three tag dropdowns above the Fumble bio and populate them from `tags.json`
- Store selected tags via `PlayerManager` so choices persist between sessions
- Initialize new tag fields in player defaults for save compatibility

## Testing
- `godot3 --headless -s tests/test_runner.gd` *(fails: project requires newer engine config_version)*

------
https://chatgpt.com/codex/tasks/task_e_68ad199af1f8832597f5528ac1fc2c52