### PR TITLE
Handle exclusivity after breakups and disable next-stage control

### DIFF
--- a/components/npc/npc_manager.gd
+++ b/components/npc/npc_manager.gd
@@ -43,6 +43,10 @@ func _ready() -> void:
 						_recheck_daterbase_exclusivity(idx))
 				entered_dating_stage.connect(func(idx): _recheck_daterbase_exclusivity(idx))
 				exclusivity_core_changed.connect(func(idx, _o, _n): _recheck_daterbase_exclusivity(idx))
+				breakup_occurred.connect(func(idx):
+					_recheck_daterbase_exclusivity(idx)
+					_check_cheating_after_breakup()
+				)
 				load_daterbase_cache()
 
 func _queue_save(idx: int) -> void:
@@ -511,7 +515,6 @@ func _mark_npc_as_cheating(npc_idx: int, other_idx: int) -> void:
 
 func player_broke_up_with(npc_idx: int) -> void:
 		emit_signal("breakup_occurred", npc_idx)
-		_check_cheating_after_breakup()
 
 func _check_cheating_after_breakup() -> void:
 		for idx in encountered_npcs:

--- a/components/popups/ex_factor_view.gd
+++ b/components/popups/ex_factor_view.gd
@@ -181,14 +181,15 @@ func _try_load_npc() -> void:
 # ---------------------------- UI updates ----------------------------
 
 func _refresh_all() -> void:
-	_update_relationship_bar()
-	_update_affinity_bar()
-	_update_buttons_text()
-	_update_love_button()
-	_update_dime_status_label()
-	_update_exclusivity_label()
-	_update_exclusivity_button()
-	_update_apologize_button()
+        _update_relationship_bar()
+        _update_affinity_bar()
+        _update_buttons_text()
+        _update_love_button()
+        _update_dime_status_label()
+        _update_exclusivity_label()
+        _update_exclusivity_button()
+        _update_next_stage_button()
+        _update_apologize_button()
 	
 func _update_relationship_bar() -> void:
 	var stage: int = npc.relationship_stage
@@ -286,16 +287,21 @@ func _update_exclusivity_label() -> void:
 		exclusivity_label.remove_theme_color_override("font_color")
 
 func _update_exclusivity_button() -> void:
-	var visible: bool = npc.relationship_stage >= NPCManager.RelationshipStage.DATING and \
-			npc.relationship_stage <= NPCManager.RelationshipStage.MARRIED
-	exclusivity_button.visible = visible
-	if not visible:
-			return
-	match npc.exclusivity_core:
-			NPCManager.ExclusivityCore.MONOG: exclusivity_button.text = "Go Poly"
-			NPCManager.ExclusivityCore.POLY: exclusivity_button.text = "Go Monog"
-			NPCManager.ExclusivityCore.CHEATING: exclusivity_button.text = "Come Clean"
-			_: exclusivity_button.text = "Toggle"
+        var visible: bool = npc.relationship_stage >= NPCManager.RelationshipStage.DATING and \
+                        npc.relationship_stage <= NPCManager.RelationshipStage.MARRIED
+        exclusivity_button.visible = visible
+        if not visible:
+                        return
+        match npc.exclusivity_core:
+                        NPCManager.ExclusivityCore.MONOG: exclusivity_button.text = "Go Poly"
+                        NPCManager.ExclusivityCore.POLY: exclusivity_button.text = "Go Monog"
+                        NPCManager.ExclusivityCore.CHEATING: exclusivity_button.text = "Come Clean"
+                        _: exclusivity_button.text = "Toggle"
+
+func _update_next_stage_button() -> void:
+        var show: bool = logic.progress_paused and npc.relationship_stage < NPCManager.RelationshipStage.DIVORCED
+        next_stage_button.visible = show
+        next_stage_button.disabled = not show
 
 func _update_apologize_button() -> void:
 	var has_upgrade: bool = UpgradeManager.get_level("ex_factor_talk_therapy") > 0
@@ -389,8 +395,8 @@ func _on_next_stage_confirm_alt_pressed() -> void:
 		_show_quip("next level")
 
 func _on_next_stage_confirm_no_pressed() -> void:
-	next_stage_confirm.visible = false
-	next_stage_button.visible = true
+        next_stage_confirm.visible = false
+        _update_next_stage_button()
 
 func _on_exclusivity_button_pressed() -> void:
 		logic.toggle_exclusivity()
@@ -468,13 +474,14 @@ func _on_progress_changed(_p: float) -> void:
 	_update_relationship_bar()
 
 func _on_stage_gate() -> void:
-	next_stage_button.visible = true
+        _update_next_stage_button()
 
 func _on_stage_changed(_stage: int) -> void:
-	_update_relationship_bar()
-	_update_love_button()
-	_update_exclusivity_label()
-	_update_exclusivity_button()
+        _update_relationship_bar()
+        _update_love_button()
+        _update_exclusivity_label()
+        _update_exclusivity_button()
+        _update_next_stage_button()
 
 func _on_affinity_changed(_a: float) -> void:
 	_update_affinity_bar()


### PR DESCRIPTION
## Summary
- broadcast breakup event so other NPCs recalc exclusivity
- hide/disable next stage button after breakups

## Testing
- `godot4 --headless -s tests/test_runner.gd` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ad1d5637cc83259a5492bf44f2f737