### PR TITLE
Fix student loan payment via debt card

### DIFF
--- a/autoloads/bill_manager.gd
+++ b/autoloads/bill_manager.gd
@@ -323,15 +323,16 @@ func pay_debt(name: String, amount: float) -> void:
 		"Credit Card":
 			PortfolioManager.pay_down_credit(amount)
 			_set_credit_card_balance(PortfolioManager.credit_used, PortfolioManager.credit_limit)
-		"Student Loan":
-			if PortfolioManager.pay_with_cash(amount):
-				PortfolioManager.set_student_loans(max(PortfolioManager.get_student_loans() - amount, 0.0))
-				_set_student_loan_balance(PortfolioManager.get_student_loans())
-		_:
-			if PortfolioManager.pay_with_cash(amount):
-				var res: Dictionary = _get_debt_resource(name)
-				if not res.is_empty():
-										res["balance"] = max(res.get("balance", 0.0) - amount, 0.0)
+                "Student Loan":
+                        if PortfolioManager.pay_with_cash(amount):
+                                PortfolioManager.set_student_loans(max(PortfolioManager.get_student_loans() - amount, 0.0))
+                                _set_student_loan_balance(PortfolioManager.get_student_loans())
+                                student_loan_changed.emit()
+                _:
+                        if PortfolioManager.pay_with_cash(amount):
+                                var res: Dictionary = _get_debt_resource(name)
+                                if not res.is_empty():
+                                        res["balance"] = max(res.get("balance", 0.0) - amount, 0.0)
 										debt_resources_changed.emit()
 
 func take_payday_loan(amount: float) -> void:
@@ -809,9 +810,9 @@ func get_student_loan_summary() -> Dictionary:
 		out["autopay"] = false
 		return out
 
-func pay_student_loan(_amount: float) -> void:
-		student_loan_changed.emit()
-		Events.focus_wallet_card("student_loan")
+func pay_student_loan(amount: float) -> void:
+                pay_debt("Student Loan", amount)
+                Events.focus_wallet_card("student_loan")
 
 func set_student_loan_autopay(_enabled: bool) -> void:
 		student_loan_changed.emit()

--- a/tests/student_loan_debt_card_pay_test.gd
+++ b/tests/student_loan_debt_card_pay_test.gd
@@ -1,0 +1,28 @@
+extends SceneTree
+
+func _ready():
+        var pm = Engine.get_singleton("PortfolioManager")
+        var bm = Engine.get_singleton("BillManager")
+        pm.reset()
+        bm.reset()
+        pm.add_cash(100.0)
+        pm.set_student_loans(100.0)
+        bm.add_debt_resource({
+                "name": "Student Loan",
+                "balance": 100.0
+        })
+        var card = DebtCardUI.new()
+        get_root().add_child(card)
+        await card.ready
+        card.init({
+                "name": "Student Loan",
+                "balance": 100.0
+        })
+        card.pay_slider.value = 50.0
+        card._on_pay_pressed()
+        assert(pm.get_student_loans() == 50.0)
+        var res = bm.get_debt_resources()[0]
+        assert(res.get("balance") == 50.0)
+        print("student_loan_debt_card_pay_test passed")
+        quit()
+

--- a/tests/student_loan_debt_card_pay_test.gd.uid
+++ b/tests/student_loan_debt_card_pay_test.gd.uid
@@ -1,0 +1,1 @@
+uid://bsl9z0xx2g1ar


### PR DESCRIPTION
## Summary
- ensure debt card student loan payments emit balance updates
- route explicit student loan payments through debt payment logic
- test student loan debt card payments reduce both cash and loan

## Testing
- `godot3-server -s tests/test_runner.gd` *(fails: Can't open project, config_version 5 is from a more recent and incompatible version)*

------
https://chatgpt.com/codex/tasks/task_e_68aff882f35483258cd6c85b5caa7552