### PR TITLE
Optimize upgrade UI refresh to reuse existing rows

### DIFF
--- a/data/upgrades/upgrade_ui.gd
+++ b/data/upgrades/upgrade_ui.gd
@@ -32,6 +32,13 @@ func set_upgrade(upgrade: Dictionary) -> void:
 	set_locked(UpgradeManager.is_locked(upgrade["id"]))
 	_update_cooldown()
 
+func refresh() -> void:
+	if upgrade_data.is_empty():
+		return
+	set_level(StatManager.get_upgrade_level(upgrade_data["id"]))
+	_refresh_cost()
+	_update_cooldown()
+
 func set_locked(locked: bool) -> void:
 	is_locked = locked
 	buy_button.disabled = locked


### PR DESCRIPTION
## Summary
- track upgrade rows by id and refresh without rebuilding
- expose `UpgradeUI.refresh()` for affordability and level updates

## Testing
- `godot --headless --path . --scene tests/test_runner.tscn` *(fails: resources missing)*

------
https://chatgpt.com/codex/tasks/task_e_68ad2d6955fc83258ab65f856078616d