### PR TITLE
fix exclusivity status when dating ex

### DIFF
--- a/components/npc/npc_manager.gd
+++ b/components/npc/npc_manager.gd
@@ -531,43 +531,43 @@ func _check_cheating_after_breakup() -> void:
 								come_clean_from_cheating(check_idx)
 
 func _recheck_daterbase_exclusivity(changed_idx: int) -> void:
-	var active: Array[int] = []
-	for idx in daterbase_npcs:
-			var npc = get_npc_by_index(int(idx))
-			if npc.relationship_stage >= RelationshipStage.DATING and npc.relationship_stage <= RelationshipStage.MARRIED:
-					active.append(int(idx))
+        var active: Array[int] = []
+        for idx in encountered_npcs:
+                        var npc = get_npc_by_index(int(idx))
+                        if npc.relationship_stage >= RelationshipStage.DATING and npc.relationship_stage <= RelationshipStage.MARRIED:
+                                        active.append(int(idx))
 
-	for idx in daterbase_npcs:
-			var npc_idx: int = int(idx)
-			if npc_idx == changed_idx:
-					continue
-			var npc: NPC = get_npc_by_index(npc_idx)
-			var npc_active: bool = active.has(npc_idx)
-			var other_active_count: int = active.size()
-			if npc_active:
-				other_active_count -= 1
+        for idx in encountered_npcs:
+                        var npc_idx: int = int(idx)
+                        if npc_idx == changed_idx:
+                                        continue
+                        var npc: NPC = get_npc_by_index(npc_idx)
+                        var npc_active: bool = active.has(npc_idx)
+                        var other_active_count: int = active.size()
+                        if npc_active:
+                                other_active_count -= 1
 
-			if npc.exclusivity_core == ExclusivityCore.MONOG and npc_active and other_active_count > 0:
-					var other_idx: int = -1
-					for ai in active:
-							if ai != npc_idx:
-									other_idx = int(ai)
-									break
-					_mark_npc_as_cheating(npc_idx, other_idx)
-			elif npc.exclusivity_core == ExclusivityCore.CHEATING and (not npc_active or other_active_count == 0):
-					come_clean_from_cheating(npc_idx)
+                        if npc.exclusivity_core == ExclusivityCore.MONOG and npc_active and other_active_count > 0:
+                                        var other_idx: int = -1
+                                        for ai in active:
+                                                        if ai != npc_idx:
+                                                                        other_idx = int(ai)
+                                                                        break
+                                        _mark_npc_as_cheating(npc_idx, other_idx)
+                        elif npc.exclusivity_core == ExclusivityCore.CHEATING and (not npc_active or other_active_count == 0):
+                                        come_clean_from_cheating(npc_idx)
 
 func notify_player_advanced_someone_to_dating(other_idx: int) -> void:
-	for idx in daterbase_npcs:
-		var npc_idx: int = int(idx)
-		if npc_idx == other_idx:
-						continue
-		var npc: NPC = get_npc_by_index(npc_idx)
-		if npc.exclusivity_core != ExclusivityCore.MONOG:
-						continue
-		if npc.relationship_stage < RelationshipStage.DATING or npc.relationship_stage > RelationshipStage.MARRIED:
-						continue
-		_mark_npc_as_cheating(npc_idx, other_idx)
+        for idx in encountered_npcs:
+                var npc_idx: int = int(idx)
+                if npc_idx == other_idx:
+                                                continue
+                var npc: NPC = get_npc_by_index(npc_idx)
+                if npc.exclusivity_core != ExclusivityCore.MONOG:
+                                                continue
+                if npc.relationship_stage < RelationshipStage.DATING or npc.relationship_stage > RelationshipStage.MARRIED:
+                                                continue
+                _mark_npc_as_cheating(npc_idx, other_idx)
 
 
 func can_show_go_exclusive(npc_idx: int) -> bool:

--- a/components/popups/ex_factor_view.gd
+++ b/components/popups/ex_factor_view.gd
@@ -72,14 +72,15 @@ func _connect_logic_signals() -> void:
 	logic.affinity_changed.connect(_on_affinity_changed)
 	logic.equilibrium_changed.connect(_on_equilibrium_changed)
 	logic.costs_changed.connect(_on_costs_changed)
-	logic.cooldown_changed.connect(_on_cooldown_changed)
-	logic.exclusivity_changed.connect(_on_exclusivity_changed)
-	logic.blocked_state_changed.connect(_on_blocked_state_changed)
-	logic.request_persist.connect(_persist_fields)
+        logic.cooldown_changed.connect(_on_cooldown_changed)
+        logic.exclusivity_changed.connect(_on_exclusivity_changed)
+        logic.blocked_state_changed.connect(_on_blocked_state_changed)
+        logic.request_persist.connect(_persist_fields)
 
-	if npc_idx != -1:
-			NPCManager.affinity_changed.connect(_on_npc_affinity_changed)
-			NPCManager.affinity_equilibrium_changed.connect(_on_npc_equilibrium_changed)
+        if npc_idx != -1:
+                        NPCManager.affinity_changed.connect(_on_npc_affinity_changed)
+                        NPCManager.affinity_equilibrium_changed.connect(_on_npc_equilibrium_changed)
+                        NPCManager.exclusivity_core_changed.connect(_on_npc_exclusivity_core_changed)
 
 func _finalize_setup() -> void:
 	if npc == null:
@@ -137,6 +138,8 @@ func _exit_tree() -> void:
                         NPCManager.affinity_changed.disconnect(_on_npc_affinity_changed)
                 if NPCManager.affinity_equilibrium_changed.is_connected(_on_npc_equilibrium_changed):
                         NPCManager.affinity_equilibrium_changed.disconnect(_on_npc_equilibrium_changed)
+                if NPCManager.exclusivity_core_changed.is_connected(_on_npc_exclusivity_core_changed):
+                        NPCManager.exclusivity_core_changed.disconnect(_on_npc_exclusivity_core_changed)
                 if npc.relationship_progress != last_saved_progress:
                         _persist_fields({"relationship_progress": npc.relationship_progress})
 
@@ -518,6 +521,12 @@ func _on_npc_affinity_changed(idx: int, _value: float) -> void:
 		_update_affinity_bar()
 
 func _on_npc_equilibrium_changed(idx: int, _value: float) -> void:
-		if idx != npc_idx:
-				return
-		_update_affinity_bar()
+                if idx != npc_idx:
+                                return
+                _update_affinity_bar()
+
+func _on_npc_exclusivity_core_changed(idx: int, _old_core: int, _new_core: int) -> void:
+                if idx != npc_idx:
+                                return
+                _update_exclusivity_label()
+                _update_exclusivity_button()

--- a/tests/exclusivity_label_update_test.gd
+++ b/tests/exclusivity_label_update_test.gd
@@ -1,6 +1,7 @@
 extends SceneTree
 
 const NPC = preload("res://components/npc/npc.gd")
+const ExFactorViewScene = preload("res://components/popups/ex_factor_view.tscn")
 
 func _ready() -> void:
     var npc_mgr = Engine.get_singleton("NPCManager")
@@ -9,11 +10,10 @@ func _ready() -> void:
     var npc1_idx := 10101
     var npc2_idx := 20202
 
-    # Stub out database writes
     db_mgr.save_npc = func(_i, _n): pass
 
     var npc1 := NPC.new()
-    npc1.relationship_stage = NPCManager.RelationshipStage.TALKING
+    npc1.relationship_stage = NPCManager.RelationshipStage.DATING
     npc1.exclusivity_core = NPCManager.ExclusivityCore.MONOG
 
     var npc2 := NPC.new()
@@ -26,9 +26,14 @@ func _ready() -> void:
     npc_mgr.persistent_npcs[npc2_idx] = {}
     npc_mgr.encountered_npcs = [npc1_idx, npc2_idx]
 
-    npc_mgr.set_relationship_stage(npc1_idx, NPCManager.RelationshipStage.DATING)
+    var view := ExFactorViewScene.instantiate()
+    add_child(view)
+    view.setup_custom({"npc": npc1, "npc_idx": npc1_idx})
+    await get_tree().process_frame
 
-    assert(npc2.exclusivity_core == NPCManager.ExclusivityCore.CHEATING)
-    print("dating_stage_signal_test passed")
+    npc_mgr.notify_player_advanced_someone_to_dating(npc2_idx)
+    await get_tree().process_frame
+
+    assert(view.exclusivity_label.text == "Exclusivity: Cheating")
+    print("exclusivity_label_update_test passed")
     quit()
-


### PR DESCRIPTION
## Summary
- check all encountered NPCs for cheating when the player starts dating someone new
- update dating stage test to use encountered NPC list
- ExFactorView listens for NPCManager exclusivity signals and updates its label immediately
- add test confirming the label updates when cheating is detected

## Testing
- `godot3 --headless -s tests/dating_stage_signal_test.gd` *(fails: command not found)*
- `godot3 --headless -s tests/exclusivity_label_update_test.gd` *(fails: command not found)*
- `curl -I https://downloads.tuxfamily.org/godotengine/4.1.3/Godot_v4.1.3-stable_linux.x86_64.zip` *(fails: 503 Service Unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68ad1e7da3d083259c1337011498cee7