### PR TITLE
Fix terminal UI visibility and clean panel comments

### DIFF
--- a/components/apps/terminal/terminal.gd
+++ b/components/apps/terminal/terminal.gd
@@ -1,7 +1,6 @@
 extends Pane
 class_name Terminal
 
-#@onready var panel: PanelContainer = $PanelContainer
 @onready var command_line: LineEdit = %CommandLine
 @onready var enter_button: Button = %EnterButton
 @onready var feedback_label: Label = %FeedbackLabel
@@ -65,12 +64,17 @@ func _ready() -> void:
 	sb.bg_color = Color.BLACK
 	add_theme_stylebox_override("panel", sb)
 
-	# Monospaced, high‑contrast terminal look
-	var term_font := load("res://assets/fonts/Chicago.ttf")
-	add_theme_font_override("font", term_font)
-	add_theme_color_override("font_color", Color(0.8, 1.0, 0.8))
-	command_line.add_theme_color_override("font_color", Color(0.8, 1.0, 0.8))
-	command_line.add_theme_color_override("caret_color", Color(0.8, 1.0, 0.8))
+        # Monospaced, high‑contrast terminal look
+        var term_font := load("res://assets/fonts/Chicago.ttf")
+        var term_theme := Theme.new()
+        term_theme.default_font = term_font
+        var term_color := Color(0.8, 1.0, 0.8)
+        term_theme.set_color("font_color", "Label", term_color)
+        term_theme.set_color("font_color", "Button", term_color)
+        term_theme.set_color("font_color", "LineEdit", term_color)
+        theme = term_theme
+        command_line.add_theme_color_override("font_color", term_color)
+        command_line.add_theme_color_override("caret_color", term_color)
 
 	mouse_filter = Control.MOUSE_FILTER_STOP
 	visible = false

--- a/components/popups/calendar_popup_ui.gd
+++ b/components/popups/calendar_popup_ui.gd
@@ -46,9 +46,8 @@ func populate_calendar(month: int, year: int) -> void:
 	var today = TimeManager.get_today()
 	var due_bills = BillManager.get_due_bills_for_month(month, year)  # {day: Array[String]}
 
-	# Clear all previous panels
-	for child in grid_container.get_children():
-		child.queue_free()
+        for child in grid_container.get_children():
+                child.queue_free()
 
 	var day_number := 1
 

--- a/components/start_panel_window.gd
+++ b/components/start_panel_window.gd
@@ -47,10 +47,9 @@ func _ready() -> void:
 
 func _input(event: InputEvent) -> void:
 	if listening_for_clicks and event is InputEventMouseButton and event.pressed:
-		# Check if the click is outside the StartPanel bounds
-		if not Rect2(Vector2.ZERO, size).has_point(get_local_mouse_position()):
-			hide()
-			listening_for_clicks = false
+                if not Rect2(Vector2.ZERO, size).has_point(get_local_mouse_position()):
+                        hide()
+                        listening_for_clicks = false
 
 func toggle_start_panel() -> void:
 	if visible:

--- a/components/ui/profile_panel.gd
+++ b/components/ui/profile_panel.gd
@@ -3,7 +3,6 @@ class_name ProfilePanel
 
 signal login_requested(slot_id: int)
 
-#@onready var profile_panel: Panel = %ProfilePanel
 @onready var profile_pic: PortraitView = %ProfilePic
 @onready var name_label: Label = %NameLabel
 @onready var username_label: Label = %UsernameLabel

--- a/components/ui/window_frame.gd
+++ b/components/ui/window_frame.gd
@@ -179,7 +179,6 @@ func _set_windowless_mode(enabled: bool) -> void:
 	close_button.visible = not enabled and window_can_close
 
 	# Adjust content margins/padding
-	#content_panel.margin_top = 0 if enabled else DEFAULT_MARGIN
 
 func _setup_windowless_drag():
 	if not pane or not pane.has_method("get_drag_handle"):

--- a/scripts/desktop_env.gd
+++ b/scripts/desktop_env.gd
@@ -27,9 +27,8 @@ func _ready() -> void:
 	#SaveManager.save_to_slot(PlayerManager.get_slot_id())
 	
 	GameManager.in_game = true
-	#hide_all_windows_and_panels()
-	WindowManager.taskbar_container = taskbar
-	WindowManager.start_panel = start_panel
+        WindowManager.taskbar_container = taskbar
+        WindowManager.start_panel = start_panel
 	DesktopLayoutManager.items_loaded.connect(_on_items_loaded)
 	DesktopLayoutManager.item_created.connect(_on_item_created)
 	DesktopLayoutManager.item_deleted.connect(_on_item_deleted)
@@ -127,7 +126,6 @@ func _apply_shader_settings() -> void:
 func hide_all_windows_and_panels() -> void:
 	start_panel.hide()
 	trash_window.hide()
-	# All apps should now open dynamically via StartPanel
 
 # ----------------------------- #
 # Taskbar / Start Menu Buttons #


### PR DESCRIPTION
## Summary
- Ensure terminal app text uses a readable theme so UI elements are visible
- Remove all leftover `#panel` comments from various scripts

## Testing
- `godot4 --headless --run tests/test_runner.tscn` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68afcccb7d608325b2c23e21b99a80d0