### PR TITLE
Fix bill popup logic due to indentation

### DIFF
--- a/autoloads/bill_manager.gd
+++ b/autoloads/bill_manager.gd
@@ -104,14 +104,14 @@ func _on_day_passed(new_day: int, new_month: int, new_year: int) -> void:
 					continue
 
 			if autopay_enabled and attempt_to_autopay(bill_name):
-					mark_bill_paid(bill_name, today_key)
-					continue
+				mark_bill_paid(bill_name, today_key)
+				continue
 
 			# Queue bill popup for display
-					pending_bill_data[today_key].append({
-													"bill_name": bill_name,
-													"amount": amount
-					})
+			pending_bill_data[today_key].append({
+					"bill_name": bill_name,
+					"amount": amount
+			})
 
 	_update_debt_due_dates()
 	apply_debt_interest()


### PR DESCRIPTION
## Summary
- fix indentation in BillManager so bill popups queue correctly when autopay fails

## Testing
- `godot3-server --headless -s tests/test_runner.gd` *(fails: project config version 5 requires Godot 4)*

------
https://chatgpt.com/codex/tasks/task_e_68affe4effdc8325b2f81b2ef1ed236e