### PR TITLE
Obfuscate profile password on login with show toggle

### DIFF
--- a/components/ui/profile_panel.gd
+++ b/components/ui/profile_panel.gd
@@ -7,7 +7,9 @@ signal login_requested(slot_id: int)
 @onready var profile_pic: PortraitView = %ProfilePic
 @onready var name_label: Label = %NameLabel
 @onready var username_label: Label = %UsernameLabel
-@onready var password_text_edit: TextEdit = %PasswordTextEdit
+@onready var password_line_edit: LineEdit = %PasswordLineEdit
+@onready var show_password_button: Button = %ShowPasswordButton
+@onready var password_hbox: HBoxContainer = %PasswordHBox
 @onready var log_in_button: Button = %LogInButton
 
 var pending_data: Dictionary
@@ -16,10 +18,11 @@ var slot_id: int = -1
 
 
 func _ready() -> void:
-	size_flags_vertical = Control.SIZE_SHRINK_CENTER
-	log_in_button.hide()
-	if pending_data:
-		_apply_profile_data()
+        size_flags_vertical = Control.SIZE_SHRINK_CENTER
+        log_in_button.hide()
+        show_password_button.toggled.connect(_on_show_password_button_toggled)
+        if pending_data:
+                _apply_profile_data()
 
 
 func set_profile_data(data: Dictionary, id: int) -> void:
@@ -33,8 +36,18 @@ func _apply_profile_data() -> void:
 	name_label.text = pending_data.get("name", "Unnamed")
 	username_label.text = "@%s" % pending_data.get("username", "user")
 
-	password_text_edit.text = pending_data.get("password", "")
-	password_text_edit.editable = false
+        var using_random_seed = pending_data.get("using_random_seed", false)
+        if using_random_seed:
+                password_line_edit.text = ""
+                show_password_button.button_pressed = false
+                show_password_button.text = "show"
+                password_hbox.hide()
+        else:
+                password_line_edit.text = pending_data.get("password", "")
+                password_line_edit.secret = true
+                show_password_button.button_pressed = false
+                show_password_button.text = "show"
+                password_hbox.show()
 
 	var cfg_dict = pending_data.get("portrait_config", {})
 	if cfg_dict is Dictionary:
@@ -51,15 +64,20 @@ func _apply_profile_data() -> void:
 
 
 func _on_mouse_entered() -> void:
-	size_flags_vertical = Control.SIZE_EXPAND_FILL
-	log_in_button.show()
+        size_flags_vertical = Control.SIZE_EXPAND_FILL
+        log_in_button.show()
 	#size = Vector2(180,270)
 
 
 func _on_log_in_button_pressed() -> void:
-	emit_signal("login_requested", slot_id)
+        emit_signal("login_requested", slot_id)
 
 
 func _on_mouse_exited() -> void:
-	size_flags_vertical = Control.SIZE_SHRINK_CENTER
-	log_in_button.hide()
+        size_flags_vertical = Control.SIZE_SHRINK_CENTER
+        log_in_button.hide()
+
+
+func _on_show_password_button_toggled(toggled_on: bool) -> void:
+        password_line_edit.secret = not toggled_on
+        show_password_button.text = toggled_on ? "hide" : "show"

--- a/components/ui/profile_panel.tscn
+++ b/components/ui/profile_panel.tscn
@@ -67,13 +67,27 @@ theme_override_font_sizes/font_size = 16
 text = "@Giga Chad"
 horizontal_alignment = 1
 
-[node name="PasswordTextEdit" type="TextEdit" parent="MarginContainer/VBoxContainer"]
+[node name="PasswordHBox" type="HBoxContainer" parent="MarginContainer/VBoxContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+
+[node name="PasswordLineEdit" type="LineEdit" parent="MarginContainer/VBoxContainer/PasswordHBox"]
 unique_name_in_owner = true
 custom_minimum_size = Vector2(0, 35)
 layout_mode = 2
 mouse_filter = 1
-placeholder_text = "seed (optional)"
 editable = false
+secret = true
+secret_character = "●"
+size_flags_horizontal = 3
+
+[node name="ShowPasswordButton" type="Button" parent="MarginContainer/VBoxContainer/PasswordHBox"]
+unique_name_in_owner = true
+layout_mode = 2
+focus_mode = 0
+text = "show"
+toggle_mode = true
+custom_minimum_size = Vector2(40, 0)
 
 [node name="LogInButton" type="Button" parent="MarginContainer/VBoxContainer"]
 unique_name_in_owner = true


### PR DESCRIPTION
## Summary
- Hide profile passwords behind circles when using a password instead of a random seed
- Add a toggle button to reveal or hide the password text

## Testing
- `godot3 --headless --path . -s tests/test_runner.gd` *(fails: Can't open project... config_version 5 requires newer engine)*
- Attempted to download Godot 4 headless binary but received 404/503 errors

------
https://chatgpt.com/codex/tasks/task_e_68afbde0232c8325a6cac2757df64abc