### PR TITLE
Display repayment details on debt cards

### DIFF
--- a/autoloads/bill_manager.gd
+++ b/autoloads/bill_manager.gd
@@ -297,8 +297,14 @@ func get_daily_lifestyle_cost() -> int:
 
 
 func add_debt_resource(resource: Dictionary) -> void:
-	debt_resources.append(resource)
-	debt_resources_changed.emit()
+        if not resource.has("interest_rate"):
+                resource["interest_rate"] = 0.0
+        if not resource.has("compound_period"):
+                resource["compound_period"] = "Monthly"
+        if not resource.has("days_until_due"):
+                resource["days_until_due"] = 30
+        debt_resources.append(resource)
+        debt_resources_changed.emit()
 
 func get_debt_resources() -> Array[Dictionary]:
 		return debt_resources
@@ -346,12 +352,17 @@ func _get_debt_resource(name: String) -> Dictionary:
 	return {}
 
 func _set_credit_card_balance(used: float, limit: float) -> void:
-	for res in debt_resources:
-		if res.get("name", "") == "Credit Card":
-			res["balance"] = used
-			res["credit_limit"] = limit
-			debt_resources_changed.emit()
-			return
+        for res in debt_resources:
+                if res.get("name", "") == "Credit Card":
+                        res["balance"] = used
+                        res["credit_limit"] = limit
+                        res["interest_rate"] = PortfolioManager.credit_interest_rate
+                        if not res.has("compound_period"):
+                                res["compound_period"] = "Monthly"
+                        if not res.has("days_until_due"):
+                                res["days_until_due"] = 30
+                        debt_resources_changed.emit()
+                        return
 
 func _set_student_loan_balance(amount: float) -> void:
 	for res in debt_resources:

--- a/autoloads/save_manager.gd
+++ b/autoloads/save_manager.gd
@@ -91,28 +91,36 @@ func initialize_new_profile(slot_id: int, user_data: Dictionary) -> void:
 	var starting_credit_limit = user_data.get("starting_credit_limit", 0.0)
 	PortfolioManager.set_credit_limit(starting_credit_limit)
 
-	BillManager.add_debt_resource({
-			"name": "Credit Card",
-			"balance": 0.0,
-			"has_credit_limit": true,
-			"credit_limit": starting_credit_limit
-	})
-	BillManager.add_debt_resource({
-			"name": "Payday Loan",
-			"balance": 0.0,
-			"has_credit_limit": false,
-			"credit_limit": 0.0,
-			"interest_rate": 2.0,
-			"can_borrow": true,
-			"borrow_limit": 1000.0
-	})
-	if starting_debt > 0.0:
-			BillManager.add_debt_resource({
-							"name": "Student Loan",
-							"balance": starting_debt,
-							"has_credit_limit": false,
-							"credit_limit": 0.0
-			})
+        BillManager.add_debt_resource({
+                        "name": "Credit Card",
+                        "balance": 0.0,
+                        "has_credit_limit": true,
+                        "credit_limit": starting_credit_limit,
+                        "interest_rate": PortfolioManager.credit_interest_rate,
+                        "compound_period": "Monthly",
+                        "days_until_due": 30
+        })
+        BillManager.add_debt_resource({
+                        "name": "Payday Loan",
+                        "balance": 0.0,
+                        "has_credit_limit": false,
+                        "credit_limit": 0.0,
+                        "interest_rate": 2.0,
+                        "compound_period": "Daily",
+                        "days_until_due": 14,
+                        "can_borrow": true,
+                        "borrow_limit": 1000.0
+        })
+        if starting_debt > 0.0:
+                        BillManager.add_debt_resource({
+                                                        "name": "Student Loan",
+                                                        "balance": starting_debt,
+                                                        "has_credit_limit": false,
+                                                        "credit_limit": 0.0,
+                                                        "interest_rate": 0.0,
+                                                        "compound_period": "Monthly",
+                                                        "days_until_due": 30
+                        })
 
 	MarketManager.init_new_save_events()
 	save_to_slot(slot_id)

--- a/components/apps/ower_view/debt_card_ui.gd
+++ b/components/apps/ower_view/debt_card_ui.gd
@@ -5,6 +5,9 @@ class_name DebtCardUI
 @onready var amount_label: Label = %AmountLabel
 @onready var limit_label: Label = %LimitLabel
 @onready var limit_bar: ProgressBar = %LimitBar
+@onready var interest_label: Label = %InterestLabel
+@onready var compound_label: Label = %CompoundLabel
+@onready var due_label: Label = %DueLabel
 @onready var pay_slider: HSlider = %PaySlider
 @onready var slider_label: Label = %SliderLabel
 @onready var pay_button: Button = %PayButton
@@ -42,6 +45,15 @@ func update_display() -> void:
 	name_label.text = resource_data.get("name", "")
 	var balance: float = float(resource_data.get("balance", 0.0))
 	amount_label.text = "$" + NumberFormatter.format_commas(balance)
+
+	var rate: float = float(resource_data.get("interest_rate", 0.0)) * 100.0
+	interest_label.text = "Interest: %.2f%%" % rate
+
+	var period: String = String(resource_data.get("compound_period", "Monthly"))
+	compound_label.text = "Compounds: %s" % period
+
+	var due_days: int = int(resource_data.get("days_until_due", 0))
+	due_label.text = "Due in: %d days" % due_days
 
 	var credit_limit = resource_data.get("credit_limit")
 	var has_limit = credit_limit != null and float(credit_limit) > 0.0

--- a/components/apps/ower_view/debt_card_ui.tscn
+++ b/components/apps/ower_view/debt_card_ui.tscn
@@ -30,6 +30,21 @@ unique_name_in_owner = true
 layout_mode = 2
 text = "$0"
 
+[node name="InterestLabel" type="Label" parent="MarginContainer/VBox"]
+unique_name_in_owner = true
+layout_mode = 2
+text = "Interest: 0%"
+
+[node name="CompoundLabel" type="Label" parent="MarginContainer/VBox"]
+unique_name_in_owner = true
+layout_mode = 2
+text = "Compounds: Monthly"
+
+[node name="DueLabel" type="Label" parent="MarginContainer/VBox"]
+unique_name_in_owner = true
+layout_mode = 2
+text = "Due in: 0 days"
+
 [node name="LimitLabel" type="Label" parent="MarginContainer/VBox"]
 unique_name_in_owner = true
 visible = false


### PR DESCRIPTION
## Summary
- Show interest rate, compounding period, and days until due on each debt card
- Track repayment details in debt resources and initialize them on new saves

## Testing
- `godot4 --headless --path . -s res://tests/credit_card_no_debt_pay_test.gd` *(failed: Identifier not found: NumberFormatter)*

------
https://chatgpt.com/codex/tasks/task_e_68ae8eeee22483259c48ed912fec2736