### PR TITLE
Prevent credit card debt accrual on zero payment

### DIFF
--- a/components/apps/ower_view/debt_card_ui.gd
+++ b/components/apps/ower_view/debt_card_ui.gd
@@ -63,6 +63,7 @@ func update_slider() -> void:
 	if pay_slider.value > max_pay:
 		pay_slider.value = max_pay
 	slider_label.text = "$%.2f" % pay_slider.value
+	pay_button.disabled = max_pay <= 0.0
 
 func _on_slider_changed(value: float) -> void:
 	if not _is_ready:
@@ -73,5 +74,7 @@ func _on_pay_pressed() -> void:
 	if not _is_ready:
 		return
 	var amount: float = float(pay_slider.value)
+	if amount <= 0.0:
+		return
 	BillManager.pay_debt(String(resource_data.get("name", "")), amount)
 	update_display()

--- a/tests/credit_card_no_debt_pay_test.gd
+++ b/tests/credit_card_no_debt_pay_test.gd
@@ -1,0 +1,24 @@
+extends SceneTree
+
+func _ready():
+	var pm = Engine.get_singleton("PortfolioManager")
+	var bm = Engine.get_singleton("BillManager")
+	pm.reset()
+	bm.reset()
+	bm.add_debt_resource({
+		"name": "Credit Card",
+		"balance": 0.0,
+		"has_credit_limit": true,
+		"credit_limit": pm.credit_limit
+	})
+	pm.credit_used = 0.0
+	var card = preload("res://components/apps/ower_view/debt_card_ui.tscn").instantiate()
+	add_child(card)
+	card.init(bm.get_debt_resources()[0])
+	card._on_pay_pressed()
+	assert(pm.credit_used == 0.0)
+	var res = bm.get_debt_resources()[0]
+	assert(res.get("balance") == 0.0)
+	print("credit_card_no_debt_pay_test passed")
+	quit()
+


### PR DESCRIPTION
## Summary
- Guard against zero payments in debt card so paying with no credit card balance no longer creates debt
- Disable pay button when there's nothing to pay
- Add regression test covering zero-balance credit card payments

## Testing
- `godot3 --headless -s tests/test_runner.gd` *(fails: project's config_version 5 requires newer engine)*

------
https://chatgpt.com/codex/tasks/task_e_68ae79c849c483258477997464606c27