### PR TITLE
Ensure stock popup setup waits for readiness

### DIFF
--- a/components/popups/stock_popup_ui.gd
+++ b/components/popups/stock_popup_ui.gd
@@ -24,8 +24,12 @@ func setup_custom(args) -> void:
 								s = args
 				elif typeof(args) == TYPE_STRING:
 								s = MarketManager.get_stock(args)
-				if s:
-								call_deferred("setup", s)
+                                if s:
+                                                if is_inside_tree():
+                                                                setup(s)
+                                                else:
+                                                                await ready
+                                                                setup(s)
 
 func setup(_stock: Stock) -> void:
 	stock = _stock
@@ -95,7 +99,11 @@ func get_custom_save_data() -> Dictionary:
 
 func load_custom_save_data(data: Dictionary) -> void:
 	var symbol: String = data.get("symbol", "")
-	if symbol != "":
-				var s: Stock = MarketManager.get_stock(symbol)
-				if s:
-						call_deferred("setup", s)
+        if symbol != "":
+                                var s: Stock = MarketManager.get_stock(symbol)
+                                if s:
+                                                if is_inside_tree():
+                                                                setup(s)
+                                                else:
+                                                                await ready
+                                                                setup(s)


### PR DESCRIPTION
## Summary
- call StockPopupUI.setup directly when stock data available, awaiting `ready` as needed
- load saved stock data using same setup pattern

## Testing
- `godot --headless -s tests/test_runner.gd` *(fails: command not found)*
- `wget https://downloads.tuxfamily.org/godotengine/4.2.1/Godot_v4.2.1-stable_linux.x86_64.zip -O /tmp/godot.zip` *(fails: 503 Service Unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68aff84ccdf48325ab57dc9485f47eb8