### PR TITLE
Add quantity spinboxes for stock and crypto trades

### DIFF
--- a/components/apps/broke_rage/stock_market.gd
+++ b/components/apps/broke_rage/stock_market.gd
@@ -30,16 +30,17 @@ func refresh_rows_from_market():
 
 
 
-func _on_buy_button_pressed(symbol: String):
-		var stock = PortfolioManager.stock_data.get(symbol)
-		if stock and PortfolioManager.get_cash() < stock.price and UpgradeManager.get_level("brokerage_pattern_day_trader") <= 0:
-				print("Credit purchase requires Pattern Day Trader upgrade")
-				return
-		if !PortfolioManager.buy_stock(symbol):
-				print("Failed to buy stock:", symbol)
+func _on_buy_button_pressed(symbol: String, quantity: int) -> void:
+	var stock = PortfolioManager.stock_data.get(symbol)
+	var total_price := stock.price * quantity if stock else 0.0
+	if stock and PortfolioManager.get_cash() < total_price and UpgradeManager.get_level("brokerage_pattern_day_trader") <= 0:
+		print("Credit purchase requires Pattern Day Trader upgrade")
+		return
+	if !PortfolioManager.buy_stock(symbol, quantity):
+		print("Failed to buy stock:", symbol)
 
-func _on_sell_button_pressed(symbol: String):
-	if !PortfolioManager.sell_stock(symbol):
+func _on_sell_button_pressed(symbol: String, quantity: int) -> void:
+	if !PortfolioManager.sell_stock(symbol, quantity):
 		print("Failed to sell stock:", symbol)
 
 func _on_stock_updated(symbol: String, updated_stock: Stock):

--- a/components/apps/broke_rage/stock_row.gd
+++ b/components/apps/broke_rage/stock_row.gd
@@ -1,12 +1,13 @@
 extends GridContainer
 class_name StockRow
 
-signal buy_pressed(stock_symbol: String)
-signal sell_pressed(stock_symbol: String)
+signal buy_pressed(stock_symbol: String, quantity: int)
+signal sell_pressed(stock_symbol: String, quantity: int)
 
 @onready var stock_label: Label = %StockLabel
 @onready var buy_button: Button = $BuyButton
 @onready var sell_button: Button = $SellButton
+@onready var quantity_spinbox: SpinBox = $QuantitySpinBox
 @onready var owned_label: Label = $OwnedLabel
 @onready var arrow = $SentimentArrow
 
@@ -19,18 +20,20 @@ func setup(_stock: Stock) -> void:
 	last_price = stock.price
 	update_display(stock)
 
-	buy_button.pressed.connect(func():
-		var price := stock.price
-		if PortfolioManager.get_cash() < price and UpgradeManager.get_level("brokerage_pattern_day_trader") <= 0:
+		buy_button.pressed.connect(func():
+			var quantity := int(quantity_spinbox.value)
+			var price := stock.price * quantity
+			if PortfolioManager.get_cash() < price and UpgradeManager.get_level("brokerage_pattern_day_trader") <= 0:
 				print("Credit purchase requires Pattern Day Trader upgrade")
 				return
-		emit_signal("buy_pressed", stock.symbol)
-		update_display(stock)
+			emit_signal("buy_pressed", stock.symbol, quantity)
+			update_display(stock)
 		)
-	sell_button.pressed.connect(func():
-		emit_signal("sell_pressed", stock.symbol)
-		update_display(stock)
-	)
+		sell_button.pressed.connect(func():
+			var quantity := int(quantity_spinbox.value)
+			emit_signal("sell_pressed", stock.symbol, quantity)
+			update_display(stock)
+		)
 	
 
 func update_display(updated_stock: Stock) -> void:

--- a/components/apps/broke_rage/stock_row.tscn
+++ b/components/apps/broke_rage/stock_row.tscn
@@ -29,7 +29,7 @@ offset_bottom = 20.0
 size_flags_horizontal = 3
 size_flags_stretch_ratio = 2.0
 theme = ExtResource("1_vmdvm")
-columns = 7
+columns = 8
 script = ExtResource("2_2mfh4")
 
 [node name="StockLabel" type="Label" parent="."]
@@ -59,6 +59,12 @@ theme_override_styles/hover_pressed = SubResource("StyleBoxTexture_t6o0i")
 theme_override_styles/pressed = SubResource("StyleBoxTexture_1g05d")
 theme_override_styles/normal = SubResource("StyleBoxTexture_cvu5h")
 text = " BUY "
+
+[node name="QuantitySpinBox" type="SpinBox" parent="."]
+layout_mode = 2
+min_value = 1.0
+step = 1.0
+value = 1.0
 
 [node name="SellButton" type="Button" parent="."]
 layout_mode = 2

--- a/components/popups/crypto_popup_ui.gd
+++ b/components/popups/crypto_popup_ui.gd
@@ -15,6 +15,7 @@ class_name CryptoPopupUI
 @onready var price_chart: ChartComponent = %PriceChart
 @onready var buy_button: Button = %BuyButton
 @onready var sell_button: Button = %SellButton
+@onready var quantity_spinbox: SpinBox = %QuantitySpinBox
 
 var crypto: Cryptocurrency
 
@@ -56,12 +57,16 @@ func _update_ui() -> void:
 	label_owned.text = "%.4f" % PortfolioManager.get_crypto_amount(crypto.symbol)
 
 func _on_buy_pressed() -> void:
-	if crypto and PortfolioManager.attempt_spend(crypto.price):
-		PortfolioManager.add_crypto(crypto.symbol, 1.0)
-		_update_ui()
+	if crypto:
+		var amount := quantity_spinbox.value
+		if PortfolioManager.attempt_spend(crypto.price * amount):
+			PortfolioManager.add_crypto(crypto.symbol, amount)
+			_update_ui()
 
 func _on_sell_pressed() -> void:
-	if crypto and PortfolioManager.sell_crypto(crypto.symbol, 1.0):
+	if crypto:
+		var amount := quantity_spinbox.value
+		if PortfolioManager.sell_crypto(crypto.symbol, amount):
 			_update_ui()
 
 

--- a/components/popups/crypto_popup_ui.tscn
+++ b/components/popups/crypto_popup_ui.tscn
@@ -177,6 +177,13 @@ theme_override_styles/pressed = SubResource("StyleBoxTexture_y3pn2")
 theme_override_styles/normal = SubResource("StyleBoxTexture_gxo7e")
 text = " BUY "
 
+[node name="QuantitySpinBox" type="SpinBox" parent="MarginContainer/VBoxContainer/HBoxContainer/InfoVBox/ButtonBox"]
+unique_name_in_owner = true
+layout_mode = 2
+min_value = 0.01
+step = 0.01
+value = 1.0
+
 [node name="SellButton" type="Button" parent="MarginContainer/VBoxContainer/HBoxContainer/InfoVBox/ButtonBox"]
 unique_name_in_owner = true
 layout_mode = 2

--- a/components/popups/stock_popup_ui.gd
+++ b/components/popups/stock_popup_ui.gd
@@ -14,6 +14,7 @@ class_name StockPopupUI
 @onready var price_chart: ChartComponent = %PriceChart
 @onready var buy_button: Button = %BuyButton
 @onready var sell_button: Button = %SellButton
+@onready var quantity_spinbox: SpinBox = %QuantitySpinBox
 
 var stock: Stock
 
@@ -65,18 +66,21 @@ func _update_ui() -> void:
 	label_owned.text = str(PortfolioManager.stocks_owned.get(stock.symbol, 0))
 
 func _on_buy_pressed() -> void:
-		if not stock:
-				return
-		var price := stock.price
-		if PortfolioManager.get_cash() < price and UpgradeManager.get_level("brokerage_pattern_day_trader") <= 0:
-				print("Credit purchase requires Pattern Day Trader upgrade")
-				return
-		if PortfolioManager.buy_stock(stock.symbol):
-				_update_ui()
+	if not stock:
+		return
+	var quantity := int(quantity_spinbox.value)
+	var price := stock.price * quantity
+	if PortfolioManager.get_cash() < price and UpgradeManager.get_level("brokerage_pattern_day_trader") <= 0:
+		print("Credit purchase requires Pattern Day Trader upgrade")
+		return
+	if PortfolioManager.buy_stock(stock.symbol, quantity):
+		_update_ui()
 
 func _on_sell_pressed() -> void:
-	if stock and PortfolioManager.sell_stock(stock.symbol):
-		_update_ui()
+	if stock:
+		var quantity := int(quantity_spinbox.value)
+		if PortfolioManager.sell_stock(stock.symbol, quantity):
+			_update_ui()
 
 
 func get_custom_save_data() -> Dictionary:

--- a/components/popups/stock_popup_ui.tscn
+++ b/components/popups/stock_popup_ui.tscn
@@ -166,6 +166,13 @@ theme_override_styles/pressed = SubResource("StyleBoxTexture_sepyu")
 theme_override_styles/normal = SubResource("StyleBoxTexture_mgfj3")
 text = " BUY "
 
+[node name="QuantitySpinBox" type="SpinBox" parent="MarginContainer/VBoxContainer/HBoxContainer/InfoVBox/ButtonBox"]
+unique_name_in_owner = true
+layout_mode = 2
+min_value = 1.0
+step = 1.0
+value = 1.0
+
 [node name="SellButton" type="Button" parent="MarginContainer/VBoxContainer/HBoxContainer/InfoVBox/ButtonBox"]
 unique_name_in_owner = true
 layout_mode = 2


### PR DESCRIPTION
## Summary
- allow selecting share counts in stock row and popup
- support fractional crypto amounts via spinbox

## Testing
- `/tmp/godot/Godot_v4.2.2-stable_linux.x86_64 --headless tests/test_runner.tscn` *(fails: missing resources and parse errors)*

------
https://chatgpt.com/codex/tasks/task_e_68afa43e18788325b9e538bca4b2dfb4