### PR TITLE
Enable battle UI reaction emoji animations

### DIFF
--- a/components/apps/fumble/fumble_battle/battle_ui.gd
+++ b/components/apps/fumble/fumble_battle/battle_ui.gd
@@ -492,7 +492,7 @@ func do_move(move_type: String) -> void:
 		player_chat.set_reaction(
 			REACTION_EMOJI["cry_laugh"],
 			get_reaction_tooltip("cry_laugh"),
-			false,
+			true,
 			"cry_laugh"
 		)
 		if player_chat.chatlog_index >= 0 and player_chat.chatlog_index < chatlog.size():
@@ -520,7 +520,7 @@ func do_move(move_type: String) -> void:
 		player_chat.set_reaction(
 			REACTION_EMOJI["heart"],
 			get_reaction_tooltip("heart"),
-			false,
+			true,
 			"heart"
 		)
 		if player_chat.chatlog_index >= 0 and player_chat.chatlog_index < chatlog.size():
@@ -532,7 +532,7 @@ func do_move(move_type: String) -> void:
 		player_chat.set_reaction(
 			REACTION_EMOJI["thumbs_down"],
 			get_reaction_tooltip("thumbs_down"),
-			false,
+			true,
 			"thumbs_down"
 		)
 		if player_chat.chatlog_index >= 0 and player_chat.chatlog_index < chatlog.size():


### PR DESCRIPTION
## Summary
- allow battle UI reaction emojis to animate by enabling animation when reactions are set

## Testing
- `apt-get install -y godot4` *(fails: Unable to locate package godot4)*
- `apt-get install -y godot` *(fails: Unable to locate package godot)*
- `godot4 --headless -s tests/test_runner.gd` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af622cea808325bc75dfa81c6e69f5