### PR TITLE
Allow windows to be dragged partially off-screen

### DIFF
--- a/components/ui/window_frame.gd
+++ b/components/ui/window_frame.gd
@@ -32,6 +32,7 @@ var normal_position: Vector2
 var normal_size: Vector2
 
 const MIN_VISIBLE_AREA: Vector2 = Vector2(80, 40)
+const SNAP_MARGIN: int = 20
 var resize_margin := 8
 var is_resizing := false
 var resize_dir := Vector2.ZERO
@@ -275,16 +276,17 @@ func _apply_default_window_size_and_position():
 		call_deferred("_clamp_to_screen")
 
 func _clamp_to_screen() -> void:
-	await get_tree().process_frame
-	var screen_size = get_viewport().get_visible_rect().size
+        await get_tree().process_frame
+        var screen_size = get_viewport().get_visible_rect().size
 
-	var taskbar_height = 0
-	if WindowManager and WindowManager.has_method("get_taskbar_height"):
-		taskbar_height = WindowManager.get_taskbar_height()
+        var taskbar_height = 0
+        if WindowManager and WindowManager.has_method("get_taskbar_height"):
+                taskbar_height = WindowManager.get_taskbar_height()
 
-	var max_position = Vector2(screen_size.x - size.x, screen_size.y - size.y - taskbar_height)
+        var min_position = Vector2(SNAP_MARGIN - size.x, SNAP_MARGIN - size.y)
+        var max_position = Vector2(screen_size.x - SNAP_MARGIN, screen_size.y - taskbar_height - SNAP_MARGIN)
 
-	position = position.clamp(Vector2.ZERO, max_position)
+        position = position.clamp(min_position, max_position)
 
 
 func _process(_delta: float) -> void:


### PR DESCRIPTION
## Summary
- Allow window frames to move slightly off-screen
- Clamp windows back only when less than 20 pixels remain visible

## Testing
- `Godot_v4.2.2-stable_linux.x86_64 --headless --path . tests/test_runner.tscn` *(fails: Could not find type "ContextAction" and other missing resources)*

------
https://chatgpt.com/codex/tasks/task_e_68aff5cc2a188325b17c37b31ad9087e