### PR TITLE
Stop showing decimals for large numbers

### DIFF
--- a/autoloads/number_formatter.gd
+++ b/autoloads/number_formatter.gd
@@ -9,6 +9,8 @@ const LONG_UNITS = [
 
 # Add commas: 1,234,567.89
 static func format_commas(number: float, decimals: int = 2, hide_trailing_zeroes: bool = false) -> String:
+	if abs(number) >= 1000:
+		decimals = 0
 	var s = "%.*f" % [decimals, number]
 	var int_part = s.split(".")[0]
 	var frac_part = ""

--- a/tests/number_formatter_format_commas_test.gd
+++ b/tests/number_formatter_format_commas_test.gd
@@ -1,0 +1,9 @@
+extends SceneTree
+
+func _ready() -> void:
+    var below := NumberFormatter.format_commas(999.99, 2)
+    assert(below == "999.99")
+    var above := NumberFormatter.format_commas(1000.12, 2)
+    assert(above == "1,000")
+    print("number_formatter_format_commas_test passed")
+    quit()


### PR DESCRIPTION
## Summary
- avoid decimal places in NumberFormatter.format_commas when value is 1,000 or more
- add test covering decimal suppression for large numbers

## Testing
- `godot_v4.2.1-stable_linux.x86_64 --headless --path . -s tests/test_runner.gd` *(fails: Can't load the script "tests/test_runner.gd" as it doesn't inherit from SceneTree or MainLoop)*

------
https://chatgpt.com/codex/tasks/task_e_68ae2ae719a883259b47e8ed64603d72