### PR TITLE
Handle randomfirstname tag

### DIFF
--- a/autoloads/markup_parser.gd
+++ b/autoloads/markup_parser.gd
@@ -82,11 +82,12 @@ func _resolve_tag(tag: String, npc: Object, context: Dictionary) -> String:
 		var npc_val_lc = _get_any(npc, tag_lc)
 		if npc_val_lc != null:
 			return str(npc_val_lc)
-	# 3. Special tags: Random first/last name (use NameManager singleton)
-	if tag_lc == "random_first_name":
-		return NameManager.get_random_first_name() if NameManager.has_method("get_random_first_name") else "FirstName"
-	if tag_lc == "random_last_name":
-		return NameManager.get_random_last_name() if NameManager.has_method("get_random_last_name") else "LastName"
+       # 3. Special tags: Random first/last name (use NameManager singleton)
+       var tag_flat = tag_lc.replace("_", "")
+       if tag_flat == "randomfirstname":
+               return NameManager.get_random_first_name() if NameManager.has_method("get_random_first_name") else "FirstName"
+       if tag_flat == "randomlastname":
+               return NameManager.get_random_last_name() if NameManager.has_method("get_random_last_name") else "LastName"
 	# 4. Search global sources (PlayerManager, etc)
 	for src in _global_sources:
 		var val = _get_any(src, tag)

--- a/tests/randomfirstname_parse_test.gd
+++ b/tests/randomfirstname_parse_test.gd
@@ -1,0 +1,8 @@
+extends SceneTree
+
+func _ready() -> void:
+    var parsed := MarkupParser.parse("Hello {randomfirstname}", null)
+    assert(parsed.find("{randomfirstname}") == -1)
+    assert(parsed != "Hello ?")
+    print("randomfirstname_parse_test passed")
+    quit()


### PR DESCRIPTION
## Summary
- support `{randomfirstname}` and `{randomlastname}` tags in markup parser
- add regression test for `{randomfirstname}` parsing

## Testing
- `godot3 --headless --path . --script tests/test_runner.gd` *(fails: Can't open project at '/workspace/SigmaSim/project.godot', its `config_version` (5) is from a more recent and incompatible version of the engine. Expected config version: 4.)*
- `/tmp/godot/Godot_v4.2.1-stable_linux.x86_64 --headless --path . --run tests/test_runner.tscn` *(fails: resources missing; project not imported)*

------
https://chatgpt.com/codex/tasks/task_e_68ae0e8cb6a083259bee85461891ebf8