### PR TITLE
feat: snapshot database on save

### DIFF
--- a/autoloads/save_manager.gd
+++ b/autoloads/save_manager.gd
@@ -168,7 +168,8 @@ func save_to_slot(slot_id: int) -> void:
 	metadata[slot_key]["cash"] = PortfolioManager.cash
 
 	save_slot_metadata(metadata)
-
+	if DBManager != null:
+		DBManager.snapshot_slot_data(slot_id)
 
 func load_from_slot(slot_id: int) -> void:
 	if slot_id <= 0:
@@ -179,9 +180,11 @@ func load_from_slot(slot_id: int) -> void:
 	if not FileAccess.file_exists(path):
 		return
 
-	# Flush NPC save queue so dynamic fields aren't lost when switching slots.
+# Flush NPC save queue so dynamic fields aren't lost when switching slots.
 	if NPCManager != null:
-			NPCManager._flush_save_queue()
+		NPCManager._flush_save_queue()
+	if DBManager != null:
+		DBManager.restore_slot_data(slot_id)
 
 	reset_managers()
 	BillManager.is_loading = true

--- a/tests/db_snapshot_restore_test.gd
+++ b/tests/db_snapshot_restore_test.gd
@@ -1,0 +1,26 @@
+extends SceneTree
+
+func _ready() -> void:
+	var save_mgr = Engine.get_singleton("SaveManager")
+	var db_mgr = Engine.get_singleton("DBManager")
+
+	save_mgr.reset_managers()
+	save_mgr.current_slot_id = 1
+
+	var npc_id := 4242
+	db_mgr.db.query("DELETE FROM npc WHERE id = %d AND slot_id = %d" % [npc_id, save_mgr.current_slot_id])
+
+	db_mgr.db.query("INSERT OR REPLACE INTO npc (id, slot_id, full_name) VALUES (%d, %d, 'Snapshot Test')" % [npc_id, save_mgr.current_slot_id])
+
+	save_mgr.save_to_slot(save_mgr.current_slot_id)
+
+	db_mgr.db.query("UPDATE npc SET full_name = 'Changed' WHERE id = %d AND slot_id = %d" % [npc_id, save_mgr.current_slot_id])
+
+	save_mgr.load_from_slot(save_mgr.current_slot_id)
+
+	var rows = db_mgr.db.select_rows("npc", "id = %d AND slot_id = %d" % [npc_id, save_mgr.current_slot_id], ["full_name"])
+	assert(rows.size() > 0)
+	assert(rows[0].full_name == "Snapshot Test")
+	print("db_snapshot_restore_test passed")
+	quit()
+


### PR DESCRIPTION
## Summary
- snapshot SQLite database to slot-specific file when saving
- restore database snapshot on load and clean up when deleting saves
- add regression test for database snapshot rollback

## Testing
- `godot --headless --path . --script res://tests/db_snapshot_restore_test.gd` *(fails: Could not find type "ContextAction" in the current scope)*

------
https://chatgpt.com/codex/tasks/task_e_68ae8cdf89e48325bebad66af4340354