### PR TITLE
Refactor Fumble tags into likes/dislikes

### DIFF
--- a/autoloads/player_manager.gd
+++ b/autoloads/player_manager.gd
@@ -87,14 +87,14 @@ var default_user_data: Dictionary = {
 	"mbti": "",
 
 # Fumble preferences
-	"fumble_pref_x": 0.0,
-	"fumble_pref_y": 0.0,
-		"fumble_pref_z": 0.0,
-		"fumble_curiosity": 50.0,
-		"fumble_fugly_filter_threshold": 0,
-	   "fumble_tag1": "",
-	   "fumble_tag2": "",
-	   "fumble_tag3": "",
+        "fumble_pref_x": 0.0,
+        "fumble_pref_y": 0.0,
+                "fumble_pref_z": 0.0,
+                "fumble_curiosity": 50.0,
+                "fumble_fugly_filter_threshold": 0,
+           "fumble_type": "",
+           "fumble_like": "",
+           "fumble_dislike": "",
 
 	# Flags and progression
 	"unlocked_perks": [],

--- a/components/apps/fumble/fumble.gd
+++ b/components/apps/fumble/fumble.gd
@@ -219,45 +219,59 @@ func _update_fugly_filter_ui() -> void:
 
 
 func _load_preferences() -> void:
-	x_slider.value = PlayerManager.get_var("fumble_pref_x", x_slider.value)
-	y_slider.value = PlayerManager.get_var("fumble_pref_y", y_slider.value)
-	z_slider.value = PlayerManager.get_var("fumble_pref_z", z_slider.value)
-	curiosity_slider.value = PlayerManager.get_var("fumble_curiosity", curiosity_slider.value)
-	fugly_slider.value = PlayerManager.get_var("fumble_fugly_filter_threshold", fugly_slider.value)
+        x_slider.value = PlayerManager.get_var("fumble_pref_x", x_slider.value)
+        y_slider.value = PlayerManager.get_var("fumble_pref_y", y_slider.value)
+        z_slider.value = PlayerManager.get_var("fumble_pref_z", z_slider.value)
+        curiosity_slider.value = PlayerManager.get_var("fumble_curiosity", curiosity_slider.value)
+        fugly_slider.value = PlayerManager.get_var("fumble_fugly_filter_threshold", fugly_slider.value)
 
-	var saved_tags = [
-			PlayerManager.get_var("fumble_tag1", ""),
-			PlayerManager.get_var("fumble_tag2", ""),
-			PlayerManager.get_var("fumble_tag3", ""),
-	]
+        var saved_prefs = [
+                        PlayerManager.get_var("fumble_type", ""),
+                        PlayerManager.get_var("fumble_like", ""),
+                        PlayerManager.get_var("fumble_dislike", ""),
+        ]
 
-	for i in range(tag_option_buttons.size()):
-			var ob = tag_option_buttons[i]
-			var tag = saved_tags[i]
-			var selected_idx = 0
-			if tag != "":
-					for j in range(ob.get_item_count()):
-							if ob.get_item_text(j) == tag:
-									selected_idx = j
-									break
-			ob.select(selected_idx)
+        for i in range(tag_option_buttons.size()):
+                        var ob = tag_option_buttons[i]
+                        var pref = saved_prefs[i]
+                        var selected_idx = 0
+                        if pref != "":
+                                        for j in range(ob.get_item_count()):
+                                                        if ob.get_item_text(j) == pref:
+                                                                        selected_idx = j
+                                                                        break
+                        ob.select(selected_idx)
 
 func _populate_tag_dropdowns() -> void:
-	var tags: Array = NPCFactory.TAG_DATA.keys()
-	tags.sort()
-	for ob in tag_option_buttons:
-			ob.clear()
-			ob.add_item("--")
-			for tag in tags:
-					ob.add_item(tag)
-			ob.select(0)
+        var tags: Array = NPCFactory.TAG_DATA.keys()
+        tags.sort()
+        tag_option_button1.clear()
+        tag_option_button1.add_item("--")
+        for tag in tags:
+                tag_option_button1.add_item(tag)
+        tag_option_button1.select(0)
+
+        var likes: Array = NPCFactory.LIKE_DATA.keys()
+        likes.sort()
+        for ob in [tag_option_button2, tag_option_button3]:
+                ob.clear()
+                ob.add_item("--")
+                for like in likes:
+                        ob.add_item(like)
+                ob.select(0)
 
 func _on_tag_option_selected(index: int, which: int) -> void:
-	var ob = tag_option_buttons[which]
-	var text = ob.get_item_text(index)
-	if text == "--":
-			text = ""
-	PlayerManager.set_var("fumble_tag%s" % [which + 1], text)
+        var ob = tag_option_buttons[which]
+        var text = ob.get_item_text(index)
+        if text == "--":
+                text = ""
+        match which:
+                0:
+                        PlayerManager.set_var("fumble_type", text)
+                1:
+                        PlayerManager.set_var("fumble_like", text)
+                2:
+                        PlayerManager.set_var("fumble_dislike", text)
 
 func _on_resize_x_requested(pixels):
 		var window_frame = get_parent().get_parent().get_parent()

--- a/components/apps/fumble/fumble.tscn
+++ b/components/apps/fumble/fumble.tscn
@@ -148,18 +148,41 @@ layout_mode = 2
 
 [node name="HBoxContainer2" type="HBoxContainer" parent="MarginContainer/VBoxContainer/SelfTab/MarginContainer/ScrollContainer/VBoxContainer2/VBoxContainer3"]
 layout_mode = 2
+[node name="TypeVBox" type="VBoxContainer" parent="MarginContainer/VBoxContainer/SelfTab/MarginContainer/ScrollContainer/VBoxContainer2/VBoxContainer3/HBoxContainer2"]
+layout_mode = 2
+size_flags_horizontal = 3
 
-[node name="TagOption1" type="OptionButton" parent="MarginContainer/VBoxContainer/SelfTab/MarginContainer/ScrollContainer/VBoxContainer2/VBoxContainer3/HBoxContainer2"]
+[node name="Label" type="Label" parent="MarginContainer/VBoxContainer/SelfTab/MarginContainer/ScrollContainer/VBoxContainer2/VBoxContainer3/HBoxContainer2/TypeVBox"]
+layout_mode = 2
+text = "Type"
+
+[node name="TagOption1" type="OptionButton" parent="MarginContainer/VBoxContainer/SelfTab/MarginContainer/ScrollContainer/VBoxContainer2/VBoxContainer3/HBoxContainer2/TypeVBox"]
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 3
 
-[node name="TagOption2" type="OptionButton" parent="MarginContainer/VBoxContainer/SelfTab/MarginContainer/ScrollContainer/VBoxContainer2/VBoxContainer3/HBoxContainer2"]
+[node name="LikesVBox" type="VBoxContainer" parent="MarginContainer/VBoxContainer/SelfTab/MarginContainer/ScrollContainer/VBoxContainer2/VBoxContainer3/HBoxContainer2"]
+layout_mode = 2
+size_flags_horizontal = 3
+
+[node name="Label" type="Label" parent="MarginContainer/VBoxContainer/SelfTab/MarginContainer/ScrollContainer/VBoxContainer2/VBoxContainer3/HBoxContainer2/LikesVBox"]
+layout_mode = 2
+text = "Likes"
+
+[node name="TagOption2" type="OptionButton" parent="MarginContainer/VBoxContainer/SelfTab/MarginContainer/ScrollContainer/VBoxContainer2/VBoxContainer3/HBoxContainer2/LikesVBox"]
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 3
 
-[node name="TagOption3" type="OptionButton" parent="MarginContainer/VBoxContainer/SelfTab/MarginContainer/ScrollContainer/VBoxContainer2/VBoxContainer3/HBoxContainer2"]
+[node name="DislikesVBox" type="VBoxContainer" parent="MarginContainer/VBoxContainer/SelfTab/MarginContainer/ScrollContainer/VBoxContainer2/VBoxContainer3/HBoxContainer2"]
+layout_mode = 2
+size_flags_horizontal = 3
+
+[node name="Label" type="Label" parent="MarginContainer/VBoxContainer/SelfTab/MarginContainer/ScrollContainer/VBoxContainer2/VBoxContainer3/HBoxContainer2/DislikesVBox"]
+layout_mode = 2
+text = "Dislikes"
+
+[node name="TagOption3" type="OptionButton" parent="MarginContainer/VBoxContainer/SelfTab/MarginContainer/ScrollContainer/VBoxContainer2/VBoxContainer3/HBoxContainer2/DislikesVBox"]
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 3


### PR DESCRIPTION
## Summary
- Split Fumble tag selectors so the first uses tag data and the second and third use like data for likes/dislikes
- Persist new type/like/dislike preferences in PlayerManager
- Wrap each selector in a VBox with labels for Type, Likes, and Dislikes

## Testing
- `godot_v4.3-stable_linux.x86_64 --headless tests/test_runner.tscn` *(fails: Can't load script/tests due to missing resources and autoload errors)*

------
https://chatgpt.com/codex/tasks/task_e_68ad26e5906883259185a89de4e411ba