### PR TITLE
Add dislikes column to NPC database schema

### DIFF
--- a/autoloads/db_manager.gd
+++ b/autoloads/db_manager.gd
@@ -38,9 +38,10 @@ const SCHEMA: Dictionary = {
 		"delta": {"data_type": "real"},
 		"omega": {"data_type": "real"},
 		"sigma": {"data_type": "real"},
-		"tags": {"data_type": "text"},
-		"likes": {"data_type": "text"},
-		"fumble_bio": {"data_type": "text"},
+                "tags": {"data_type": "text"},
+                "likes": {"data_type": "text"},
+                "dislikes": {"data_type": "text"},
+                "fumble_bio": {"data_type": "text"},
 		"self_esteem": {"data_type": "int"},
 		"apprehension": {"data_type": "int"},
 		"chemistry": {"data_type": "int"},
@@ -130,9 +131,10 @@ func save_npc(idx: int, npc: NPC, slot_id: int = SaveManager.current_slot_id):
 		dict["claimed_serious_monog_boost"] = 0
 	# Serialize all complex fields as JSON
 	dict["gender_vector"] = to_json(dict.get("gender_vector", {"x":0,"y":0,"z":1}))
-	dict["tags"] = to_json(dict.get("tags", []))
-	dict["likes"] = to_json(dict.get("likes", []))
-	dict["preferred_pet_names"] = to_json(dict.get("preferred_pet_names", []))
+        dict["tags"] = to_json(dict.get("tags", []))
+        dict["likes"] = to_json(dict.get("likes", []))
+        dict["dislikes"] = to_json(dict.get("dislikes", []))
+        dict["preferred_pet_names"] = to_json(dict.get("preferred_pet_names", []))
 	dict["player_pet_names"] = to_json(dict.get("player_pet_names", []))
 	dict["ocean"] = to_json(dict.get("ocean", {}))
 	dict["wall_posts"] = to_json(dict.get("wall_posts", []))
@@ -157,9 +159,10 @@ func load_npc(idx: int, slot_id: int = SaveManager.current_slot_id) -> NPC:
 	var row = result[0]
 	# Deserialize JSON fields safely
 	row["gender_vector"] = _safe_from_json(row.get("gender_vector", null), '{"x":0,"y":0,"z":1}')
-	row["tags"] = _safe_from_json(row.get("tags", null), "[]")
-	row["likes"] = _safe_from_json(row.get("likes", null), "[]")
-	row["preferred_pet_names"] = _safe_from_json(row.get("preferred_pet_names", null), "[]")
+        row["tags"] = _safe_from_json(row.get("tags", null), "[]")
+        row["likes"] = _safe_from_json(row.get("likes", null), "[]")
+        row["dislikes"] = _safe_from_json(row.get("dislikes", null), "[]")
+        row["preferred_pet_names"] = _safe_from_json(row.get("preferred_pet_names", null), "[]")
 	row["player_pet_names"] = _safe_from_json(row.get("player_pet_names", null), "[]")
 	row["ocean"] = _safe_from_json(row.get("ocean", null), "{}")
 	row["wall_posts"] = _safe_from_json(row.get("wall_posts", null), "[]")
@@ -171,9 +174,10 @@ func get_all_npcs_for_slot(slot_id: int = SaveManager.current_slot_id) -> Array:
 	var out: Array = []
 	for row in raw_rows:
 		row["gender_vector"] = _safe_from_json(row.get("gender_vector", null), '{"x":0,"y":0,"z":1}')
-		row["tags"] = _safe_from_json(row.get("tags", null), "[]")
-		row["likes"] = _safe_from_json(row.get("likes", null), "[]")
-		row["preferred_pet_names"] = _safe_from_json(row.get("preferred_pet_names", null), "[]")
+                row["tags"] = _safe_from_json(row.get("tags", null), "[]")
+                row["likes"] = _safe_from_json(row.get("likes", null), "[]")
+                row["dislikes"] = _safe_from_json(row.get("dislikes", null), "[]")
+                row["preferred_pet_names"] = _safe_from_json(row.get("preferred_pet_names", null), "[]")
 		row["player_pet_names"] = _safe_from_json(row.get("player_pet_names", null), "[]")
 		row["ocean"] = _safe_from_json(row.get("ocean", null), "{}")
 		row["wall_posts"] = _safe_from_json(row.get("wall_posts", null), "[]")


### PR DESCRIPTION
## Summary
- store NPC dislikes in SQLite schema
- serialize and deserialize dislikes alongside likes

## Testing
- `godot4 --headless --script tests/test_runner.gd` *(fails: command not found)*
- `apt-get install -y godot` *(fails: Unable to locate package godot)*

------
https://chatgpt.com/codex/tasks/task_e_68ae0ebe7e6083259e1a1d460180b9f0