### PR TITLE
Fix UserLoginCardUI vertical sizing on selection

### DIFF
--- a/components/ui/user_login_card_ui.gd
+++ b/components/ui/user_login_card_ui.gd
@@ -80,37 +80,39 @@ func _apply_profile_data() -> void:
 	slot_id = pending_slot_id
 
 func expand() -> void:
-	if expanded:
-		return
-	expanded = true
-	net_worth_label.text = "$" + NumberFormatter.format_commas(float(pending_data.get("net_worth", 0.0)), 2, true)
-	net_worth_label.show()
-	password_hbox.show()
-	log_in_button.show()
-	if tween != null:
-		tween.kill()
-	tween = create_tween()
-	tween.tween_property(self, "custom_minimum_size:y", expanded_height, 0.25)
-	tween.parallel().tween_property(self, "size:y", expanded_height, 0.25)
-	tween.parallel().tween_property(net_worth_label, "modulate:a", 1.0, 0.25).from(0.0)
-	tween.parallel().tween_property(password_hbox, "modulate:a", 1.0, 0.25).from(0.0)
+        if expanded:
+                return
+        expanded = true
+        size_flags_vertical = Control.SIZE_EXPAND_FILL
+        net_worth_label.text = "$" + NumberFormatter.format_commas(float(pending_data.get("net_worth", 0.0)), 2, true)
+        net_worth_label.show()
+        password_hbox.show()
+        log_in_button.show()
+        if tween != null:
+                tween.kill()
+        tween = create_tween()
+        tween.tween_property(self, "custom_minimum_size:y", expanded_height, 0.25)
+        tween.parallel().tween_property(self, "size:y", expanded_height, 0.25)
+        tween.parallel().tween_property(net_worth_label, "modulate:a", 1.0, 0.25).from(0.0)
+        tween.parallel().tween_property(password_hbox, "modulate:a", 1.0, 0.25).from(0.0)
 
 func collapse() -> void:
-		if not expanded:
-				return
-		expanded = false
-		if tween != null:
-				tween.kill()
-		tween = create_tween()
-		tween.tween_property(self, "custom_minimum_size:y", collapsed_height, 0.25)
-		tween.parallel().tween_property(self, "size:y", collapsed_height, 0.25)
-		tween.parallel().tween_property(net_worth_label, "modulate:a", 0.0, 0.25)
-		tween.parallel().tween_property(password_hbox, "modulate:a", 0.0, 0.25)
-		tween.finished.connect(func() -> void:
-				net_worth_label.hide()
-				password_hbox.hide()
-				log_in_button.hide()
-		)
+        if not expanded:
+                return
+        expanded = false
+        size_flags_vertical = Control.SIZE_SHRINK_CENTER
+        if tween != null:
+                tween.kill()
+        tween = create_tween()
+        tween.tween_property(self, "custom_minimum_size:y", collapsed_height, 0.25)
+        tween.parallel().tween_property(self, "size:y", collapsed_height, 0.25)
+        tween.parallel().tween_property(net_worth_label, "modulate:a", 0.0, 0.25)
+        tween.parallel().tween_property(password_hbox, "modulate:a", 0.0, 0.25)
+        tween.finished.connect(func() -> void:
+                net_worth_label.hide()
+                password_hbox.hide()
+                log_in_button.hide()
+        )
 
 func _on_log_in_button_pressed() -> void:
 	emit_signal("login_requested", slot_id)

--- a/components/ui/user_login_card_ui.tscn
+++ b/components/ui/user_login_card_ui.tscn
@@ -15,6 +15,7 @@ custom_minimum_size = Vector2(180, 190)
 offset_right = 181.0
 offset_bottom = 190.0
 size_flags_horizontal = 3
+size_flags_vertical = 4
 mouse_filter = 1
 theme_override_styles/panel = SubResource("StyleBoxFlat_6fwkw")
 script = ExtResource("1_k4nqg")


### PR DESCRIPTION
## Summary
- ensure selected user login card stretches vertically by setting `size_flags_vertical` on expand/collapse
- set default scene size flags to shrink vertically

## Testing
- `godot3-server --headless --quit --path . tests/test_runner.tscn` *(fails: Saved with newer format version)*

------
https://chatgpt.com/codex/tasks/task_e_68aff6d6e09c8325bf99b4acbe68092f