### PR TITLE
Handle long credit score labels in OwerView

### DIFF
--- a/components/apps/ower_view/credit_score_bar.gd
+++ b/components/apps/ower_view/credit_score_bar.gd
@@ -3,6 +3,7 @@ extends Control
 @export var min_score: int = 300
 @export var max_score: int = 850
 @export var step: int = 50
+@export var bar_width: float = 40.0
 
 var current_score: int = min_score
 var gradient_tex: ImageTexture = null
@@ -11,6 +12,7 @@ func _ready() -> void:
 	PortfolioManager.credit_updated.connect(_on_credit_changed)
 	_on_credit_changed(0.0, 0.0)
 	_generate_gradient_texture()
+	_update_size()
 
 func _on_credit_changed(_used: float, _limit: float) -> void:
 	current_score = PortfolioManager.get_credit_score()
@@ -25,18 +27,32 @@ func _generate_gradient_texture() -> void:
 	var img := Image.create(1, h, false, Image.FORMAT_RGBA8)
 
 	for y in range(h):
-		var t: float = 1.0 - (float(y) / float(h))  # bottom=0, top=1
-		var col: Color
-		if t < 0.5:
-			col = Color.RED.lerp(Color.YELLOW, t / 0.5)
-		else:
-			col = Color.YELLOW.lerp(Color.GREEN, (t - 0.5) / 0.5)
-		img.set_pixel(0, y, col)
+	var t: float = 1.0 - (float(y) / float(h))  # bottom=0, top=1
+	var col: Color
+	if t < 0.5:
+	col = Color.RED.lerp(Color.YELLOW, t / 0.5)
+	else:
+	col = Color.YELLOW.lerp(Color.GREEN, (t - 0.5) / 0.5)
+	img.set_pixel(0, y, col)
 
 	# Convert to texture
 	gradient_tex = ImageTexture.create_from_image(img)
+
+func _update_size() -> void:
+	# Calculate width needed for unlock labels and expand our minimum size
+	# so that text is never clipped.
+	var font: Font = ThemeDB.fallback_font
+	var font_size: int = 12
+	var max_label_width: float = 0.0
+	for score in range(min_score, max_score + 1, step):
+		var unlocks: String = _get_label_for_score(score)
+		if unlocks != "":
+				var w: float = font.get_string_size(unlocks, HORIZONTAL_ALIGNMENT_LEFT, -1, font_size).x
+				max_label_width = max(max_label_width, w)
+	custom_minimum_size.x = bar_width + 4.0 + max_label_width
 func _draw() -> void:
 	var rect: Rect2 = Rect2(Vector2.ZERO, size)
+	var bar_rect: Rect2 = Rect2(rect.position, Vector2(bar_width, rect.size.y))
 
 	# --- Background with rounded corners
 	var bg_box := StyleBoxFlat.new()
@@ -45,17 +61,17 @@ func _draw() -> void:
 	bg_box.corner_radius_top_right = 8
 	bg_box.corner_radius_bottom_left = 8
 	bg_box.corner_radius_bottom_right = 8
-	draw_style_box(bg_box, rect)
+	draw_style_box(bg_box, bar_rect)
 
 	# --- Filled Gradient (no corner radius here)
 	if gradient_tex != null:
 		var ratio: float = float(current_score - min_score) / float(max_score - min_score)
 		ratio = clamp(ratio, 0.0, 1.0)
 
-		var fill_height: float = rect.size.y * ratio
+		var fill_height: float = bar_rect.size.y * ratio
 		if fill_height > 0.0:
-			var fill_rect := Rect2(rect.position + Vector2(0, rect.size.y - fill_height), Vector2(rect.size.x, fill_height))
-			draw_texture_rect(gradient_tex, fill_rect, true)
+				var fill_rect := Rect2(bar_rect.position + Vector2(0, bar_rect.size.y - fill_height), Vector2(bar_rect.size.x, fill_height))
+				draw_texture_rect(gradient_tex, fill_rect, true)
 
 	# --- Labels and Lines ---
 	var font: Font = ThemeDB.fallback_font
@@ -63,37 +79,37 @@ func _draw() -> void:
 
 	for score in range(min_score, max_score + 1, step):
 		var t: float = float(score - min_score) / float(max_score - min_score)
-		var y: float = rect.size.y * (1.0 - t)
+		var y: float = bar_rect.size.y * (1.0 - t)
 
-		# section color
-		var section_color: Color
-		if t < 0.5:
-			section_color = Color.RED.lerp(Color.YELLOW, t / 0.5)
-		else:
-			section_color = Color.YELLOW.lerp(Color.GREEN, (t - 0.5) / 0.5)
+	# section color
+	var section_color: Color
+	if t < 0.5:
+	section_color = Color.RED.lerp(Color.YELLOW, t / 0.5)
+	else:
+	section_color = Color.YELLOW.lerp(Color.GREEN, (t - 0.5) / 0.5)
 
-		draw_line(Vector2(0, y), Vector2(rect.size.x, y), Color.BLACK)
+		draw_line(Vector2(0, y), Vector2(bar_rect.size.x, y), Color.BLACK)
 
-		var score_text: String = str(score)
-		var score_size: Vector2 = font.get_string_size(score_text, HORIZONTAL_ALIGNMENT_LEFT, -1, font_size)
-		draw_string(font, Vector2(-score_size.x - 6.0, y + score_size.y / 2.0),
-			score_text, HORIZONTAL_ALIGNMENT_LEFT, -1, font_size, section_color)
+	var score_text: String = str(score)
+	var score_size: Vector2 = font.get_string_size(score_text, HORIZONTAL_ALIGNMENT_LEFT, -1, font_size)
+	draw_string(font, Vector2(-score_size.x - 6.0, y + score_size.y / 2.0),
+	score_text, HORIZONTAL_ALIGNMENT_LEFT, -1, font_size, section_color)
 
-		var unlocks: String = _get_label_for_score(score)
-		if unlocks != "":
-			var unlock_size: Vector2 = font.get_string_size(unlocks, HORIZONTAL_ALIGNMENT_LEFT, -1, font_size)
-			draw_string(font, Vector2(rect.size.x + 4.0, y + unlock_size.y / 2.0),
-				unlocks, HORIZONTAL_ALIGNMENT_LEFT, -1, font_size, Color.WHITE)
+	var unlocks: String = _get_label_for_score(score)
+	if unlocks != "":
+	var unlock_size: Vector2 = font.get_string_size(unlocks, HORIZONTAL_ALIGNMENT_LEFT, -1, font_size)
+				draw_string(font, Vector2(bar_rect.size.x + 4.0, y + unlock_size.y / 2.0),
+						unlocks, HORIZONTAL_ALIGNMENT_LEFT, -1, font_size, Color.WHITE)
 
 func _get_label_for_score(score: int) -> String:
 	var unlocked_here: Array[String] = []
 	for purchase in PortfolioManager.CREDIT_REQUIREMENTS.keys():
-		if PortfolioManager.CREDIT_REQUIREMENTS[purchase] == score:
-			unlocked_here.append(String(purchase))
+	if PortfolioManager.CREDIT_REQUIREMENTS[purchase] == score:
+	unlocked_here.append(String(purchase))
 	unlocked_here.sort()
 	return ", ".join(unlocked_here)
 
 func _notification(what: int) -> void:
 	# Regenerate gradient when control is resized
 	if what == NOTIFICATION_RESIZED:
-		_generate_gradient_texture()
+	_generate_gradient_texture()


### PR DESCRIPTION
## Summary
- expand credit score thermometer width based on right-side label lengths
- draw thermometer content inside fixed-width bar while allowing extra space for labels

## Testing
- `godot3 --headless --no-window -s tests/test_runner.gd` *(fails: Can't open project at '/workspace/SigmaSim/project.godot', config_version 5 is newer than engine)*

------
https://chatgpt.com/codex/tasks/task_e_68ae86158f0883258bf691edb1c5253c