### PR TITLE
Fix day_passed signal to restore bill popups

### DIFF
--- a/autoloads/time_manager.gd
+++ b/autoloads/time_manager.gd
@@ -241,9 +241,9 @@ func load_from_data(data: Dictionary) -> void:
 
 	autosave_hour_counter = 0
 	# Emit signals to let listeners refresh
-	emit_signal("minute_passed", in_game_minutes)
-	emit_signal("hour_passed", current_hour, total_minutes_elapsed)
-	emit_signal("day_passed", current_day, current_month, current_year)
+        emit_signal("minute_passed", in_game_minutes)
+        emit_signal("hour_passed", current_hour, total_minutes_elapsed)
+        emit_signal("day_passed", current_day, current_month, current_year, total_minutes_elapsed)
 
 func reset() -> void:
 		_rebuild_total_minutes_from_defaults()
@@ -290,9 +290,9 @@ func _advance_time(minutes_to_add: int) -> void:
 				SaveManager.save_to_slot(SaveManager.current_slot_id)
 				print("Autosaving on slot " + str(SaveManager.current_slot_id))
 
-		# Day rollover detection via date change
-		if current_day != prev_day or current_month != prev_month or current_year != prev_year:
-			emit_signal("day_passed", current_day, current_month, current_year)
+                # Day rollover detection via date change
+                if current_day != prev_day or current_month != prev_month or current_year != prev_year:
+                        emit_signal("day_passed", current_day, current_month, current_year, total_minutes_elapsed)
 
 		# Mirror compatibility field after loop
 		total_minutes_elapsed = _total_minutes_elapsed - _start_total_minutes

--- a/tests/bill_manager_day_passed_popup_test.gd
+++ b/tests/bill_manager_day_passed_popup_test.gd
@@ -1,0 +1,15 @@
+extends SceneTree
+
+func _ready():
+    var bm = Engine.get_singleton("BillManager")
+    bm.reset()
+    var tm = Engine.get_singleton("TimeManager")
+    tm.reset()
+    # Advance one full day to trigger day_passed
+    tm._advance_time(24 * 60)
+    var date_key = "%d/%d/%d" % [tm.current_day, tm.current_month, tm.current_year]
+    assert(bm.active_bills.has(date_key))
+    assert(bm.active_bills[date_key].size() > 0)
+    print("bill_manager_day_passed_popup_test passed")
+    quit()
+

--- a/tests/bill_manager_day_passed_popup_test.gd.uid
+++ b/tests/bill_manager_day_passed_popup_test.gd.uid
@@ -1,0 +1,1 @@
+uid://fccf1ed7db984b1783c315b6151934ea


### PR DESCRIPTION
## Summary
- Ensure TimeManager emits `day_passed` with the expected total_minutes argument
- Add regression test confirming bill popups trigger when a new day starts

## Testing
- `godot3-server --headless --path . --script tests/test_runner.gd` *(fails: project requires Godot 4)*

------
https://chatgpt.com/codex/tasks/task_e_68aff8a849ec8325ab1c2b180d5269d3