### PR TITLE
Add relationship status label to ExFactor view

### DIFF
--- a/components/popups/ex_factor_view.gd
+++ b/components/popups/ex_factor_view.gd
@@ -29,6 +29,7 @@ const PROGRESS_MIN_DELTA: float = 0.01
 @onready var next_stage_confirm_alt_button: Button = %NextStageConfirmAltButton
 @onready var next_stage_confirm_no_button: Button = %NextStageConfirmNoButton
 @onready var dime_status_label: Label = %DimeStatusLabel
+@onready var relationship_status_label: Label = %RelationshipStatusLabel
 @onready var exclusivity_label: Label = %ExclusivityLabel
 @onready var exclusivity_button: Button = %ExclusivityButton
 
@@ -189,15 +190,16 @@ func _try_load_npc() -> void:
 # ---------------------------- UI updates ----------------------------
 
 func _refresh_all() -> void:
-		_update_relationship_bar()
-		_update_affinity_bar()
-		_update_buttons_text()
-		_update_love_button()
-		_update_dime_status_label()
-		_update_exclusivity_label()
-		_update_exclusivity_button()
-		_update_next_stage_button()
-		_update_apologize_button()
+	_update_relationship_bar()
+	_update_affinity_bar()
+	_update_buttons_text()
+	_update_love_button()
+	_update_dime_status_label()
+	_update_relationship_status_label()
+	_update_exclusivity_label()
+	_update_exclusivity_button()
+	_update_next_stage_button()
+	_update_apologize_button()
 	
 func _update_relationship_bar() -> void:
 	var stage: int = npc.relationship_stage
@@ -269,6 +271,49 @@ func _update_love_button() -> void:
 
 func _update_dime_status_label() -> void:
 	dime_status_label.text = "🔥 %.1f/10" % (float(npc.attractiveness) / 10.0)
+
+func _update_relationship_status_label() -> void:
+	var text: String = ""
+	match npc.relationship_stage:
+		NPCManager.RelationshipStage.TALKING:
+			text = "You are TALKING to"
+		NPCManager.RelationshipStage.DATING:
+			match npc.exclusivity_core:
+				NPCManager.ExclusivityCore.MONOG:
+					text = "You are DATING EXCLUSIVELY"
+				NPCManager.ExclusivityCore.CHEATING:
+					text = "You are DATING and CHEATING ON"
+				_:
+					text = "You are DATING"
+		NPCManager.RelationshipStage.SERIOUS:
+			match npc.exclusivity_core:
+				NPCManager.ExclusivityCore.MONOG:
+					text = "You are SERIOUSLY DATING, EXCLUSIVELY"
+				NPCManager.ExclusivityCore.CHEATING:
+					text = "You are SERIOUSLY DATING, and CHEATING ON"
+				_:
+					text = "You are SERIOUSLY DATING, POLYAMOROUSLY"
+		NPCManager.RelationshipStage.ENGAGED:
+			match npc.exclusivity_core:
+				NPCManager.ExclusivityCore.MONOG:
+					text = "You are ENGAGED to"
+				NPCManager.ExclusivityCore.CHEATING:
+					text = "You are ENGAGED and CHEATING ON"
+				_:
+					text = "You are ENGAGED, and POLY with"
+		NPCManager.RelationshipStage.MARRIED:
+			match npc.exclusivity_core:
+				NPCManager.ExclusivityCore.MONOG:
+					text = "You are MARRIED to"
+				NPCManager.ExclusivityCore.CHEATING:
+					text = "You are MARRIED and CHEATING ON"
+				_:
+					text = "You are MARRIED, and POLY with"
+		NPCManager.RelationshipStage.DIVORCED, NPCManager.RelationshipStage.EX:
+			text = "Your EX:"
+		_:
+			text = ""
+	relationship_status_label.text = text
 
 func _update_exclusivity_label() -> void:
 	var label_text: String
@@ -485,11 +530,12 @@ func _on_stage_gate() -> void:
 		_update_next_stage_button()
 
 func _on_stage_changed(_stage: int) -> void:
-		_update_relationship_bar()
-		_update_love_button()
-		_update_exclusivity_label()
-		_update_exclusivity_button()
-		_update_next_stage_button()
+	_update_relationship_bar()
+	_update_love_button()
+	_update_relationship_status_label()
+	_update_exclusivity_label()
+	_update_exclusivity_button()
+	_update_next_stage_button()
 
 func _on_affinity_changed(_a: float) -> void:
 	_update_affinity_bar()
@@ -507,8 +553,9 @@ func _on_minute_passed(_m: int) -> void:
 		_update_love_button()
 
 func _on_exclusivity_changed(_core: int) -> void:
-		_update_exclusivity_label()
-		_update_exclusivity_button()
+	_update_relationship_status_label()
+	_update_exclusivity_label()
+	_update_exclusivity_button()
 
 func _on_blocked_state_changed(is_blocked: bool) -> void:
 	gift_button.disabled = is_blocked

--- a/components/popups/ex_factor_view.tscn
+++ b/components/popups/ex_factor_view.tscn
@@ -61,6 +61,13 @@ theme_override_constants/margin_bottom = 25
 layout_mode = 2
 theme_override_constants/separation = 8
 
+[node name="RelationshipStatusLabel" type="Label" parent="MarginContainer/VBox"]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 4
+theme_override_font_sizes/font_size = 16
+horizontal_alignment = 1
+
 [node name="NameLabel" type="Label" parent="MarginContainer/VBox"]
 unique_name_in_owner = true
 layout_mode = 2

--- a/tests/relationship_status_label_update_test.gd
+++ b/tests/relationship_status_label_update_test.gd
@@ -1,0 +1,105 @@
+extends SceneTree
+
+const NPC = preload("res://components/npc/npc.gd")
+const ExFactorViewScene = preload("res://components/popups/ex_factor_view.tscn")
+
+func _ready() -> void:
+    var npc_mgr = Engine.get_singleton("NPCManager")
+    var db_mgr = Engine.get_singleton("DBManager")
+    db_mgr.save_npc = func(_i, _n): pass
+    npc_mgr.npcs = {}
+    npc_mgr.persistent_npcs = {}
+    npc_mgr.encountered_npcs = []
+
+    var cases = [
+        {
+            "stage": NPCManager.RelationshipStage.TALKING,
+            "core": NPCManager.ExclusivityCore.POLY,
+            "expected": "You are TALKING to"
+        },
+        {
+            "stage": NPCManager.RelationshipStage.DATING,
+            "core": NPCManager.ExclusivityCore.POLY,
+            "expected": "You are DATING"
+        },
+        {
+            "stage": NPCManager.RelationshipStage.DATING,
+            "core": NPCManager.ExclusivityCore.MONOG,
+            "expected": "You are DATING EXCLUSIVELY"
+        },
+        {
+            "stage": NPCManager.RelationshipStage.DATING,
+            "core": NPCManager.ExclusivityCore.CHEATING,
+            "expected": "You are DATING and CHEATING ON"
+        },
+        {
+            "stage": NPCManager.RelationshipStage.SERIOUS,
+            "core": NPCManager.ExclusivityCore.POLY,
+            "expected": "You are SERIOUSLY DATING, POLYAMOROUSLY"
+        },
+        {
+            "stage": NPCManager.RelationshipStage.SERIOUS,
+            "core": NPCManager.ExclusivityCore.MONOG,
+            "expected": "You are SERIOUSLY DATING, EXCLUSIVELY"
+        },
+        {
+            "stage": NPCManager.RelationshipStage.SERIOUS,
+            "core": NPCManager.ExclusivityCore.CHEATING,
+            "expected": "You are SERIOUSLY DATING, and CHEATING ON"
+        },
+        {
+            "stage": NPCManager.RelationshipStage.ENGAGED,
+            "core": NPCManager.ExclusivityCore.POLY,
+            "expected": "You are ENGAGED, and POLY with"
+        },
+        {
+            "stage": NPCManager.RelationshipStage.ENGAGED,
+            "core": NPCManager.ExclusivityCore.MONOG,
+            "expected": "You are ENGAGED to"
+        },
+        {
+            "stage": NPCManager.RelationshipStage.ENGAGED,
+            "core": NPCManager.ExclusivityCore.CHEATING,
+            "expected": "You are ENGAGED and CHEATING ON"
+        },
+        {
+            "stage": NPCManager.RelationshipStage.MARRIED,
+            "core": NPCManager.ExclusivityCore.POLY,
+            "expected": "You are MARRIED, and POLY with"
+        },
+        {
+            "stage": NPCManager.RelationshipStage.MARRIED,
+            "core": NPCManager.ExclusivityCore.MONOG,
+            "expected": "You are MARRIED to"
+        },
+        {
+            "stage": NPCManager.RelationshipStage.MARRIED,
+            "core": NPCManager.ExclusivityCore.CHEATING,
+            "expected": "You are MARRIED and CHEATING ON"
+        },
+        {
+            "stage": NPCManager.RelationshipStage.EX,
+            "core": NPCManager.ExclusivityCore.POLY,
+            "expected": "Your EX:"
+        }
+    ]
+
+    var idx := 1
+    for c in cases:
+        var npc := NPC.new()
+        npc.relationship_stage = c.stage
+        npc.exclusivity_core = c.core
+        var npc_idx := 1000 + idx
+        npc_mgr.npcs[npc_idx] = npc
+        npc_mgr.persistent_npcs[npc_idx] = {}
+        npc_mgr.encountered_npcs.append(npc_idx)
+        var view := ExFactorViewScene.instantiate()
+        add_child(view)
+        view.setup_custom({"npc": npc, "npc_idx": npc_idx})
+        await get_tree().process_frame
+        assert(view.relationship_status_label.text == c.expected)
+        view.queue_free()
+        await get_tree().process_frame
+        idx += 1
+    print("relationship_status_label_update_test passed")
+    quit()


### PR DESCRIPTION
## Summary
- show relationship status above NPC name in ExFactorView
- update label as exclusivity and stage change
- add test covering relationship status label values

## Testing
- `/tmp/godot/Godot_v4.2.2-stable_linux.x86_64 --headless --path . -s tests/relationship_status_label_update_test.gd` *(fails: Missing resources prevent Godot from loading the project)*


------
https://chatgpt.com/codex/tasks/task_e_68ad38e1e35c832584781f4c9643fcae