### PR TITLE
Fix ExFactor random first name tag parsing

### DIFF
--- a/data/npc_data/exfactor/eXFactorQuips.json
+++ b/data/npc_data/exfactor/eXFactorQuips.json
@@ -42,7 +42,7 @@
 		"exclusivity": "poly",
 		"prefix": "Awww, ",
 		"core": "thank you",
-		"suffix": "! I'll wear that when I go out with {random first_name} tomorrow."
+                "suffix": "! I'll wear that when I go out with {random_first_name} tomorrow."
 	},
 	{
 		"type": "any",
@@ -78,7 +78,7 @@
 		"exclusivity": "poly",
 		"prefix": "",
 		"core": "That was even better than ",
-		"suffix": "{random first_name} last night!"
+                "suffix": "{random_first_name} last night!"
 	},
 	{
 		"type": "any",
@@ -87,7 +87,7 @@
 		"exclusivity": "poly",
 		"prefix": "",
 		"core": "That was incredible",
-		"suffix": ". By the way, {random first_name} is coming over later!"
+                "suffix": ". By the way, {random_first_name} is coming over later!"
 	},
 	{
 		"type": "any",

--- a/tests/randomfirstname_parse_test.gd
+++ b/tests/randomfirstname_parse_test.gd
@@ -1,9 +1,14 @@
 extends SceneTree
 
 func _ready() -> void:
-    var parsed := MarkupParser.parse("Hello {randomfirstname}", null)
-    assert(parsed.find("{randomfirstname}") == -1)
-    assert(parsed != "Hello FirstName")
-    assert(parsed != "Hello ?")
-    print("randomfirstname_parse_test passed")
+    var parsed1 := MarkupParser.parse("Hello {randomfirstname}", null)
+    assert(parsed1.find("{randomfirstname}") == -1)
+    assert(parsed1 != "Hello FirstName")
+    assert(parsed1 != "Hello ?")
+
+    var parsed2 := MarkupParser.parse("Hello {random_first_name}", null)
+    assert(parsed2.find("{random_first_name}") == -1)
+    assert(parsed2 != "Hello FirstName")
+    assert(parsed2 != "Hello ?")
+    print("random firstname variants parse test passed")
     quit()


### PR DESCRIPTION
## Summary
- fix random first name placeholders in ExFactor quips
- test parsing of both `{randomfirstname}` and `{random_first_name}` tags

## Testing
- `godot3-server --headless --script tests/randomfirstname_parse_test.gd` *(fails: Can't open project; requires newer Godot version)*

------
https://chatgpt.com/codex/tasks/task_e_68ae157847b48325a8d7941a945fbf42