### PR TITLE
Add payday loan card with daily interest

### DIFF
--- a/autoloads/save_manager.gd
+++ b/autoloads/save_manager.gd
@@ -91,19 +91,28 @@ func initialize_new_profile(slot_id: int, user_data: Dictionary) -> void:
 	var starting_credit_limit = user_data.get("starting_credit_limit", 0.0)
 	PortfolioManager.set_credit_limit(starting_credit_limit)
 
-	BillManager.add_debt_resource({
-		"name": "Credit Card",
-		"balance": 0.0,
-		"has_credit_limit": true,
-		"credit_limit": starting_credit_limit
-	})
-	if starting_debt > 0.0:
-		BillManager.add_debt_resource({
-				"name": "Student Loan",
-				"balance": starting_debt,
-				"has_credit_limit": false,
-				"credit_limit": 0.0
-		})
+        BillManager.add_debt_resource({
+                "name": "Credit Card",
+                "balance": 0.0,
+                "has_credit_limit": true,
+                "credit_limit": starting_credit_limit
+        })
+        BillManager.add_debt_resource({
+                "name": "Payday Loan",
+                "balance": 0.0,
+                "has_credit_limit": false,
+                "credit_limit": 0.0,
+                "interest_rate": 2.0,
+                "can_borrow": true,
+                "borrow_limit": 1000.0
+        })
+        if starting_debt > 0.0:
+                BillManager.add_debt_resource({
+                                "name": "Student Loan",
+                                "balance": starting_debt,
+                                "has_credit_limit": false,
+                                "credit_limit": 0.0
+                })
 
 		MarketManager.init_new_save_events()
 		save_to_slot(slot_id)
@@ -228,10 +237,25 @@ func load_from_slot(slot_id: int) -> void:
 		WorkerManager.load_from_data(data["workers"])
 	if data.has("gpus"):
 			GPUManager.load_from_data(data["gpus"])
-	if data.has("bills"):
-		BillManager.load_from_data(data["bills"])
-	if data.has("desktop"):
-					DesktopLayoutManager.load_from_data(data["desktop"])
+        if data.has("bills"):
+                BillManager.load_from_data(data["bills"])
+                var has_payday := false
+                for res in BillManager.get_debt_resources():
+                        if res.get("name", "") == "Payday Loan":
+                                has_payday = true
+                                break
+                if not has_payday:
+                        BillManager.add_debt_resource({
+                                "name": "Payday Loan",
+                                "balance": 0.0,
+                                "has_credit_limit": false,
+                                "credit_limit": 0.0,
+                                "interest_rate": 2.0,
+                                "can_borrow": true,
+                                "borrow_limit": 1000.0
+                        })
+        if data.has("desktop"):
+                                        DesktopLayoutManager.load_from_data(data["desktop"])
 	if data.has("windows"):  # Always load windows last
 				WindowManager.load_from_data(data["windows"])
 	BillManager.is_loading = false

--- a/components/apps/ower_view/debt_card_ui.gd
+++ b/components/apps/ower_view/debt_card_ui.gd
@@ -8,15 +8,21 @@ class_name DebtCardUI
 @onready var pay_slider: HSlider = %PaySlider
 @onready var slider_label: Label = %SliderLabel
 @onready var pay_button: Button = %PayButton
+@onready var borrow_hbox: HBoxContainer = %BorrowHBox
+@onready var borrow_slider: HSlider = %BorrowSlider
+@onready var borrow_label: Label = %BorrowLabel
+@onready var borrow_button: Button = %BorrowButton
 
 var resource_data: Dictionary = {}
 var _is_ready: bool = false
 
 func _ready() -> void:
-	# Hook signals only when children are guaranteed to exist
-	pay_slider.value_changed.connect(_on_slider_changed)
-	pay_button.pressed.connect(_on_pay_pressed)
-	_is_ready = true
+        # Hook signals only when children are guaranteed to exist
+        pay_slider.value_changed.connect(_on_slider_changed)
+        pay_button.pressed.connect(_on_pay_pressed)
+        borrow_slider.value_changed.connect(_on_borrow_slider_changed)
+        borrow_button.pressed.connect(_on_borrow_pressed)
+        _is_ready = true
 
 	# If data was provided before _ready, reflect it now
 	if not resource_data.is_empty():
@@ -37,8 +43,8 @@ func update_display() -> void:
 	var balance: float = float(resource_data.get("balance", 0.0))
 	amount_label.text = "$" + NumberFormatter.format_commas(balance)
 
-	var credit_limit = resource_data.get("credit_limit")
-	var has_limit = credit_limit != null and float(credit_limit) > 0.0
+        var credit_limit = resource_data.get("credit_limit")
+        var has_limit = credit_limit != null and float(credit_limit) > 0.0
 	if has_limit:
 		var limit: float = float(credit_limit)
 		limit_bar.max_value = limit
@@ -46,11 +52,15 @@ func update_display() -> void:
 		limit_bar.visible = true
 		limit_label.text = "Limit: $" + NumberFormatter.format_commas(limit)
 		limit_label.visible = true
-	else:
-		limit_bar.visible = false
-		limit_label.visible = false
+        else:
+                limit_bar.visible = false
+                limit_label.visible = false
 
-	update_slider()
+        var can_borrow: bool = bool(resource_data.get("can_borrow", false))
+        borrow_hbox.visible = can_borrow
+        borrow_button.visible = can_borrow
+        update_slider()
+        update_borrow_slider()
 
 func update_slider() -> void:
 	if not _is_ready:
@@ -62,13 +72,27 @@ func update_slider() -> void:
 	pay_slider.max_value = max_pay
 	if pay_slider.value > max_pay:
 		pay_slider.value = max_pay
-	slider_label.text = "$%.2f" % pay_slider.value
-	pay_button.disabled = max_pay <= 0.0
+        slider_label.text = "$%.2f" % pay_slider.value
+        pay_button.disabled = max_pay <= 0.0
+
+func update_borrow_slider() -> void:
+        if not _is_ready or not bool(resource_data.get("can_borrow", false)):
+                return
+        var limit: float = float(resource_data.get("borrow_limit", 0.0))
+        borrow_slider.max_value = limit
+        if borrow_slider.value > limit:
+                borrow_slider.value = limit
+        borrow_label.text = "$%.2f" % borrow_slider.value
 
 func _on_slider_changed(value: float) -> void:
-	if not _is_ready:
-		return
-	slider_label.text = "$%.2f" % value
+        if not _is_ready:
+                return
+        slider_label.text = "$%.2f" % value
+
+func _on_borrow_slider_changed(value: float) -> void:
+        if not _is_ready:
+                return
+        borrow_label.text = "$%.2f" % value
 
 func _on_pay_pressed() -> void:
 	if not _is_ready:
@@ -76,5 +100,14 @@ func _on_pay_pressed() -> void:
 	var amount: float = float(pay_slider.value)
 	if amount <= 0.0:
 		return
-	BillManager.pay_debt(String(resource_data.get("name", "")), amount)
-	update_display()
+        BillManager.pay_debt(String(resource_data.get("name", "")), amount)
+        update_display()
+
+func _on_borrow_pressed() -> void:
+        if not _is_ready:
+                return
+        var amount: float = float(borrow_slider.value)
+        if amount <= 0.0:
+                return
+        BillManager.take_payday_loan(amount)
+        update_display()

--- a/components/apps/ower_view/debt_card_ui.tscn
+++ b/components/apps/ower_view/debt_card_ui.tscn
@@ -59,3 +59,23 @@ text = "$0.00"
 unique_name_in_owner = true
 layout_mode = 2
 text = "Pay Off Debt"
+
+[node name="BorrowHBox" type="HBoxContainer" parent="MarginContainer/VBox"]
+unique_name_in_owner = true
+layout_mode = 2
+
+[node name="BorrowSlider" type="HSlider" parent="MarginContainer/VBox/BorrowHBox"]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 3
+
+[node name="BorrowLabel" type="Label" parent="MarginContainer/VBox/BorrowHBox"]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 3
+text = "$0.00"
+
+[node name="BorrowButton" type="Button" parent="MarginContainer/VBox"]
+unique_name_in_owner = true
+layout_mode = 2
+text = "Borrow"

--- a/tests/payday_loan_interest_test.gd
+++ b/tests/payday_loan_interest_test.gd
@@ -1,0 +1,25 @@
+extends SceneTree
+
+func _ready():
+    var pm = Engine.get_singleton("PortfolioManager")
+    var bm = Engine.get_singleton("BillManager")
+    pm.reset()
+    bm.reset()
+    bm.add_debt_resource({
+        "name": "Payday Loan",
+        "balance": 0.0,
+        "has_credit_limit": false,
+        "credit_limit": 0.0,
+        "interest_rate": 2.0,
+        "can_borrow": true,
+        "borrow_limit": 1000.0
+    })
+    bm.take_payday_loan(100.0)
+    assert(pm.cash == 100.0)
+    var res = bm.get_debt_resources()[0]
+    assert(res.get("balance") == 100.0)
+    bm.apply_debt_interest()
+    res = bm.get_debt_resources()[0]
+    assert(res.get("balance") == 300.0)
+    print("payday_loan_interest_test passed")
+    quit()

--- a/tests/payday_loan_interest_test.gd.uid
+++ b/tests/payday_loan_interest_test.gd.uid
@@ -1,0 +1,1 @@
+uid://paydayloanint


### PR DESCRIPTION
## Summary
- Add payday loan resource with 200% daily compounded interest
- Enable borrowing directly from the debt card in OwerView
- Seed and load payday loan data in saves and add regression test

## Testing
- `godot --headless tests/test_runner.tscn` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae86b6443083258c42bb5c7c37054f