### PR TITLE
Add close context menu for taskbar icons

### DIFF
--- a/autoloads/window_manager.gd
+++ b/autoloads/window_manager.gd
@@ -262,6 +262,20 @@ func _create_taskbar_icon(window: WindowFrame) -> Button:
 	icon_button.focus_mode = Control.FOCUS_NONE
 	icon_button.theme = get_tree().root.theme
 
+	var wm := self
+	icon_button.gui_input.connect(func(event):
+		if event is InputEventMouseButton:
+			var mb: InputEventMouseButton = event
+			if mb.button_index == MOUSE_BUTTON_RIGHT and mb.pressed:
+				var action_close: ContextAction = ContextAction.new()
+				action_close.id = 0
+				action_close.label = "Close"
+				action_close.method = "close_window"
+				action_close.args = [window]
+				ContextMenuManager.open_for(wm, mb.global_position, [action_close])
+				icon_button.accept_event()
+	)
+
 	icon_button.pressed.connect(func():
 		if window.visible and focused_window == window:
 			var center = icon_button.get_global_position() + icon_button.size / 2


### PR DESCRIPTION
## Summary
- add right-click context menu with a Close option to taskbar icons so users can close windows from the taskbar

## Testing
- `godot --headless --path . tests/test_runner.tscn` *(fails: Could not find type "ContextAction" in the current scope)*

------
https://chatgpt.com/codex/tasks/task_e_68ae041f076c83259296799366f1e9df