### PR TITLE
Fix brokerage stock popup spacing and scroll handling

### DIFF
--- a/components/apps/broke_rage/broke_rage_ui.gd
+++ b/components/apps/broke_rage/broke_rage_ui.gd
@@ -26,16 +26,17 @@ class_name BrokeRage
 var stock_popup_scene: PackedScene = preload("res://components/popups/stock_popup_ui.tscn")
 
 func _ensure_charts_content() -> Control:
-	var existing: Node = charts_view.get_node_or_null("ChartsContent")
-	if existing != null and existing is Control:
-		return existing as Control
+        var existing: Node = charts_view.get_node_or_null("ChartsContent")
+        if existing != null and existing is Control:
+                return existing as Control
 
-	var content: VBoxContainer = VBoxContainer.new()
-	content.name = "ChartsContent"
-	content.size_flags_horizontal = Control.SIZE_EXPAND_FILL
-	content.size_flags_vertical = Control.SIZE_EXPAND_FILL
-	charts_view.add_child(content)
-	return content
+        var content: VBoxContainer = VBoxContainer.new()
+        content.name = "ChartsContent"
+        content.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+        content.size_flags_vertical = Control.SIZE_EXPAND_FILL
+        content.add_theme_constant_override("separation", 16)
+        charts_view.add_child(content)
+        return content
 
 
 
@@ -164,29 +165,15 @@ func _on_charts_tab_pressed() -> void:
 
 
 func _build_charts_view() -> void:
-	# Only clear dynamic chart content, not the tab buttons or labels.
-	for child: Node in charts_content.get_children():
-		child.queue_free()
+        # Only clear dynamic chart content, not the tab buttons or labels.
+        for child: Node in charts_content.get_children():
+                child.queue_free()
 
-	var container: Control = null
-
-	for symbol: String in MarketManager.stock_market.keys():
-			var stock: Stock = MarketManager.get_stock(symbol)
-			var popup: StockPopupUI = stock_popup_scene.instantiate()
-			popup.custom_minimum_size = Vector2(350, 150)
-			popup.size_flags_horizontal = Control.SIZE_EXPAND_FILL
-			popup.size_flags_vertical = Control.SIZE_EXPAND_FILL
-			popup.setup(stock)
-
-			if container == null:
-					container = popup
-			else:
-					var split: VSplitContainer = VSplitContainer.new()
-					split.size_flags_horizontal = Control.SIZE_EXPAND_FILL
-					split.size_flags_vertical = Control.SIZE_EXPAND_FILL
-					split.add_child(container)
-					split.add_child(popup)
-					container = split
-
-	if container != null:
-		charts_content.add_child(container)
+        for symbol: String in MarketManager.stock_market.keys():
+                var stock: Stock = MarketManager.get_stock(symbol)
+                var popup: StockPopupUI = stock_popup_scene.instantiate()
+                popup.custom_minimum_size = Vector2(350, 150)
+                popup.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+                popup.size_flags_vertical = Control.SIZE_EXPAND_FILL
+                popup.setup(stock)
+                charts_content.add_child(popup)

--- a/components/popups/stock_popup_ui.gd
+++ b/components/popups/stock_popup_ui.gd
@@ -36,15 +36,22 @@ func setup(_stock: Stock) -> void:
 	MarketManager.stock_price_updated.connect(_on_stock_price_updated)
 
 func _ready() -> void:
-	super._ready()
-	buy_button.pressed.connect(_on_buy_pressed)
-	sell_button.pressed.connect(_on_sell_pressed)
+        super._ready()
+        buy_button.pressed.connect(_on_buy_pressed)
+        sell_button.pressed.connect(_on_sell_pressed)
+
+func _gui_input(event: InputEvent) -> void:
+        if event is InputEventMouseButton:
+                if event.button_index == MOUSE_BUTTON_WHEEL_UP or event.button_index == MOUSE_BUTTON_WHEEL_DOWN:
+                        accept_event()
+        elif event is InputEventPanGesture:
+                accept_event()
 
 func _on_stock_price_updated(symbol: String, updated_stock: Stock) -> void:
-	if stock == null or updated_stock.symbol != stock.symbol:
-		return
-	stock = updated_stock
-	_update_ui()
+        if stock == null or updated_stock.symbol != stock.symbol:
+                return
+        stock = updated_stock
+        _update_ui()
 
 func _update_ui() -> void:
 	window_title = str(stock.symbol) + " " + str(stock.price)


### PR DESCRIPTION
## Summary
- Arrange brokerage stock popups in a VBox with separation to prevent overlapping buttons
- Consume mouse wheel and pan gestures in StockPopupUI so scrolling over a popup doesn't move parent scroll boxes

## Testing
- `godot --headless tests/test_runner.tscn` *(fails: missing imported resources and parse errors)*

------
https://chatgpt.com/codex/tasks/task_e_68adfc2888e8832595154379fef0bdb3