### PR TITLE
Fix Terminal stress test cyclic reference

### DIFF
--- a/components/apps/terminal/terminal.gd
+++ b/components/apps/terminal/terminal.gd
@@ -283,8 +283,12 @@ func process_command(command: String) -> bool:
 		
 		
 		"stress_test":
-			for app_name in WindowManager.app_registry.keys():
-				WindowManager.launch_app_by_name(app_name)
+			var wm := get_tree().root.get_node("WindowManager")
+			if wm:
+				var registry := wm.get("app_registry")
+				if registry is Dictionary:
+					for app_name in registry.keys():
+						wm.call("launch_app_by_name", app_name)
 			return true
 		
 		


### PR DESCRIPTION
## Summary
- prevent a parse-time cyclic reference in the Terminal's `stress_test` command by accessing the WindowManager autoload dynamically

## Testing
- `godot --headless -s tests/test_runner.gd` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68afc490b1588325bb2245b3689778b4