### PR TITLE
Refactor terminal into pane-based app

### DIFF
--- a/autoload/terminal_manager.gd
+++ b/autoload/terminal_manager.gd
@@ -1,54 +1,56 @@
 extends Node
 # Autoload: TerminalManager
 
-var terminal_scene: PackedScene
-var terminal: Terminal
-
 const TOGGLE_ACTION := "toggle_terminal"
 
 func _ready() -> void:
-		_ensure_toggle_action()
-
-		terminal_scene = load("res://components/apps/terminal/terminal.tscn")
-		terminal = terminal_scene.instantiate() as Terminal
-		terminal.hide()
-
-		# Defer adding to root to avoid "Parent node is busy setting up children"
-		get_tree().root.call_deferred("add_child", terminal)
+    _ensure_toggle_action()
 
 func _input(event: InputEvent) -> void:
-		if event.is_action_pressed(TOGGLE_ACTION):
-				if is_instance_valid(terminal):
-						terminal.toggle()
-						get_viewport().set_input_as_handled()
+    if event.is_action_pressed(TOGGLE_ACTION):
+        toggle()
+        get_viewport().set_input_as_handled()
 
 func open() -> void:
-		if is_instance_valid(terminal):
-				terminal.open()
+    var existing := WindowManager.find_window_by_app("Terminal")
+    if existing:
+        WindowManager.focus_window(existing)
+        if existing.pane is Terminal:
+            (existing.pane as Terminal).open()
+        return
+
+    WindowManager.launch_app_by_name("Terminal")
+    existing = WindowManager.find_window_by_app("Terminal")
+    if existing and existing.pane is Terminal:
+        (existing.pane as Terminal).open()
 
 func close() -> void:
-		if is_instance_valid(terminal):
-				terminal.close()
+    var existing := WindowManager.find_window_by_app("Terminal")
+    if existing:
+        WindowManager.close_window(existing)
 
 func toggle() -> void:
-		if is_instance_valid(terminal):
-				terminal.toggle()
+    var existing := WindowManager.find_window_by_app("Terminal")
+    if existing:
+        WindowManager.close_window(existing)
+    else:
+        open()
 
 func _ensure_toggle_action() -> void:
-	if not InputMap.has_action(TOGGLE_ACTION):
-		InputMap.add_action(TOGGLE_ACTION)
+    if not InputMap.has_action(TOGGLE_ACTION):
+        InputMap.add_action(TOGGLE_ACTION)
 
-	var events := InputMap.action_get_events(TOGGLE_ACTION)
-	if events.size() == 0:
-		var ev := InputEventKey.new()
-		var k: int = KEY_QUOTELEFT  # backtick (`) in Godot 4
-		ev.keycode = k
-		ev.physical_keycode = k
-		ev.pressed = false
-		InputMap.action_add_event(TOGGLE_ACTION, ev)
+    var events := InputMap.action_get_events(TOGGLE_ACTION)
+    if events.size() == 0:
+        var ev := InputEventKey.new()
+        var k: int = KEY_QUOTELEFT  # backtick (`) in Godot 4
+        ev.keycode = k
+        ev.physical_keycode = k
+        ev.pressed = false
+        InputMap.action_add_event(TOGGLE_ACTION, ev)
 
-		# Optional: add F1 as a secondary toggle
-		var ev2 := InputEventKey.new()
-		ev2.keycode = KEY_F1
-		ev2.physical_keycode = KEY_F1
-		InputMap.action_add_event(TOGGLE_ACTION, ev2)
+        var ev2 := InputEventKey.new()
+        ev2.keycode = KEY_F1
+        ev2.physical_keycode = KEY_F1
+        InputMap.action_add_event(TOGGLE_ACTION, ev2)
+

--- a/autoloads/window_manager.gd
+++ b/autoloads/window_manager.gd
@@ -26,8 +26,9 @@ var app_registry := {
 	"Fumble": preload("res://components/apps/fumble/fumble.tscn"),
 	"Daterbase": preload("res://components/apps/daterbase/daterbase.tscn"),
 	"NewYou": preload("res://components/apps/new_you/new_you.tscn"),
-	"Wallet": preload("res://components/apps/wallet/wallet_ui.tscn"),
+        "Wallet": preload("res://components/apps/wallet/wallet_ui.tscn"),
   "Notepad": preload("res://components/apps/app_scenes/notepad.tscn"),
+        "Terminal": preload("res://components/apps/terminal/terminal.tscn"),
 
 }
 

--- a/components/apps/terminal/terminal.tscn
+++ b/components/apps/terminal/terminal.tscn
@@ -5,10 +5,10 @@
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_0xw1n"]
 bg_color = Color(0, 0, 0, 1)
 
-[node name="Terminal" type="CanvasLayer"]
-layer = 100
+[node name="Terminal" type="Pane"]
 script = ExtResource("1_ekq6y")
 window_title = "Terminal"
+show_in_taskbar = false
 
 [node name="PanelContainer" type="PanelContainer" parent="."]
 anchors_preset = 15


### PR DESCRIPTION
## Summary
- Convert Terminal scene into a Pane-based app and hide it from taskbar/start menu
- Register Terminal with the window manager and manage it via `TerminalManager`

## Testing
- `godot --headless -s tests/test_runner.gd` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68afbc30456c8325bd333cabec23459e