### PR TITLE
Fix login card shrink behavior

### DIFF
--- a/components/ui/user_login_card_ui.tscn
+++ b/components/ui/user_login_card_ui.tscn
@@ -15,6 +15,7 @@ custom_minimum_size = Vector2(180, 190)
 offset_right = 181.0
 offset_bottom = 190.0
 size_flags_horizontal = 3
+size_flags_vertical = 4
 mouse_filter = 1
 theme_override_styles/panel = SubResource("StyleBoxFlat_6fwkw")
 script = ExtResource("1_k4nqg")


### PR DESCRIPTION
## Summary
- Ensure unselected login cards shrink by preventing vertical fill

## Testing
- `./godot4/Godot_v4.2.1-stable_linux.x86_64 --headless tests/test_runner.tscn` *(fails: Failed loading resource: res://assets/money_pixeled.png)*

------
https://chatgpt.com/codex/tasks/task_e_68aff29c61fc83259f8670b1b5cc597b