### PR TITLE
Fix profile card stack resizing

### DIFF
--- a/components/apps/fumble/profile_card_stack.gd
+++ b/components/apps/fumble/profile_card_stack.gd
@@ -36,25 +36,27 @@ func load_initial_cards() -> void:
 
 
 func _add_card_at_top(idx: int) -> void:
-	var card = profile_card_scene.instantiate()
-	card.set("npc_idx", idx)
-	var npc = NPCManager.get_npc_by_index(idx)
-	add_child(card)
-	card.call("load_npc", npc)
-	cards.append(card)
-	npc_indices.append(idx)
-	_update_card_positions()
+        var card = profile_card_scene.instantiate()
+        card.set("npc_idx", idx)
+        var npc = NPCManager.get_npc_by_index(idx)
+        add_child(card)
+        card.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
+        card.call("load_npc", npc)
+        cards.append(card)
+        npc_indices.append(idx)
+        _update_card_positions()
 
 
 func _add_card_at_bottom(idx: int) -> void:
-	var card = profile_card_scene.instantiate()
-	card.set("npc_idx", idx)
-	var npc = NPCManager.get_npc_by_index(idx)
-	add_child(card)
-	card.call("load_npc", npc)
-	cards.insert(0, card)
-	npc_indices.insert(0, idx)
-	_update_card_positions()
+        var card = profile_card_scene.instantiate()
+        card.set("npc_idx", idx)
+        var npc = NPCManager.get_npc_by_index(idx)
+        add_child(card)
+        card.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
+        card.call("load_npc", npc)
+        cards.insert(0, card)
+        npc_indices.insert(0, idx)
+        _update_card_positions()
 
 
 func _update_card_positions() -> void:


### PR DESCRIPTION
## Summary
- ensure newly added profile cards fill available space by anchoring them to the full rect when instanced

## Testing
- `godot --version` *(fails: command not found)*
- `/usr/bin/apt-get update` *(fails: gpgv not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68ad5cfdaf888325bf4eabc841f9a10c