### PR TITLE
Add crypto-specific upgrade UI with Big Blocks upgrade

### DIFF
--- a/components/apps/minerr/minerr_ui.gd
+++ b/components/apps/minerr/minerr_ui.gd
@@ -64,8 +64,10 @@ func update_gpu_label() -> void:
 
 func _on_open_upgrades(symbol: String) -> void:
 	print("Open upgrade panel for:", symbol)
-
-
+	var scene = preload("res://components/upgrade_scenes/crypto_upgrade_ui.tscn")
+	var pane: Pane = scene.instantiate()
+	pane.unique_popup_key = "crypto_upgrades_%s" % symbol
+	WindowManager.launch_pane_instance(pane, symbol)
 
 func _on_add_gpu(symbol: String) -> void:
 	if GPUManager.get_free_gpu_count() > 0:

--- a/components/upgrade_scenes/crypto_upgrade_ui.gd
+++ b/components/upgrade_scenes/crypto_upgrade_ui.gd
@@ -1,0 +1,45 @@
+extends Pane
+class_name CryptoUpgradeUI
+
+@onready var system_ui: SystemUpgradeUI = %SystemUpgradeUI
+
+var crypto_symbol: String = ""
+
+func setup_custom(symbol: String) -> void:
+    crypto_symbol = symbol
+    unique_popup_key = "crypto_upgrades_%s" % symbol
+    window_title = "%s Upgrades" % symbol
+    _ensure_upgrades()
+    system_ui.system_name = _get_system_name()
+    system_ui.refresh_upgrades()
+
+func _get_system_name() -> String:
+    return "crypto_%s" % crypto_symbol
+
+func _upgrade_id() -> String:
+    return "%s_big_blocks" % crypto_symbol
+
+func _ensure_upgrades() -> void:
+    var id = _upgrade_id()
+    if not UpgradeManager.upgrades.has(id):
+        var upgrade = {
+            "id": id,
+            "name": "Big Blocks",
+            "description": "Increase block size by 1",
+            "systems": [_get_system_name()],
+            "dependencies": [],
+            "max_level": -1,
+            "repeatable": true,
+            "cost_per_level": {crypto_symbol: 1},
+            "effects": [],
+        }
+        UpgradeManager.upgrades[id] = upgrade
+        Events.register_upgrade_signals([id])
+    if not Events.is_connected("%s_purchased" % id, Callable(self, "_on_big_blocks_purchased")):
+        Events.connect("%s_purchased" % id, Callable(self, "_on_big_blocks_purchased"))
+
+func _on_big_blocks_purchased(level: int) -> void:
+    var crypto: Cryptocurrency = MarketManager.crypto_market.get(crypto_symbol)
+    if crypto:
+        crypto.block_size += 1
+        MarketManager.crypto_price_updated.emit(crypto_symbol, crypto)

--- a/components/upgrade_scenes/crypto_upgrade_ui.tscn
+++ b/components/upgrade_scenes/crypto_upgrade_ui.tscn
@@ -1,0 +1,28 @@
+[gd_scene load_steps=3 format=3]
+
+[ext_resource type="Script" path="res://components/upgrade_scenes/crypto_upgrade_ui.gd" id="1"]
+[ext_resource type="PackedScene" path="res://data/upgrades/system_upgrade_ui.tscn" id="2"]
+
+[node name="CryptoUpgradeUI" type="PanelContainer"]
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+mouse_filter = 1
+script = ExtResource("1")
+window_title = "Crypto Upgrades"
+default_window_size = Vector2(480, 480)
+
+[node name="MarginContainer" type="MarginContainer" parent="."]
+layout_mode = 2
+theme_override_constants/margin_left = 15
+theme_override_constants/margin_top = 15
+theme_override_constants/margin_right = 15
+theme_override_constants/margin_bottom = 15
+
+[node name="SystemUpgradeUI" parent="MarginContainer" instance=ExtResource("2")]
+layout_mode = 2
+size_flags_vertical = 3

--- a/tests/crypto_big_blocks_upgrade_test.gd
+++ b/tests/crypto_big_blocks_upgrade_test.gd
@@ -1,0 +1,22 @@
+extends SceneTree
+
+func _ready() -> void:
+    await MarketManager.crypto_market_ready
+    var symbol := "BITC"
+    var crypto: Cryptocurrency = MarketManager.crypto_market[symbol]
+    var start_block := crypto.block_size
+    var owned_before := PortfolioManager.get_crypto_amount(symbol)
+    PortfolioManager.add_crypto(symbol, 1.0)
+    var scene = preload("res://components/upgrade_scenes/crypto_upgrade_ui.tscn")
+    var ui = scene.instantiate() as CryptoUpgradeUI
+    add_child(ui)
+    await ui.ready
+    ui.setup_custom(symbol)
+    var upgrade_id := "%s_big_blocks" % symbol
+    var pre_spend := PortfolioManager.get_crypto_amount(symbol)
+    var ok := UpgradeManager.purchase(upgrade_id)
+    assert(ok)
+    assert(crypto.block_size == start_block + 1)
+    assert(PortfolioManager.get_crypto_amount(symbol) == pre_spend - 1.0)
+    print("crypto_big_blocks_upgrade_test passed")
+    quit()


### PR DESCRIPTION
## Summary
- add `crypto_upgrade_ui` pane to handle per-crypto upgrades
- implement repeatable Big Blocks upgrade costing 1 of the crypto and increasing block size
- allow Minerr to open crypto upgrade windows
- add test for Big Blocks upgrade

## Testing
- `godot --headless --path . tests/test_runner.tscn` *(fails: Error opening file 'uid://gl0rjxkrh4wh')*

------
https://chatgpt.com/codex/tasks/task_e_68ae3c1c143883258f904d26a42c9e7c