### PR TITLE
Add tags section to Fumble profile UI

### DIFF
--- a/components/apps/fumble/fumble_profile.gd
+++ b/components/apps/fumble/fumble_profile.gd
@@ -7,26 +7,30 @@ extends PanelContainer
 @onready var type_label: Label = %TypeLabel
 @onready var likes_container: Control = %LikesContainer
 @onready var likes_label: Label = %LikesLabel
+@onready var tags_container: Control = %TagsContainer
+@onready var tags_label: Label = %TagsLabel
 @onready var bio_text: RichTextLabel = %BioText
 @onready var astrology_value: Label = %AstrologyValue
 @onready var greek_stats_ui: Node = %GreekStatsUI
 @onready var wealth_value: Label = %WealthValue
 
 @onready var likes_section: VBoxContainer = %LikesSection
+@onready var tags_section: VBoxContainer = %TagsSection
 @onready var bio_panel: PanelContainer = %BioPanel
 @onready var astrology_row: HBoxContainer = %AstrologyRow
 @onready var greek_panel: PanelContainer = %GreekPanel
 @onready var wealth_row: HBoxContainer = %WealthRow
 
 @onready var sections: Array[Control] = [
-	dime_status_label,
-	name_label,
-	type_label,
-	likes_section,
-	bio_panel,
-	astrology_row,
-	greek_panel,
-	wealth_row
+        dime_status_label,
+        name_label,
+        type_label,
+        likes_section,
+        tags_section,
+        bio_panel,
+        astrology_row,
+        greek_panel,
+        wealth_row
 ]
 
 func load_npc(npc: NPC, npc_idx: int = -1) -> void:
@@ -45,14 +49,15 @@ func load_npc(npc: NPC, npc_idx: int = -1) -> void:
 		dime_status = "🔥 %0.1f/10" % (float(npc.attractiveness) / 10.0)
 	dime_status_label.text = dime_status
 
-	name_label.text = npc.full_name
-	type_label.text = str(npc.chat_battle_type)
+        name_label.text = npc.full_name
+        type_label.text = str(npc.chat_battle_type)
 
-	_populate_likes(npc)
-	_populate_bio(npc)
-	_populate_astrology(npc)
-	_populate_greek(npc)
-	_populate_wealth(npc)
+        _populate_likes(npc)
+        _populate_tags(npc)
+        _populate_bio(npc)
+        _populate_astrology(npc)
+        _populate_greek(npc)
+        _populate_wealth(npc)
 
 	_run_entrance_animation()
 
@@ -66,8 +71,21 @@ func _populate_likes(npc: NPC) -> void:
 	else:
 		var none_label: Label = Label.new()
 		none_label.text = "No likes listed"
-		none_label.modulate = Color(1.0, 1.0, 1.0, 0.6)
-		likes_container.add_child(none_label)
+                none_label.modulate = Color(1.0, 1.0, 1.0, 0.6)
+                likes_container.add_child(none_label)
+
+func _populate_tags(npc: NPC) -> void:
+        tags_label.text = "Tags"
+        _clear_children(tags_container)
+        if npc.tags != null and npc.tags.size() > 0:
+                for tag in npc.tags:
+                        var pill: Control = _make_like_pill(_safe_str(tag))
+                        tags_container.add_child(pill)
+        else:
+                var none_label: Label = Label.new()
+                none_label.text = "No tags listed"
+                none_label.modulate = Color(1.0, 1.0, 1.0, 0.6)
+                tags_container.add_child(none_label)
 
 func _populate_bio(npc: NPC) -> void:
 	var lines: Array[String] = []

--- a/components/apps/fumble/fumble_profile_ui.tscn
+++ b/components/apps/fumble/fumble_profile_ui.tscn
@@ -92,6 +92,23 @@ layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 2
 
+[node name="TagsSection" type="VBoxContainer" parent="Margin/Scroll/VBox"]
+unique_name_in_owner = true
+layout_mode = 2
+theme_override_constants/separation = 4
+
+[node name="TagsLabel" type="Label" parent="Margin/Scroll/VBox/TagsSection"]
+unique_name_in_owner = true
+layout_mode = 2
+theme_override_font_sizes/font_size = 18
+text = "Tags"
+
+[node name="TagsContainer" type="FlowContainer" parent="Margin/Scroll/VBox/TagsSection"]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 2
+
 [node name="BioPanel" type="PanelContainer" parent="Margin/Scroll/VBox"]
 unique_name_in_owner = true
 layout_mode = 2


### PR DESCRIPTION
## Summary
- add tags section alongside likes in Fumble profile UI
- load NPC tags and display them as pills similar to likes

## Testing
- `godot3-server --headless --path . -s tests/daterbase_persistence_test.gd` *(fails: Can't open project, config_version 5)*

------
https://chatgpt.com/codex/tasks/task_e_68ad641ae7e48325a403312628ffde41