### PR TITLE
Sync NPC cheating updates and label refresh

### DIFF
--- a/components/npc/npc_manager.gd
+++ b/components/npc/npc_manager.gd
@@ -30,6 +30,7 @@ var persistent_by_gender: Dictionary = {}
 var persistent_by_wealth: Dictionary = {}
 var _save_queue: Dictionary = {}
 var _save_timer: Timer
+var _last_dating_notify_time_msec: int = 0
 
 func _ready() -> void:
 				TimeManager.hour_passed.connect(_on_hour_passed)
@@ -574,16 +575,21 @@ func _recheck_daterbase_exclusivity(changed_idx: int) -> void:
 										come_clean_from_cheating(npc_idx)
 
 func notify_player_advanced_someone_to_dating(other_idx: int) -> void:
-		for idx in encountered_npcs:
-				var npc_idx: int = int(idx)
-				if npc_idx == other_idx:
-												continue
-				var npc: NPC = get_npc_by_index(npc_idx)
-				if npc.exclusivity_core != ExclusivityCore.MONOG:
-												continue
-				if npc.relationship_stage < RelationshipStage.DATING or npc.relationship_stage > RelationshipStage.MARRIED:
-												continue
-				_mark_npc_as_cheating(npc_idx, other_idx)
+        var now_msec: int = Time.get_ticks_msec()
+        if now_msec - _last_dating_notify_time_msec < 100:
+                return
+        _last_dating_notify_time_msec = now_msec
+
+        for idx in encountered_npcs:
+                var npc_idx: int = int(idx)
+                if npc_idx == other_idx:
+                        continue
+                var npc: NPC = get_npc_by_index(npc_idx)
+                if npc.exclusivity_core != ExclusivityCore.MONOG:
+                        continue
+                if npc.relationship_stage < RelationshipStage.DATING or npc.relationship_stage > RelationshipStage.MARRIED:
+                        continue
+                _mark_npc_as_cheating(npc_idx, other_idx)
 
 
 func can_show_go_exclusive(npc_idx: int) -> bool:

--- a/components/popups/ex_factor_view.gd
+++ b/components/popups/ex_factor_view.gd
@@ -96,10 +96,7 @@ func _finalize_setup() -> void:
 	if portrait_view.has_method("apply_config") and npc.portrait_config:
 		portrait_view.apply_config(npc.portrait_config)
 
-	if npc_idx != -1 and npc.relationship_stage >= NPCManager.RelationshipStage.DATING:
-		NPCManager.notify_player_advanced_someone_to_dating(npc_idx)
-
-	_refresh_all()
+        _refresh_all()
 
 func _ready() -> void:
 	gift_button.pressed.connect(_on_gift_pressed)
@@ -325,11 +322,11 @@ func _update_relationship_status_label() -> void:
 			text = ""
 	relationship_status_label.text = text
 
-	# Color the text red if cheating, else white
-	if npc.exclusivity_core == NPCManager.ExclusivityCore.CHEATING:
-		relationship_status_label.add_theme_color_override("font_color", Color.RED)
-	else:
-		relationship_status_label.add_theme_color_override("font_color", Color.WHITE)
+        # Color the text red if cheating, otherwise remove any override
+        if npc.exclusivity_core == NPCManager.ExclusivityCore.CHEATING:
+                relationship_status_label.add_theme_color_override("font_color", Color.RED)
+        else:
+                relationship_status_label.remove_theme_color_override("font_color")
 
 
 
@@ -591,42 +588,47 @@ func _on_stat_changed(stat: String, _value: Variant) -> void:
 		_update_apologize_button()
 
 func _on_npc_affinity_changed(idx: int, _value: float) -> void:
-		if idx != npc_idx:
-				return
-		_update_affinity_bar()
+                if idx != npc_idx:
+                                return
+                _sync_from_manager()
+                _update_affinity_bar()
 
 func _on_npc_equilibrium_changed(idx: int, _value: float) -> void:
-				if idx != npc_idx:
-								return
-				_update_affinity_bar()
+                                if idx != npc_idx:
+                                                                return
+                                _sync_from_manager()
+                                _update_affinity_bar()
 
 func _on_npc_exclusivity_core_changed(idx: int, _old_core: int, _new_core: int) -> void:
-				if idx != npc_idx:
-								return
-				_update_exclusivity_label()
-				_update_exclusivity_button()
-				_update_relationship_status_label()
+                                if idx != npc_idx:
+                                                                return
+                                _sync_from_manager()
+                                _update_exclusivity_label()
+                                _update_exclusivity_button()
+                                _update_relationship_status_label()
 
 func _on_npc_stage_changed(idx: int, _old_stage: int, _new_stage: int) -> void:
-	if idx != npc_idx:
-		return
-	# Re-run all UI derived from stage.
-	_update_relationship_bar()
-	_update_love_button()
-	_update_relationship_status_label()
-	_update_exclusivity_label()
-	_update_exclusivity_button()
-	_update_next_stage_button()
-	_update_apologize_button()
+        if idx != npc_idx:
+                return
+        _sync_from_manager()
+        # Re-run all UI derived from stage.
+        _update_relationship_bar()
+        _update_love_button()
+        _update_relationship_status_label()
+        _update_exclusivity_label()
+        _update_exclusivity_button()
+        _update_next_stage_button()
+        _update_apologize_button()
 
 func _on_cheating_detected(primary_idx: int, other_idx: int) -> void:
 	# If this view’s NPC is either the one marked cheating or the “other”, refresh.
 	if primary_idx != npc_idx and other_idx != npc_idx:
 		return
-	_update_relationship_status_label()
-	_update_exclusivity_label()
-	_update_exclusivity_button()
-	_update_affinity_bar()
+        _sync_from_manager()
+        _update_relationship_status_label()
+        _update_exclusivity_label()
+        _update_exclusivity_button()
+        _update_affinity_bar()
 
 func _sync_from_manager() -> void:
 	if npc_idx == -1:

--- a/tests/exclusivity_label_update_test.gd
+++ b/tests/exclusivity_label_update_test.gd
@@ -31,9 +31,15 @@ func _ready() -> void:
     view.setup_custom({"npc": npc1, "npc_idx": npc1_idx})
     await get_tree().process_frame
 
+    # Opening the view should not trigger cheating cascades
+    assert(npc2.exclusivity_core == NPCManager.ExclusivityCore.MONOG)
+    assert(not view.relationship_status_label.has_theme_color_override("font_color"))
+
     npc_mgr.notify_player_advanced_someone_to_dating(npc2_idx)
     await get_tree().process_frame
 
     assert(view.exclusivity_label.text == "Exclusivity: Cheating")
+    assert(view.exclusivity_button.text == "Come Clean")
+    assert(view.relationship_status_label.get_theme_color("font_color") == Color.RED)
     print("exclusivity_label_update_test passed")
     quit()


### PR DESCRIPTION
## Summary
- Refresh ExFactorView's NPC from manager before handling signals
- Remove auto dating notification and color relationship status red only when cheating
- Debounce NPCManager's dating advancement cascade

## Testing
- `godot3 -q --path . --headless tests/test_runner.gd` *(fails: config version from newer engine)*

------
https://chatgpt.com/codex/tasks/task_e_68ad564840b083258f4eef09899d7ec8