### PR TITLE
Fix CryptoUpgradeUI null reference

### DIFF
--- a/components/upgrade_scenes/crypto_upgrade_ui.gd
+++ b/components/upgrade_scenes/crypto_upgrade_ui.gd
@@ -10,6 +10,8 @@ func setup_custom(symbol: String) -> void:
     unique_popup_key = "crypto_upgrades_%s" % symbol
     window_title = "%s Upgrades" % symbol
     _ensure_upgrades()
+    if not is_node_ready():
+        await ready
     system_ui.system_name = _get_system_name()
     system_ui.refresh_upgrades()
 

--- a/components/upgrade_scenes/crypto_upgrade_ui.tscn
+++ b/components/upgrade_scenes/crypto_upgrade_ui.tscn
@@ -50,5 +50,6 @@ theme_override_constants/margin_right = 15
 theme_override_constants/margin_bottom = 15
 
 [node name="SystemUpgradeUI" parent="MarginContainer" instance=ExtResource("2")]
+unique_name_in_owner = true
 layout_mode = 2
 size_flags_vertical = 3


### PR DESCRIPTION
## Summary
- Ensure crypto upgrade UI waits for readiness before accessing SystemUpgradeUI
- Mark SystemUpgradeUI node as unique for reliable lookups

## Testing
- `godot4 --headless --path . -s tests/test_runner.gd` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae94f3160883259b37dd7cec5e99f1