### PR TITLE
Add Fumble upgrades and NPC dislikes

### DIFF
--- a/components/apps/fumble/fumble_battle/battle_logic.gd
+++ b/components/apps/fumble/fumble_battle/battle_logic.gd
@@ -50,13 +50,27 @@ func get_success_chance(move_type: String) -> float:
 				var self_esteem_bonus = max(0, 50 - self_esteem) * 0.01
 				return clamp(chance + self_esteem_bonus, 0.0, 1.0)
 
-	var base_chance = 0.5 + (get_attractiveness_delta() / 10.0)
-	if move_type == "simp":
-		base_chance = 0.65 + (get_attractiveness_delta() / 10.0)
+        var base_chance = 0.5 + (get_attractiveness_delta() / 10.0)
+        if move_type == "simp":
+                base_chance = 0.65 + (get_attractiveness_delta() / 10.0)
 
-	var type_chance_adj = RizzBattleData.get_type_mod_chance_adjust(npc_type, move_type)
+        var type_chance_adj = RizzBattleData.get_type_mod_chance_adjust(npc_type, move_type)
+        var chance = base_chance + type_chance_adj
 
-	return clamp(base_chance + type_chance_adj, 0.0, 1.0)
+        if UpgradeManager.get_level("fumble_my_type") > 0:
+                var player_type = PlayerManager.get_var("fumble_type", "")
+                if player_type != "" and player_type == npc.chat_battle_type:
+                        chance += 0.1
+        if UpgradeManager.get_level("fumble_shared_hobbies") > 0:
+                var player_like = PlayerManager.get_var("fumble_like", "")
+                if player_like != "" and npc.likes.has(player_like):
+                        chance += 0.1
+        if UpgradeManager.get_level("fumble_hate_bonding") > 0:
+                var player_dislike = PlayerManager.get_var("fumble_dislike", "")
+                if player_dislike != "" and npc.dislikes != null and npc.dislikes.has(player_dislike):
+                        chance += 0.1
+
+        return clamp(chance, 0.0, 1.0)
 
 
 

--- a/components/apps/fumble/fumble_profile.gd
+++ b/components/apps/fumble/fumble_profile.gd
@@ -14,6 +14,8 @@ extends PanelContainer
 @onready var type_label: Label = %TypeLabel
 @onready var likes_container: Control = %LikesContainer
 @onready var likes_label: Label = %LikesLabel
+@onready var dislikes_container: Control = %DislikesContainer
+@onready var dislikes_label: Label = %DislikesLabel
 @onready var tags_container: Control = %TagsContainer
 @onready var tags_label: Label = %TagsLabel
 @onready var bio_text: RichTextLabel = %BioText
@@ -28,6 +30,7 @@ extends PanelContainer
 @onready var neuroticism_value: Label = %NeuroticismValue
 
 @onready var likes_section: VBoxContainer = %LikesSection
+@onready var dislikes_section: VBoxContainer = %DislikesSection
 @onready var tags_section: VBoxContainer = %TagsSection
 @onready var bio_panel: PanelContainer = %BioPanel
 @onready var greek_panel: PanelContainer = %GreekPanel
@@ -36,14 +39,15 @@ extends PanelContainer
 # Updated: astrology_row / wealth_row don’t exist in your scene,
 # so we animate the value labels instead.
 @onready var sections: Array[Control] = [
-		dime_status_label,
-		name_label,
-		type_label,
-		likes_section,
-		tags_section,
-		bio_panel,
-		stats_grid,
-		greek_panel
+                dime_status_label,
+                name_label,
+                type_label,
+                likes_section,
+                dislikes_section,
+                tags_section,
+                bio_panel,
+                stats_grid,
+                greek_panel
 ]
 
 
@@ -66,12 +70,13 @@ func load_npc(npc: NPC, npc_idx: int = -1) -> void:
 		dime_status = "🔥 %0.1f/10" % (float(npc.attractiveness) / 10.0)
 	dime_status_label.text = dime_status
 
-	name_label.text = npc.full_name
-	type_label.text = str(npc.chat_battle_type)
+        name_label.text = npc.full_name
+        type_label.text = str(npc.chat_battle_type)
 
-	_populate_likes(npc)
-	_populate_tags(npc)
-	_populate_bio(npc)
+        _populate_likes(npc)
+        _populate_dislikes(npc)
+        _populate_tags(npc)
+        _populate_bio(npc)
 	_populate_astrology(npc)
 	_populate_greek(npc)
 	_populate_wealth(npc)
@@ -93,8 +98,9 @@ func _apply_colors() -> void:
 	dime_status_label.modulate = label_color
 	name_label.modulate = label_color
 	type_label.modulate = label_color
-	likes_label.modulate = label_color
-	tags_label.modulate = label_color
+        likes_label.modulate = label_color
+        dislikes_label.modulate = label_color
+        tags_label.modulate = label_color
 
 	bio_text.modulate = value_color
 	astrology_value.modulate = value_color
@@ -118,7 +124,20 @@ func _populate_likes(npc: NPC) -> void:
 				var none_label: Label = Label.new()
 				none_label.text = "No likes listed"
 				none_label.modulate = none_label_color
-				likes_container.add_child(none_label)
+                                likes_container.add_child(none_label)
+
+func _populate_dislikes(npc: NPC) -> void:
+        dislikes_label.text = "Dislikes"
+        _clear_children(dislikes_container)
+        if npc.dislikes != null and npc.dislikes.size() > 0:
+                for dislike in npc.dislikes:
+                        var pill: Control = _make_like_pill(_safe_str(dislike))
+                        dislikes_container.add_child(pill)
+        else:
+                var none_label: Label = Label.new()
+                none_label.text = "No dislikes listed"
+                none_label.modulate = none_label_color
+                dislikes_container.add_child(none_label)
 
 func _populate_tags(npc: NPC) -> void:
 		tags_label.text = "Tags"

--- a/components/apps/fumble/fumble_profile_ui.tscn
+++ b/components/apps/fumble/fumble_profile_ui.tscn
@@ -108,6 +108,25 @@ layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 2
 
+[node name="DislikesSection" type="VBoxContainer" parent="Margin/Scroll/VBox/HBoxContainer2"]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 3
+theme_override_constants/separation = 4
+
+[node name="DislikesLabel" type="Label" parent="Margin/Scroll/VBox/HBoxContainer2/DislikesSection"]
+unique_name_in_owner = true
+layout_mode = 2
+theme_override_colors/font_color = Color(0, 0, 0, 1)
+theme_override_font_sizes/font_size = 14
+text = "Dislikes"
+
+[node name="DislikesContainer" type="FlowContainer" parent="Margin/Scroll/VBox/HBoxContainer2/DislikesSection"]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 2
+
 [node name="TagsSection" type="VBoxContainer" parent="Margin/Scroll/VBox/HBoxContainer2"]
 unique_name_in_owner = true
 layout_mode = 2

--- a/components/npc/npc.gd
+++ b/components/npc/npc.gd
@@ -64,6 +64,7 @@ var wealth: int
 # === Tags / Attributes ===
 @export var tags: Array[String] = ["alive"]
 @export var likes: Array[String] = []
+@export var dislikes: Array[String] = []
 
 @export var fumble_bio: String
 
@@ -188,9 +189,10 @@ func to_dict() -> Dictionary:
 		"delta": delta,
 		"omega": omega,
 		"sigma": sigma,
-		"tags": tags.duplicate(),
-		"likes": likes.duplicate(),
-		"fumble_bio": fumble_bio,
+                "tags": tags.duplicate(),
+                "likes": likes.duplicate(),
+                "dislikes": dislikes.duplicate(),
+                "fumble_bio": fumble_bio,
 		"self_esteem": self_esteem,
 		"apprehension": apprehension,
 		"chemistry": chemistry,
@@ -291,9 +293,10 @@ static func from_dict(data: Dictionary) -> NPC:
 	npc.delta = _safe_float(data.get("delta"))
 	npc.omega = _safe_float(data.get("omega"))
 	npc.sigma = _safe_float(data.get("sigma"))
-	_assign_string_array(npc.tags, data.get("tags"), ["alive"])
-	_assign_string_array(npc.likes, data.get("likes"))
-	npc.fumble_bio  = _safe_string(data.get("fumble_bio"))
+        _assign_string_array(npc.tags, data.get("tags"), ["alive"])
+        _assign_string_array(npc.likes, data.get("likes"))
+        _assign_string_array(npc.dislikes, data.get("dislikes"))
+        npc.fumble_bio  = _safe_string(data.get("fumble_bio"))
 	npc.self_esteem = _safe_int(data.get("self_esteem"), 70)
 	npc.apprehension= _safe_int(data.get("apprehension"), 50)
 	npc.chemistry= _safe_int(data.get("chemistry"), 0)

--- a/data/upgrades/fumble_hate_bonding.json
+++ b/data/upgrades/fumble_hate_bonding.json
@@ -1,0 +1,14 @@
+{
+  "id": "fumble_hate_bonding",
+  "name": "Hate Bonding",
+  "description": "Increases action success chance when you share a dislike with an NPC.",
+  "effects": [],
+  "systems": ["fumble"],
+  "dependencies": [],
+  "cost_per_level": {
+    "ex": 10
+  },
+  "max_level": 1,
+  "repeatable": false,
+  "scale_by_formula": false
+}

--- a/data/upgrades/fumble_my_type.json
+++ b/data/upgrades/fumble_my_type.json
@@ -1,0 +1,14 @@
+{
+  "id": "fumble_my_type",
+  "name": "My Type",
+  "description": "Increases action success chance when your type matches theirs.",
+  "effects": [],
+  "systems": ["fumble"],
+  "dependencies": [],
+  "cost_per_level": {
+    "ex": 10
+  },
+  "max_level": 1,
+  "repeatable": false,
+  "scale_by_formula": false
+}

--- a/data/upgrades/fumble_shared_hobbies.json
+++ b/data/upgrades/fumble_shared_hobbies.json
@@ -1,0 +1,14 @@
+{
+  "id": "fumble_shared_hobbies",
+  "name": "Shared Hobbies",
+  "description": "Increases action success chance when you share a like with an NPC.",
+  "effects": [],
+  "systems": ["fumble"],
+  "dependencies": [],
+  "cost_per_level": {
+    "ex": 10
+  },
+  "max_level": 1,
+  "repeatable": false,
+  "scale_by_formula": false
+}


### PR DESCRIPTION
## Summary
- Add three 10 EX Fumble upgrades: My Type, Shared Hobbies, and Hate Bonding
- Implement NPC dislikes and show them beside likes in Fumble profile UI
- Boost Fumble action success when matching type, like, or dislike

## Testing
- `godot3 --headless --run tests/test_runner.tscn` *(fails: project requires newer Godot version)*

------
https://chatgpt.com/codex/tasks/task_e_68ae020694a08325b7d382bf3a63f1bb