### PR TITLE
Ensure StockPopupUI initializes with selected stock

### DIFF
--- a/components/apps/broke_rage/stock_row.gd
+++ b/components/apps/broke_rage/stock_row.gd
@@ -76,7 +76,7 @@ func update_sentiment_arrow(sentiment: float) -> void:
 
 
 func _on_stock_label_gui_input(event: InputEvent) -> void:
-	if event is InputEventMouseButton and event.pressed and event.button_index == MOUSE_BUTTON_LEFT:
-		var popup_scene = preload("res://components/popups/stock_popup_ui.tscn")
-		var stock_popup = popup_scene.instantiate() as Pane
-		WindowManager.launch_pane_instance(stock_popup, stock)
+        if event is InputEventMouseButton and event.pressed and event.button_index == MOUSE_BUTTON_LEFT:
+                var popup_scene = preload("res://components/popups/stock_popup_ui.tscn")
+                var stock_popup = popup_scene.instantiate() as Pane
+                WindowManager.launch_pane_instance(stock_popup, stock.symbol)

--- a/components/popups/stock_popup_ui.gd
+++ b/components/popups/stock_popup_ui.gd
@@ -19,8 +19,13 @@ class_name StockPopupUI
 var stock: Stock
 
 func setup_custom(args) -> void:
-	if args is Stock:
-		setup(args)
+        var s: Stock = null
+        if args is Stock:
+                s = args
+        elif typeof(args) == TYPE_STRING:
+                s = MarketManager.get_stock(args)
+        if s:
+                setup(s)
 
 func setup(_stock: Stock) -> void:
 	stock = _stock


### PR DESCRIPTION
## Summary
- Launch StockPopupUI using the stock's symbol from StockRow
- Allow StockPopupUI to accept either a Stock or symbol and load the corresponding stock

## Testing
- `godot --headless --path . tests/test_runner.tscn` *(fails: Error loading custom project theme, missing resources, parse errors)*

------
https://chatgpt.com/codex/tasks/task_e_68afe1b91de483258c9759120e0d9916