### PR TITLE
Optimize Fumble swiping performance

### DIFF
--- a/components/apps/fumble/chats_tab.gd
+++ b/components/apps/fumble/chats_tab.gd
@@ -46,30 +46,35 @@ func refresh_matches(time_budget_msec: int = 8) -> void:
 	for child in matches_container.get_children():
 		child.queue_free()
 
-	var matches_rows: Array = FumbleManager.get_matches_with_times()
-	var battles: Array = FumbleManager.get_active_battles()
-	var battle_npc_indices := battles.map(func(b): return b.npc_idx)
+       var matches_rows: Array = FumbleManager.get_matches_with_times()
+       var battles: Array = FumbleManager.get_active_battles()
+       var battle_lookup: Dictionary = {}
 
-	var total_attractiveness: int = 0
-	var match_count: int = 0
-	var data: Array = []
-	var min_att: float = PlayerManager.get_var("fumble_fugly_filter_threshold", 0.0) * 10.0
+       var total_attractiveness: int = 0
+       var match_count: int = 0
+       var data: Array = []
+       var min_att: float = PlayerManager.get_var("fumble_fugly_filter_threshold", 0.0) * 10.0
 
-	var start_time: int = Time.get_ticks_msec()
+       var start_time: int = Time.get_ticks_msec()
+       for b in battles:
+               battle_lookup[b.npc_idx] = NPCManager.get_npc_by_index(b.npc_idx)
+               if Time.get_ticks_msec() - start_time > time_budget_msec:
+                       await get_tree().process_frame
+                       start_time = Time.get_ticks_msec()
 
-	for row in matches_rows:
-		var idx: int = row.npc_id
-		if battle_npc_indices.has(idx):
-			continue
-		var npc = NPCManager.get_npc_by_index(idx)
-		if npc.attractiveness < min_att:
-			continue
-		total_attractiveness += npc.attractiveness
-		match_count += 1
-		data.append({"npc": npc, "idx": idx, "created_at": row.created_at})
-		if Time.get_ticks_msec() - start_time > time_budget_msec:
-			await get_tree().process_frame
-			start_time = Time.get_ticks_msec()
+       for row in matches_rows:
+               var idx: int = row.npc_id
+               if battle_lookup.has(idx):
+                       continue
+               var npc = NPCManager.get_npc_by_index(idx)
+               if npc.attractiveness < min_att:
+                       continue
+               total_attractiveness += npc.attractiveness
+               match_count += 1
+               data.append({"npc": npc, "idx": idx, "created_at": row.created_at})
+               if Time.get_ticks_msec() - start_time > time_budget_msec:
+                       await get_tree().process_frame
+                       start_time = Time.get_ticks_msec()
 
 	match matches_sort.selected:
 		0:
@@ -92,12 +97,11 @@ func refresh_matches(time_budget_msec: int = 8) -> void:
 			await get_tree().process_frame
 			start_time = Time.get_ticks_msec()
 
-	for b in battles:
-		var npc = NPCManager.get_npc_by_index(b.npc_idx)
-		total_attractiveness += npc.attractiveness
-		if Time.get_ticks_msec() - start_time > time_budget_msec:
-			await get_tree().process_frame
-			start_time = Time.get_ticks_msec()
+       for npc in battle_lookup.values():
+               total_attractiveness += npc.attractiveness
+               if Time.get_ticks_msec() - start_time > time_budget_msec:
+                       await get_tree().process_frame
+                       start_time = Time.get_ticks_msec()
 
 	var total_count: int = match_count + battles.size()
 	matches_label.text = "Matches: %d" % total_count

--- a/components/apps/fumble/profile_card_stack.gd
+++ b/components/apps/fumble/profile_card_stack.gd
@@ -191,42 +191,53 @@ func _refill_swipe_pool_async(time_budget_msec: int = 8) -> void:
 	var percent: float = lerp(min_recycled_percent, max_recycled_percent, t)
 	var num_recycled: int = int(round(swipe_pool_size * percent))
 	var num_new: int = swipe_pool_size - num_recycled
-	var pool: Array[int] = []
+       var pool: Array[int] = []
 
-	var exclude: Array = npc_indices + swipe_pool
-	var min_att: float = PlayerManager.get_var("fumble_fugly_filter_threshold", 0.0) * 10.0
+       var exclude: Dictionary = {}
+       for id in npc_indices:
+               exclude[id] = true
+       for id in swipe_pool:
+               exclude[id] = true
+       var min_att: float = PlayerManager.get_var("fumble_fugly_filter_threshold", 0.0) * 10.0
 
-	var new_indices: Array[int] = []
-	for idx in NPCManager.get_batch_of_new_npc_indices(app_name, num_new * 3):
-		if not exclude.has(idx):
-			var npc = NPCManager.get_npc_by_index(idx)
-			if npc.attractiveness >= min_att and gender_dot_similarity(preferred_gender, npc.gender_vector) >= gender_similarity_threshold:
-				new_indices.append(idx)
-		if new_indices.size() >= num_new:
-			break
-		if Time.get_ticks_msec() - start_time > time_budget_msec:
-			await get_tree().process_frame
-			start_time = Time.get_ticks_msec()
+       var new_indices: Array[int] = []
+       for idx in NPCManager.get_batch_of_new_npc_indices(app_name, num_new * 3):
+               if exclude.has(idx):
+                       continue
+               var npc = NPCManager.get_npc_by_index(idx)
+               if npc.attractiveness >= min_att and gender_dot_similarity(preferred_gender, npc.gender_vector) >= gender_similarity_threshold:
+                       new_indices.append(idx)
+                       exclude[idx] = true
+               if new_indices.size() >= num_new:
+                       break
+               if Time.get_ticks_msec() - start_time > time_budget_msec:
+                       await get_tree().process_frame
+                       start_time = Time.get_ticks_msec()
 
-	var recycled_indices: Array[int] = []
-	var matched = NPCManager.matched_npcs_by_app.get(app_name, {})
-	for idx in NPCManager.get_batch_of_recycled_npc_indices(app_name, num_recycled * 3):
-		if not exclude.has(idx) and not matched.has(idx):
-			var npc = NPCManager.get_npc_by_index(idx)
-			if npc.attractiveness >= min_att and gender_dot_similarity(preferred_gender, npc.gender_vector) >= gender_similarity_threshold:
-				recycled_indices.append(idx)
-		if recycled_indices.size() >= num_recycled:
-			break
-		if Time.get_ticks_msec() - start_time > time_budget_msec:
-			await get_tree().process_frame
-			start_time = Time.get_ticks_msec()
+       var recycled_indices: Array[int] = []
+       var matched_array: Array = NPCManager.matched_npcs_by_app.get(app_name, [])
+       var matched: Dictionary = {}
+       for m in matched_array:
+               matched[m] = true
+       for idx in NPCManager.get_batch_of_recycled_npc_indices(app_name, num_recycled * 3):
+               if exclude.has(idx) or matched.has(idx):
+                       continue
+               var npc = NPCManager.get_npc_by_index(idx)
+               if npc.attractiveness >= min_att and gender_dot_similarity(preferred_gender, npc.gender_vector) >= gender_similarity_threshold:
+                       recycled_indices.append(idx)
+                       exclude[idx] = true
+               if recycled_indices.size() >= num_recycled:
+                       break
+               if Time.get_ticks_msec() - start_time > time_budget_msec:
+                       await get_tree().process_frame
+                       start_time = Time.get_ticks_msec()
 
-	pool += new_indices
-	pool += recycled_indices
-	RNGManager.fumble_profile_stack.shuffle(pool)
+       pool += new_indices
+       pool += recycled_indices
+       RNGManager.fumble_profile_stack.shuffle(pool)
 
-	while swipe_pool.size() < swipe_pool_size and not pool.is_empty():
-		swipe_pool.append(pool.pop_front())
+       while swipe_pool.size() < swipe_pool_size and not pool.is_empty():
+               swipe_pool.append(pool.pop_front())
 
 
 

--- a/components/npc/npc_manager.gd
+++ b/components/npc/npc_manager.gd
@@ -85,19 +85,19 @@ func load_fumble_relationship_cache() -> void:
 # === MAIN API ===
 
 func get_npc_by_index(idx: int) -> NPC:
-	if npcs.has(idx):
-		return npcs[idx]
+        if npcs.has(idx):
+                return npcs[idx]
 
-	var npc: NPC
+        var npc: NPC
+       if encountered_npcs.has(idx):
+               npc = _load_npc_from_db(idx)
+       else:
+               npc = NPCFactory.create_npc(idx)
+               encountered_npcs.append(idx)
 
-	if DBManager.has_npc(idx, SaveManager.current_slot_id):
-		npc = _load_npc_from_db(idx)
-	else:
-		npc = NPCFactory.create_npc(idx)
-
-	# Apply persistent or override data without clobbering existing fields
-	var data: Dictionary = persistent_npcs.get(idx, npc_overrides.get(idx, {}))
-	_merge_npc_data(npc, data)
+        # Apply persistent or override data without clobbering existing fields
+        var data: Dictionary = persistent_npcs.get(idx, npc_overrides.get(idx, {}))
+        _merge_npc_data(npc, data)
 
 	if npc.portrait_config == null:
 		npc.portrait_config = PortraitFactory.ensure_config_for_npc(idx, npc.full_name)


### PR DESCRIPTION
## Summary
- avoid DB lookup in `NPCManager.get_npc_by_index` by using `encountered_npcs`
- reduce repeated NPC fetches in Fumble profile stack by caching and using dictionaries
- build battle NPC lookup for `ChatsTab.refresh_matches` to reuse cached NPCs

## Testing
- `godot3 --headless -s tests/test_runner.gd` *(fails: project requires newer Godot config version)*

------
https://chatgpt.com/codex/tasks/task_e_68ae897f2758832583550f5ccdf40b70