### PR TITLE
Fix rainbow password display for random seed

### DIFF
--- a/components/ui/user_login_card_ui.gd
+++ b/components/ui/user_login_card_ui.gd
@@ -135,11 +135,9 @@ func _generate_rainbow_password() -> String:
 		Color(0.29, 0, 0.51),
 		Color(0.56, 0, 1),
 	]
-	var rng: RandomNumberGenerator = RandomNumberGenerator.new()
-	rng.randomize()
-	var bbcode: String = ""
-	for i in text.length():
-		var ch: String = text.substr(i, 1)
-		var color: Color = colors[rng.randi_range(0, colors.size() - 1)]
-		bbcode += "[color=%s]%s[/color]" % [color.to_html(), ch]
-	return bbcode
+        var bbcode: String = ""
+        for i in text.length():
+                var ch: String = text.substr(i, 1)
+                var color: Color = colors[i % colors.size()]
+                bbcode += "[color=%s]%s[/color]" % [color.to_html(), ch]
+        return bbcode


### PR DESCRIPTION
## Summary
- Cycle through rainbow colors sequentially when rendering default password for random seed users

## Testing
- `godot --headless -s tests/test_runner.gd` *(fails: command not found)*
- `apt-get install -y godot4` *(fails: Unable to locate package godot4)*

------
https://chatgpt.com/codex/tasks/task_e_68afebc7739883258ab885be9bd40caf