### PR TITLE
Fix stock popup initialization

### DIFF
--- a/components/apps/broke_rage/stock_row.gd
+++ b/components/apps/broke_rage/stock_row.gd
@@ -76,7 +76,7 @@ func update_sentiment_arrow(sentiment: float) -> void:
 
 
 func _on_stock_label_gui_input(event: InputEvent) -> void:
-        if event is InputEventMouseButton and event.pressed and event.button_index == MOUSE_BUTTON_LEFT:
-                var popup_scene = preload("res://components/popups/stock_popup_ui.tscn")
-                var stock_popup = popup_scene.instantiate() as Pane
-                WindowManager.launch_pane_instance(stock_popup, stock.symbol)
+       if event is InputEventMouseButton and event.pressed and event.button_index == MOUSE_BUTTON_LEFT:
+               var popup_scene = preload("res://components/popups/stock_popup_ui.tscn")
+               var stock_popup = popup_scene.instantiate() as Pane
+               WindowManager.launch_pane_instance(stock_popup, stock)


### PR DESCRIPTION
## Summary
- Pass the full `Stock` resource when launching StockPopupUI so the popup initializes correctly.

## Testing
- `godot --headless -s tests/test_runner.gd` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68afe7ba98b88325b0b5b459228679ce