### PR TITLE
Add daily market surge and crash events

### DIFF
--- a/resources/market_events/generic_asset_crash.tres
+++ b/resources/market_events/generic_asset_crash.tres
@@ -1,0 +1,18 @@
+[gd_resource type="Resource" script_class="MarketEvent" load_steps=2 format=3 uid="uid://genericassetcrash"]
+
+[ext_resource type="Script" uid="uid://tfwk2nll7534" path="res://resources/market_events/market_event.gd" id="1"]
+
+[resource]
+script = ExtResource("1")
+target_symbol = ""
+target_type = "stock"
+start_min_minutes = 0
+start_max_minutes = 0
+pump_duration_min = 60
+pump_duration_max = 1440
+pump_multiplier_min = 0.5
+pump_multiplier_max = 0.9
+dump_duration_min = 0
+dump_duration_max = 0
+dump_multiplier_min = 1.0
+dump_multiplier_max = 1.0

--- a/resources/market_events/generic_asset_surge.tres
+++ b/resources/market_events/generic_asset_surge.tres
@@ -1,0 +1,18 @@
+[gd_resource type="Resource" script_class="MarketEvent" load_steps=2 format=3 uid="uid://genericassetsurge"]
+
+[ext_resource type="Script" uid="uid://tfwk2nll7534" path="res://resources/market_events/market_event.gd" id="1"]
+
+[resource]
+script = ExtResource("1")
+target_symbol = ""
+target_type = "stock"
+start_min_minutes = 0
+start_max_minutes = 0
+pump_duration_min = 60
+pump_duration_max = 1440
+pump_multiplier_min = 1.2
+pump_multiplier_max = 3.0
+dump_duration_min = 0
+dump_duration_max = 0
+dump_multiplier_min = 1.0
+dump_multiplier_max = 1.0


### PR DESCRIPTION
## Summary
- Introduce generic_asset_surge and generic_asset_crash market events
- Schedule a random surge or crash on one crypto and one stock every day at 9 AM

## Testing
- `godot4 --headless --script tests/test_runner.gd` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae2cb2fd048325b25a739060726c5b