### PR TITLE
Cache fumble matches

### DIFF
--- a/autoloads/save_manager.gd
+++ b/autoloads/save_manager.gd
@@ -233,10 +233,11 @@ func load_from_slot(slot_id: int) -> void:
 	if data.has("desktop"):
 					DesktopLayoutManager.load_from_data(data["desktop"])
 	if data.has("windows"):  # Always load windows last
-		WindowManager.load_from_data(data["windows"])
-		BillManager.is_loading = false
-		NPCManager.restore_encountered_from_db()
-		NPCManager.load_daterbase_cache()
+                WindowManager.load_from_data(data["windows"])
+                BillManager.is_loading = false
+                NPCManager.restore_encountered_from_db()
+                NPCManager.load_daterbase_cache()
+                NPCManager.load_fumble_relationship_cache()
 
 
 func reset_game_state() -> void:


### PR DESCRIPTION
## Summary
- cache NPCs liked or matched in Fumble
- load Fumble relationship cache when loading saves
- keep matched NPC cache in sync when relationships change

## Testing
- `godot3-server --headless -s tests/test_runner.gd` *(fails: Can't open project, config_version 5 is from newer Godot)*

------
https://chatgpt.com/codex/tasks/task_e_68ade77ec59c8325892fa4e0d64cd0fe