### PR TITLE
Fix debt card pay button

### DIFF
--- a/components/apps/ower_view/debt_card_ui.gd
+++ b/components/apps/ower_view/debt_card_ui.gd
@@ -107,13 +107,13 @@ func _on_borrow_slider_changed(value: float) -> void:
 		borrow_label.text = "$%.2f" % value
 
 func _on_pay_pressed() -> void:
-	if not _is_ready:
-		return
-	var amount: float = float(pay_slider.value)
-	if amount <= 0.0:
-		return
-		BillManager.pay_debt(String(resource_data.get("name", "")), amount)
-		update_display()
+        if not _is_ready:
+                return
+        var amount: float = float(pay_slider.value)
+        if amount <= 0.0:
+                return
+        BillManager.pay_debt(String(resource_data.get("name", "")), amount)
+        update_display()
 
 func _on_borrow_pressed() -> void:
 		if not _is_ready:

--- a/tests/debt_card_pay_test.gd
+++ b/tests/debt_card_pay_test.gd
@@ -1,0 +1,26 @@
+extends SceneTree
+
+func _ready():
+        var pm = Engine.get_singleton("PortfolioManager")
+        var bm = Engine.get_singleton("BillManager")
+        pm.reset()
+        bm.reset()
+        pm.add_cash(100.0)
+        bm.add_debt_resource({
+                "name": "Test Debt",
+                "balance": 100.0
+        })
+        var card = DebtCardUI.new()
+        get_root().add_child(card)
+        await card.ready
+        card.init({
+                "name": "Test Debt",
+                "balance": 100.0
+        })
+        card.pay_slider.value = 50.0
+        card._on_pay_pressed()
+        var res = bm.get_debt_resources()[0]
+        assert(res.get("balance") == 50.0)
+        print("debt_card_pay_test passed")
+        quit()
+


### PR DESCRIPTION
## Summary
- call BillManager.pay_debt when pressing the debt-card pay button
- add test to ensure pressing debt-card pay button reduces debt

## Testing
- `godot3 --headless --script tests/test_runner.gd` *(fails: Can't open project, config_version from newer engine)*

------
https://chatgpt.com/codex/tasks/task_e_68afaf4c0a888325b9afb1011c919e77