### PR TITLE
Fix pending bill iteration clearing

### DIFF
--- a/autoloads/bill_manager.gd
+++ b/autoloads/bill_manager.gd
@@ -78,42 +78,42 @@ func _on_day_passed(new_day: int, new_month: int, new_year: int) -> void:
 	var bills_today: Array = get_due_bills_for_date(new_day, new_month, new_year)
 	var already_paid: Array = paid_bills.get(today_key, [])
 
-	for bill_name in bills_today:
-		if bill_name in already_paid:
-			continue
+        for bill_name in bills_today:
+                if bill_name in already_paid:
+                        continue
 
-		# 🧠 Check if this bill popup already exists or is pending for today
-		var already_open: bool = false
-		for existing in active_bills[today_key]:
-			if is_instance_valid(existing) and existing.bill_name == bill_name:
-				already_open = true
-				break
-		if not already_open:
-			for pending in pending_bill_data[today_key]:
-				if pending.get("bill_name", "") == bill_name:
-					already_open = true
-					break
+                # 🧠 Check if this bill popup already exists or is pending for today
+                var already_open: bool = false
+                for existing in active_bills[today_key]:
+                        if is_instance_valid(existing) and existing.bill_name == bill_name:
+                                already_open = true
+                                break
+                if not already_open:
+                        for pending in pending_bill_data.get(today_key, []):
+                                if pending.get("bill_name", "") == bill_name:
+                                        already_open = true
+                                        break
 
-		if already_open:
-			continue  # ✅ Skip duplicate
+                if already_open:
+                        continue  # ✅ Skip duplicate
 
-		var amount: float = get_bill_amount(bill_name)
-		if amount <= 0.0:
-			print("Skipping %s bill (amount is 0)" % bill_name)
-			continue
+                var amount: float = get_bill_amount(bill_name)
+                if amount <= 0.0:
+                        print("Skipping %s bill (amount is 0)" % bill_name)
+                        continue
 
-		if autopay_enabled and attempt_to_autopay(bill_name):
-			mark_bill_paid(bill_name, today_key)
-			continue
+                if autopay_enabled and attempt_to_autopay(bill_name):
+                        mark_bill_paid(bill_name, today_key)
+                        continue
 
-		# Queue bill popup for display
-		pending_bill_data[today_key].append({
-				"bill_name": bill_name,
-				"amount": amount
-		})
+                # Queue bill popup for display
+                pending_bill_data[today_key].append({
+                                "bill_name": bill_name,
+                                "amount": amount
+                })
 
-		apply_debt_interest()
-		show_due_popups()
+        apply_debt_interest()
+        show_due_popups()
 
 
 


### PR DESCRIPTION
## Summary
- Avoid invalid key access when checking pending bills
- Display due popups after processing all bills to keep pending data intact

## Testing
- `godot4 --headless --run tests/test_runner.tscn` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae964417ec83258517edafc6072d92