### PR TITLE
Skip matched NPCs when recycling

### DIFF
--- a/components/apps/fumble/profile_card_stack.gd
+++ b/components/apps/fumble/profile_card_stack.gd
@@ -196,17 +196,18 @@ func _refill_swipe_pool_async(time_budget_msec: int = 8) -> void:
 			await get_tree().process_frame
 			start_time = Time.get_ticks_msec()
 
-	var recycled_indices: Array[int] = []
-	for idx in NPCManager.get_batch_of_recycled_npc_indices(app_name, num_recycled * 3):
-		if not exclude.has(idx):
-			var npc = NPCManager.get_npc_by_index(idx)
-			if npc.attractiveness >= min_att and gender_dot_similarity(preferred_gender, npc.gender_vector) >= gender_similarity_threshold:
-				recycled_indices.append(idx)
-		if recycled_indices.size() >= num_recycled:
-			break
-		if Time.get_ticks_msec() - start_time > time_budget_msec:
-			await get_tree().process_frame
-			start_time = Time.get_ticks_msec()
+        var recycled_indices: Array[int] = []
+        var matched = NPCManager.matched_npcs_by_app.get(app_name, {})
+        for idx in NPCManager.get_batch_of_recycled_npc_indices(app_name, num_recycled * 3):
+                if not exclude.has(idx) and not matched.has(idx):
+                        var npc = NPCManager.get_npc_by_index(idx)
+                        if npc.attractiveness >= min_att and gender_dot_similarity(preferred_gender, npc.gender_vector) >= gender_similarity_threshold:
+                                recycled_indices.append(idx)
+                if recycled_indices.size() >= num_recycled:
+                        break
+                if Time.get_ticks_msec() - start_time > time_budget_msec:
+                        await get_tree().process_frame
+                        start_time = Time.get_ticks_msec()
 
 	pool += new_indices
 	pool += recycled_indices

--- a/components/npc/npc_manager.gd
+++ b/components/npc/npc_manager.gd
@@ -674,12 +674,13 @@ func get_batch_of_new_npc_indices(app_name: String, count: int) -> Array[int]:
 	return result
 
 func get_batch_of_recycled_npc_indices(app_name: String, count: int) -> Array[int]:
-	var pool: Array[int] = []
-	var encountered = encountered_npcs_by_app.get(app_name, [])
-	var active = active_npcs_by_app.get(app_name, [])
-	for idx in encountered:
-		if not active.has(idx) and not persistent_npcs.has(idx):
-			pool.append(idx)
+        var pool: Array[int] = []
+        var encountered = encountered_npcs_by_app.get(app_name, [])
+        var active = active_npcs_by_app.get(app_name, [])
+        var matched = matched_npcs_by_app.get(app_name, {})
+        for idx in encountered:
+                if not active.has(idx) and not persistent_npcs.has(idx) and not matched.has(idx):
+                        pool.append(idx)
 	RNGManager.npc_manager.shuffle(pool)
 	var result: Array[int] = []
 	for idx in pool.slice(0, count):


### PR DESCRIPTION
## Summary
- avoid recycling NPCs already matched in an app
- guard against stale matched data when refilling the swipe pool

## Testing
- `godot4 --headless -s tests/test_runner.gd` *(fails: script must inherit from SceneTree or MainLoop)*

------
https://chatgpt.com/codex/tasks/task_e_68ade940974c8325bec47ccd6a29d606