### PR TITLE
Add cooldown timers for Fumble tag selections

### DIFF
--- a/autoloads/player_manager.gd
+++ b/autoloads/player_manager.gd
@@ -92,9 +92,12 @@ var default_user_data: Dictionary = {
 				"fumble_pref_z": 0.0,
 				"fumble_curiosity": 50.0,
 				"fumble_fugly_filter_threshold": 0,
-		   "fumble_type": "",
-		   "fumble_like": "",
-		   "fumble_dislike": "",
+                   "fumble_type": "",
+                   "fumble_like": "",
+                   "fumble_dislike": "",
+                   "fumble_type_cd": 0,
+                   "fumble_like_cd": 0,
+                   "fumble_dislike_cd": 0,
 
 	# Flags and progression
 	"unlocked_perks": [],

--- a/components/apps/fumble/fumble.tscn
+++ b/components/apps/fumble/fumble.tscn
@@ -153,10 +153,19 @@ layout_mode = 2
 layout_mode = 2
 size_flags_horizontal = 3
 
-[node name="Label" type="Label" parent="MarginContainer/VBoxContainer/SelfTab/MarginContainer/ScrollContainer/VBoxContainer2/VBoxContainer3/HBoxContainer2/TypeVBox"]
+[node name="TypeHeader" type="HBoxContainer" parent="MarginContainer/VBoxContainer/SelfTab/MarginContainer/ScrollContainer/VBoxContainer2/VBoxContainer3/HBoxContainer2/TypeVBox"]
+layout_mode = 2
+
+[node name="Label" type="Label" parent="MarginContainer/VBoxContainer/SelfTab/MarginContainer/ScrollContainer/VBoxContainer2/VBoxContainer3/HBoxContainer2/TypeVBox/TypeHeader"]
 layout_mode = 2
 theme_override_font_sizes/font_size = 12
 text = "Type"
+
+[node name="TypeCooldownLabel" type="Label" parent="MarginContainer/VBoxContainer/SelfTab/MarginContainer/ScrollContainer/VBoxContainer2/VBoxContainer3/HBoxContainer2/TypeVBox/TypeHeader"]
+unique_name_in_owner = true
+layout_mode = 2
+theme_override_font_sizes/font_size = 12
+visible = false
 
 [node name="TagOption1" type="OptionButton" parent="MarginContainer/VBoxContainer/SelfTab/MarginContainer/ScrollContainer/VBoxContainer2/VBoxContainer3/HBoxContainer2/TypeVBox"]
 unique_name_in_owner = true
@@ -169,10 +178,19 @@ theme_override_font_sizes/font_size = 12
 layout_mode = 2
 size_flags_horizontal = 3
 
-[node name="Label" type="Label" parent="MarginContainer/VBoxContainer/SelfTab/MarginContainer/ScrollContainer/VBoxContainer2/VBoxContainer3/HBoxContainer2/LikesVBox"]
+[node name="LikesHeader" type="HBoxContainer" parent="MarginContainer/VBoxContainer/SelfTab/MarginContainer/ScrollContainer/VBoxContainer2/VBoxContainer3/HBoxContainer2/LikesVBox"]
+layout_mode = 2
+
+[node name="Label" type="Label" parent="MarginContainer/VBoxContainer/SelfTab/MarginContainer/ScrollContainer/VBoxContainer2/VBoxContainer3/HBoxContainer2/LikesVBox/LikesHeader"]
 layout_mode = 2
 theme_override_font_sizes/font_size = 12
 text = "Likes"
+
+[node name="LikesCooldownLabel" type="Label" parent="MarginContainer/VBoxContainer/SelfTab/MarginContainer/ScrollContainer/VBoxContainer2/VBoxContainer3/HBoxContainer2/LikesVBox/LikesHeader"]
+unique_name_in_owner = true
+layout_mode = 2
+theme_override_font_sizes/font_size = 12
+visible = false
 
 [node name="TagOption2" type="OptionButton" parent="MarginContainer/VBoxContainer/SelfTab/MarginContainer/ScrollContainer/VBoxContainer2/VBoxContainer3/HBoxContainer2/LikesVBox"]
 unique_name_in_owner = true
@@ -185,10 +203,19 @@ theme_override_font_sizes/font_size = 12
 layout_mode = 2
 size_flags_horizontal = 3
 
-[node name="Label" type="Label" parent="MarginContainer/VBoxContainer/SelfTab/MarginContainer/ScrollContainer/VBoxContainer2/VBoxContainer3/HBoxContainer2/DislikesVBox"]
+[node name="DislikesHeader" type="HBoxContainer" parent="MarginContainer/VBoxContainer/SelfTab/MarginContainer/ScrollContainer/VBoxContainer2/VBoxContainer3/HBoxContainer2/DislikesVBox"]
+layout_mode = 2
+
+[node name="Label" type="Label" parent="MarginContainer/VBoxContainer/SelfTab/MarginContainer/ScrollContainer/VBoxContainer2/VBoxContainer3/HBoxContainer2/DislikesVBox/DislikesHeader"]
 layout_mode = 2
 theme_override_font_sizes/font_size = 12
 text = "Dislikes"
+
+[node name="DislikesCooldownLabel" type="Label" parent="MarginContainer/VBoxContainer/SelfTab/MarginContainer/ScrollContainer/VBoxContainer2/VBoxContainer3/HBoxContainer2/DislikesVBox/DislikesHeader"]
+unique_name_in_owner = true
+layout_mode = 2
+theme_override_font_sizes/font_size = 12
+visible = false
 
 [node name="TagOption3" type="OptionButton" parent="MarginContainer/VBoxContainer/SelfTab/MarginContainer/ScrollContainer/VBoxContainer2/VBoxContainer3/HBoxContainer2/DislikesVBox"]
 unique_name_in_owner = true


### PR DESCRIPTION
## Summary
- Add cooldown timer labels to Fumble Type, Likes, and Dislikes headers
- Disable tag dropdowns for 24 in-game hours after selection and show remaining time
- Persist cooldowns in player data and update each in-game hour

## Testing
- `godot3-server --headless -s tests/test_runner.gd` *(fails: Can't open project, config_version from more recent engine)*

------
https://chatgpt.com/codex/tasks/task_e_68adf95a79d083259af42e650165be04