### PR TITLE
Revamp LifeStylist app styling

### DIFF
--- a/components/apps/app_scenes/life_stylist.tscn
+++ b/components/apps/app_scenes/life_stylist.tscn
@@ -1,16 +1,8 @@
-[gd_scene load_steps=6 format=3 uid="uid://6sibrffc2ni7"]
+[gd_scene load_steps=4 format=3 uid="uid://6sibrffc2ni7"]
 
-[ext_resource type="Texture2D" uid="uid://dtd0wy3l6ohhq" path="res://assets/ui/buttons/lemon_chiffon_normal.png" id="1_16n21"]
 [ext_resource type="Script" uid="uid://d0sq5gmsn0mp7" path="res://components/apps/lifestylist/life_stylist.gd" id="1_80bik"]
 [ext_resource type="PackedScene" uid="uid://p3nf4gwmvex1" path="res://components/apps/lifestylist/lifestyle_row.tscn" id="2_80bik"]
 [ext_resource type="Texture2D" uid="uid://cgxywei8rjptj" path="res://assets/logos/monocle_man.png" id="4_16n21"]
-
-[sub_resource type="StyleBoxTexture" id="StyleBoxTexture_8oiat"]
-texture = ExtResource("1_16n21")
-texture_margin_left = 2.0
-texture_margin_top = 2.0
-texture_margin_right = 2.0
-texture_margin_bottom = 2.0
 
 [node name="LifeStylist" type="PanelContainer"]
 anchors_preset = 15
@@ -21,7 +13,6 @@ grow_vertical = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
 mouse_filter = 1
-theme_override_styles/panel = SubResource("StyleBoxTexture_8oiat")
 script = ExtResource("1_80bik")
 lifestyle_row_scene = ExtResource("2_80bik")
 window_title = "LifeStylist"
@@ -30,43 +21,43 @@ default_window_size = Vector2(815, 650)
 
 [node name="MarginContainer" type="MarginContainer" parent="."]
 layout_mode = 2
-theme_override_constants/margin_left = 25
-theme_override_constants/margin_top = 25
-theme_override_constants/margin_right = 25
-theme_override_constants/margin_bottom = 25
+theme_override_constants/margin_left = 24
+theme_override_constants/margin_top = 24
+theme_override_constants/margin_right = 24
+theme_override_constants/margin_bottom = 24
 
 [node name="CategoryList" type="VBoxContainer" parent="MarginContainer"]
 unique_name_in_owner = true
 layout_mode = 2
-theme_override_constants/separation = 30
+theme_override_constants/separation = 16
 
 [node name="HBoxContainer" type="HBoxContainer" parent="MarginContainer/CategoryList"]
 layout_mode = 2
 size_flags_horizontal = 4
+theme_override_constants/separation = 8
 
 [node name="TextureRect" type="TextureRect" parent="MarginContainer/CategoryList/HBoxContainer"]
 layout_mode = 2
 texture = ExtResource("4_16n21")
 
-[node name="Label" type="Label" parent="MarginContainer/CategoryList/HBoxContainer"]
+[node name="HeaderLabel" type="Label" parent="MarginContainer/CategoryList/HBoxContainer"]
+unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 4
-theme_override_colors/font_color = Color(0, 0.522189, 2.88785e-07, 1)
-theme_override_font_sizes/font_size = 48
+theme_override_font_sizes/font_size = 36
 text = "LifeStylist"
 
 [node name="VBoxContainer2" type="VBoxContainer" parent="MarginContainer"]
 layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 8
+theme_override_constants/separation = 16
 
 [node name="WeeklyCostLabel" type="Label" parent="MarginContainer/VBoxContainer2"]
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 8
 mouse_filter = 1
-theme_override_colors/font_color = Color(0, 0, 0, 1)
-theme_override_colors/font_outline_color = Color(0, 0, 0, 1)
 text = "Weekly Cost:"
 
 [node name="Footer" type="HBoxContainer" parent="MarginContainer/VBoxContainer2"]
@@ -74,13 +65,12 @@ unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 8
 size_flags_vertical = 10
+theme_override_constants/separation = 8
 
 [node name="DailyCostLabel" type="Label" parent="MarginContainer/VBoxContainer2/Footer"]
 unique_name_in_owner = true
 layout_mode = 2
 mouse_filter = 1
-theme_override_colors/font_color = Color(0, 0, 0, 1)
-theme_override_colors/font_outline_color = Color(0, 0, 0, 1)
 text = "Daily Cost (rent & insurance not included):"
 
 [node name="DailyCostCountdownLabel" type="Label" parent="MarginContainer/VBoxContainer2/Footer"]

--- a/components/apps/lifestylist/life_stylist.gd
+++ b/components/apps/lifestylist/life_stylist.gd
@@ -5,29 +5,38 @@ class_name LifeStylist
 @onready var weekly_cost_label: Label = %WeeklyCostLabel
 @onready var daily_cost_label: Label = %DailyCostLabel
 @onready var daily_countdown_label: Label = %DailyCostCountdownLabel
+@onready var header_label: Label = %HeaderLabel
 
 @export var lifestyle_row_scene: PackedScene
+
+# Exported colors to allow easy theme changes
+@export var background_color: Color = Color.hex("242424")
+@export var header_text_color: Color = Color.hex("ffffff")
+@export var text_color: Color = Color.hex("e0e0e0")
+@export var accent_color: Color = Color.hex("4caf50")
 
 var total_weekly_cost: int = 0
 
 func _ready():
-	TimeManager.minute_passed.connect(_on_minute_passed)
+        TimeManager.minute_passed.connect(_on_minute_passed)
+        _apply_theme()
 
-	# Create and configure each lifestyle row
-	for category in BillManager.lifestyle_options.keys():
-		var options = BillManager.get_lifestyle_options(category)
-		var row = lifestyle_row_scene.instantiate()
-		category_list.add_child(row)
-		row.setup(category, options)
-		row.option_changed.connect(_on_row_changed)
+        # Create and configure each lifestyle row
+        for category in BillManager.lifestyle_options.keys():
+                var options = BillManager.get_lifestyle_options(category)
+                var row = lifestyle_row_scene.instantiate()
+                row.text_color = text_color
+                category_list.add_child(row)
+                row.setup(category, options)
+                row.option_changed.connect(_on_row_changed)
 
-		# Set selection from BillManager or default to 0
-		var selected_index = BillManager.lifestyle_indices.get(category, 0)
-		selected_index = clamp(selected_index, 0, options.size() - 1)
-		row.dropdown.select(selected_index)
-		row._on_option_selected(selected_index)
+                # Set selection from BillManager or default to 0
+                var selected_index = BillManager.lifestyle_indices.get(category, 0)
+                selected_index = clamp(selected_index, 0, options.size() - 1)
+                row.dropdown.select(selected_index)
+                row._on_option_selected(selected_index)
 
-	_update_cost_labels()
+        _update_cost_labels()
 
 
 func _on_row_changed(category: String, option_index: int):
@@ -64,7 +73,19 @@ func _on_minute_passed(current_minutes: int):
 	var hours = minutes_remaining / 60
 	var mins = minutes_remaining % 60
 
-	daily_countdown_label.text = "Next bill in %02d:%02d" % [hours, mins]
+        daily_countdown_label.text = "Next bill in %02d:%02d" % [hours, mins]
+
+
+func _apply_theme():
+        var style := StyleBoxFlat.new()
+        style.bg_color = background_color
+        style.corner_radius_all = 8
+        add_theme_style_override("panel", style)
+
+        header_label.add_theme_color_override("font_color", header_text_color)
+        weekly_cost_label.add_theme_color_override("font_color", text_color)
+        daily_cost_label.add_theme_color_override("font_color", text_color)
+        daily_countdown_label.add_theme_color_override("font_color", accent_color)
 
 
 func _get_row_by_category(category_name: String) -> LifestyleRow:

--- a/components/apps/lifestylist/lifestyle_row.gd
+++ b/components/apps/lifestylist/lifestyle_row.gd
@@ -3,6 +3,7 @@ class_name LifestyleRow
 
 @export var category_name: String
 @export var spending_options: Array = []
+@export var text_color: Color = Color.hex("e0e0e0")
 
 @onready var label: Label = %Label
 @onready var dropdown: OptionButton = %Dropdown
@@ -13,14 +14,19 @@ class_name LifestyleRow
 signal option_changed(category: String, option_index: int)
 
 func _ready():
-	var popup = %Dropdown.get_popup()
-	popup.add_theme_font_size_override("font_size", 12)
+        var popup = %Dropdown.get_popup()
+        popup.add_theme_font_size_override("font_size", 14)
 
-	label.text = category_name
-	for option in spending_options:
-		dropdown.add_item(option["name"])
+        label.add_theme_color_override("font_color", text_color)
+        dropdown.add_theme_color_override("font_color", text_color)
+        cost_label.add_theme_color_override("font_color", text_color)
+        effects_label.add_theme_color_override("font_color", text_color)
 
-	dropdown.connect("item_selected", _on_option_selected)
+        label.text = category_name
+        for option in spending_options:
+                dropdown.add_item(option["name"])
+
+        dropdown.connect("item_selected", _on_option_selected)
 
 func setup(category: String, options: Array):
 	category_name = category

--- a/components/apps/lifestylist/lifestyle_row.tscn
+++ b/components/apps/lifestylist/lifestyle_row.tscn
@@ -8,29 +8,26 @@ anchor_right = 1.0
 offset_bottom = 16.0
 grow_horizontal = 2
 size_flags_horizontal = 3
-theme_override_constants/separation = 20
+theme_override_constants/separation = 16
 script = ExtResource("1_k3nky")
+layout_mode = 2
 
 [node name="Label" type="Label" parent="."]
 unique_name_in_owner = true
 layout_mode = 2
-theme_override_colors/font_color = Color(0, 0, 0, 1)
 text = "Category"
 
 [node name="Dropdown" type="OptionButton" parent="."]
 unique_name_in_owner = true
 layout_mode = 2
-theme_override_colors/font_color = Color(0, 0, 0, 1)
-theme_override_font_sizes/font_size = 12
+theme_override_font_sizes/font_size = 14
 
 [node name="CostLabel" type="Label" parent="."]
 unique_name_in_owner = true
 layout_mode = 2
-theme_override_colors/font_color = Color(0, 0, 0, 1)
 text = "$cost"
 
 [node name="EffectsLabel" type="Label" parent="."]
 unique_name_in_owner = true
 layout_mode = 2
-theme_override_colors/font_color = Color(0, 0, 0, 1)
 text = "effects"


### PR DESCRIPTION
## Summary
- Modernize LifeStylist UI with configurable colors and flat styling
- Streamline layout spacing for a cleaner look across app scenes
- Provide exported text color for lifestyle rows

## Testing
- `godot3 --headless -s tests/test_runner.gd` *(fails: project requires newer Godot engine)*

------
https://chatgpt.com/codex/tasks/task_e_68adfa72ca8c83258df3ff21157859d7