### PR TITLE
Ensure terminal UI is visible on launch

### DIFF
--- a/components/apps/terminal/terminal.gd
+++ b/components/apps/terminal/terminal.gd
@@ -76,23 +76,24 @@ func _ready() -> void:
         command_line.add_theme_color_override("font_color", term_color)
         command_line.add_theme_color_override("caret_color", term_color)
 
-	mouse_filter = Control.MOUSE_FILTER_STOP
-	visible = false
+        mouse_filter = Control.MOUSE_FILTER_STOP
 
-	enter_button.pressed.connect(_on_enter_pressed)
-	command_line.text_submitted.connect(_on_text_submitted)
-	enter_button.focus_mode = Control.FOCUS_NONE
+        enter_button.pressed.connect(_on_enter_pressed)
+        command_line.text_submitted.connect(_on_text_submitted)
+        enter_button.focus_mode = Control.FOCUS_NONE
 
-	_populate_command_list()
-	#command_list_container.visible = false
-	command_list_parent_container.visible = false
+        _populate_command_list()
+        #command_list_container.visible = false
+        command_list_parent_container.visible = false
+
+        # Ensure the terminal UI is visible when the app launches
+        call_deferred("open")
 	
 
 func open() -> void:
-		print("opening terminal")
-		visible = true
-		visible = true
-		call_deferred("_focus_line")
+                print("opening terminal")
+                visible = true
+                call_deferred("_focus_line")
 
 func close() -> void:
 	visible = false


### PR DESCRIPTION
## Summary
- Make Terminal panel visible when its window opens
- Remove duplicate visibility toggle
- Focus command line by default on launch

## Testing
- `godot3-server --path . --headless --script tests/test_runner.gd` *(fails: Can't open project at '/workspace/SigmaSim/project.godot', config_version 5 is from a more recent version of the engine)*

------
https://chatgpt.com/codex/tasks/task_e_68afd1b10e148325867bfaf2a57ed65d