### PR TITLE
Use NumberFormatter for bill popup cash values

### DIFF
--- a/components/popups/bill_popup_ui.gd
+++ b/components/popups/bill_popup_ui.gd
@@ -31,13 +31,14 @@ func init(name: String) -> void:
 	_update_display()
 
 func _update_display() -> void:
-	if is_instance_valid(bill_label):
-		bill_label.text = "%s\n$%.2f" % [bill_name, amount]
-	if is_instance_valid(interest_label):
-		interest_label.text = "Paying with credit will cost $%.2f total at %.0f%% interest" % [
-			amount * (1.0 + PortfolioManager.credit_interest_rate),
-			PortfolioManager.credit_interest_rate * 100
-		]
+       if is_instance_valid(bill_label):
+               bill_label.text = "%s\n$%s" % [bill_name, NumberFormatter.format_commas(amount)]
+       if is_instance_valid(interest_label):
+               var total := amount * (1.0 + PortfolioManager.credit_interest_rate)
+               interest_label.text = "Paying with credit will cost $%s total at %.0f%% interest" % [
+                       NumberFormatter.format_commas(total),
+                       PortfolioManager.credit_interest_rate * 100
+               ]
 
 
 func update_amount_display() -> void:


### PR DESCRIPTION
## Summary
- format bill amount and credit total with `NumberFormatter.format_commas`

## Testing
- `/tmp/godot4/Godot_v4.2.1-stable_linux.x86_64 --headless --path . tests/test_runner.tscn` *(fails: missing resources and base classes)*

------
https://chatgpt.com/codex/tasks/task_e_68ae2ac0519c83259a7813f9cdf448e6