### PR TITLE
Allow optional passwords and random seed tracking

### DIFF
--- a/autoloads/player_manager.gd
+++ b/autoloads/player_manager.gd
@@ -103,12 +103,13 @@ var default_user_data: Dictionary = {
 		"hh_open_fumble_cost": 10,
 
 		# Flags and progression
-		"unlocked_perks": [],
-		"seen_dialogue_ids": [],
-		"global_rng_seed": 0,
-	# Background shader settings
-	"background_shaders": DEFAULT_BACKGROUND_SHADERS.duplicate(true),
-	}
+               "unlocked_perks": [],
+               "seen_dialogue_ids": [],
+               "global_rng_seed": 0,
+               "using_random_seed": false,
+        # Background shader settings
+        "background_shaders": DEFAULT_BACKGROUND_SHADERS.duplicate(true),
+        }
 
 var user_data: Dictionary = default_user_data.duplicate(true)
 

--- a/components/ui/profile_creation/name_entry_screen.gd
+++ b/components/ui/profile_creation/name_entry_screen.gd
@@ -7,20 +7,19 @@ signal step_valid(valid: bool)
 @onready var password_line_edit: LineEdit = %PasswordLineEdit
 
 func _ready():
-	# Connect validation on any text change
-	name_line_edit.text_changed.connect(_check_validity)
-	username_line_edit.text_changed.connect(_check_validity)
-	password_line_edit.text_changed.connect(_check_validity)
+        # Connect validation on any text change
+        name_line_edit.text_changed.connect(_check_validity)
+        username_line_edit.text_changed.connect(_check_validity)
+       password_line_edit.text_changed.connect(_check_validity)
 
 	# Initial check in case of autofill or default values
 	_check_validity("")
 
 func _check_validity(_text) -> void:
-	var is_valid : bool = (
-		name_line_edit.text.strip_edges() != "" and
-		username_line_edit.text.strip_edges() != "" and
-		password_line_edit.text.strip_edges() != ""
-	)
+        var is_valid : bool = (
+               name_line_edit.text.strip_edges() != "" and
+               username_line_edit.text.strip_edges() != ""
+        )
 	
 	emit_signal("step_valid", is_valid)
 

--- a/components/ui/profile_creation/profile_creation_ui.gd
+++ b/components/ui/profile_creation/profile_creation_ui.gd
@@ -51,21 +51,25 @@ func _input(event: InputEvent) -> void:
 			get_viewport().set_input_as_handled()
 
 func _finish_profile_creation():
-	var password = user_data.get("password", "")
-	var seed_val: int
-	if password != "":
-		seed_val = PlayerManager.djb2(password)
-		print("Profile creation password:", password, " -> seed:", seed_val)
-	else:
-		seed_val = int(Time.get_unix_time_from_system())
-		print("Profile creation no password; using unix time seed:", seed_val)
-	user_data["global_rng_seed"] = seed_val
-	RNGManager.init_seed(seed_val)
-	var slot_id = SaveManager.get_next_available_slot()
-	print("Finalizing profile in slot", slot_id, "with seed", seed_val)
-	SaveManager.initialize_new_profile(slot_id, user_data)
-	emit_signal("profile_created", slot_id)
-	queue_free()
+        var password = user_data.get("password", "")
+        var seed_val: int
+        if password != "":
+               seed_val = PlayerManager.djb2(password)
+               user_data["using_random_seed"] = false
+               print("Profile creation password:", password, " -> seed:", seed_val)
+        else:
+               var rng = RandomNumberGenerator.new()
+               rng.randomize()
+               seed_val = rng.randi()
+               user_data["using_random_seed"] = true
+               print("Profile creation no password; generated random seed:", seed_val)
+        user_data["global_rng_seed"] = seed_val
+        RNGManager.init_seed(seed_val)
+        var slot_id = SaveManager.get_next_available_slot()
+        print("Finalizing profile in slot", slot_id, "with seed", seed_val)
+        SaveManager.initialize_new_profile(slot_id, user_data)
+        emit_signal("profile_created", slot_id)
+        queue_free()
 
 
 

--- a/tests/using_random_seed_generation_test.gd
+++ b/tests/using_random_seed_generation_test.gd
@@ -1,0 +1,21 @@
+extends SceneTree
+
+func _ready():
+    var stat_mgr = Engine.get_singleton("StatManager")
+    var player_mgr = Engine.get_singleton("PlayerManager")
+    var save_mgr = Engine.get_singleton("SaveManager")
+
+    stat_mgr.reset()
+    player_mgr.reset()
+
+    var user_data = player_mgr.user_data.duplicate(true)
+    user_data["name"] = "Test"
+    user_data["username"] = "testuser"
+    user_data["password"] = ""
+
+    save_mgr.initialize_new_profile(1, user_data)
+
+    assert(player_mgr.user_data.get("using_random_seed", false))
+    assert(player_mgr.user_data.get("global_rng_seed", 0) != 0)
+    print("using_random_seed_generation_test passed")
+    quit()


### PR DESCRIPTION
## Summary
- Allow profile creation to proceed without a password
- Generate and persist a random seed when no password is provided
- Track whether a profile was initialized with a random seed
- Test random seed generation for passwordless profiles

## Testing
- `godot --headless -s tests/test_runner.gd` *(fails: command not found)*
- `apt-get install -y godot4` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68afa4d382948325a6eb4ba852fd17b7