### PR TITLE
Launch crypto upgrade UI from card's upgrade button

### DIFF
--- a/components/apps/minerr/crypto_card.gd
+++ b/components/apps/minerr/crypto_card.gd
@@ -4,7 +4,6 @@ class_name CryptoCard
 signal add_gpu(symbol: String)
 signal remove_gpu(symbol: String)
 signal overclock_toggled(symbol: String)
-signal open_upgrades(symbol: String)
 signal selected(symbol: String)
 
 @onready var symbol_label: Label = %SymbolLabel
@@ -55,8 +54,8 @@ func setup(crypto_data: Cryptocurrency) -> void:
 
 	add_gpu_button.pressed.connect(_emit_add_gpu)
 	remove_gpu_button.pressed.connect(_emit_remove_gpu)
-	overclock_button.pressed.connect(_emit_overclock_toggled)
-	upgrade_button.pressed.connect(_emit_open_upgrades)
+        overclock_button.pressed.connect(_emit_overclock_toggled)
+        upgrade_button.pressed.connect(_on_upgrade_button_pressed)
 	gui_input.connect(_on_card_gui_input)
 	sell_button.pressed.connect(_on_sell_pressed)
 
@@ -90,10 +89,13 @@ func _emit_overclock_toggled() -> void:
 		return
 	emit_signal("overclock_toggled", crypto.symbol)
 
-func _emit_open_upgrades() -> void:
-	if crypto == null:
-		return
-	emit_signal("open_upgrades", crypto.symbol)
+func _on_upgrade_button_pressed() -> void:
+        if crypto == null:
+                return
+        var scene = preload("res://components/upgrade_scenes/crypto_upgrade_ui.tscn")
+        var pane: Pane = scene.instantiate()
+        pane.unique_popup_key = "crypto_upgrades_%s" % crypto.symbol
+        WindowManager.launch_pane_instance(pane, crypto.symbol)
 
 func _on_card_gui_input(event: InputEvent) -> void:
 		if event is InputEventMouseButton and event.pressed:

--- a/components/apps/minerr/minerr_ui.gd
+++ b/components/apps/minerr/minerr_ui.gd
@@ -40,8 +40,7 @@ func refresh_cards_from_market() -> void:
 		# Connect card signals to Minerr handlers so buttons work.
 		card.add_gpu.connect(_on_add_gpu)
 		card.remove_gpu.connect(_on_remove_gpu)
-		card.overclock_toggled.connect(_on_toggle_overclock)
-		card.open_upgrades.connect(_on_open_upgrades)
+                card.overclock_toggled.connect(_on_toggle_overclock)
 		crypto_cards[crypto.symbol] = card
 	debug_dump_cards()
 func update_gpu_label() -> void:
@@ -61,13 +60,6 @@ func update_gpu_label() -> void:
 
 
 
-
-func _on_open_upgrades(symbol: String) -> void:
-	print("Open upgrade panel for:", symbol)
-	var scene = preload("res://components/upgrade_scenes/crypto_upgrade_ui.tscn")
-	var pane: Pane = scene.instantiate()
-	pane.unique_popup_key = "crypto_upgrades_%s" % symbol
-	WindowManager.launch_pane_instance(pane, symbol)
 
 func _on_add_gpu(symbol: String) -> void:
 	if GPUManager.get_free_gpu_count() > 0:


### PR DESCRIPTION
## Summary
- Open crypto upgrade UI directly from each card's Upgrade button using WindowManager.
- Remove obsolete open_upgrades signal handling from Minerr UI.

## Testing
- `godot --headless --run tests/test_runner.tscn` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae425f27a48325958c4275772853ea