### PR TITLE
Guard reload from invalid save slot

### DIFF
--- a/autoloads/game_manager.gd
+++ b/autoloads/game_manager.gd
@@ -70,9 +70,10 @@ func reset_managers() -> void:
 	# Add more as systems grow
 
 func _on_reload_save():
-	if SaveManager.get_slot_path(SaveManager.current_slot_id) == null:
-		return
-	SaveManager.load_from_slot(SaveManager.current_slot_id)
+        # Avoid errors if there's no active save slot to reload
+        if SaveManager.current_slot_id <= 0:
+                return
+        SaveManager.load_from_slot(SaveManager.current_slot_id)
 
 	# Close Game Over screen
 	for child in get_tree().get_root().get_children():

--- a/components/popups/game_over.gd
+++ b/components/popups/game_over.gd
@@ -15,13 +15,16 @@ signal continue_pressed
 @onready var continue_button := %ContinueButton
 
 func _ready():
-	header_label.text = " GAME OVER "
-	reason_label.text = reason
-	
-	
-	delete_button.pressed.connect(func(): emit_signal("delete_save_pressed"))
-	reload_button.pressed.connect(func(): emit_signal("reload_save_pressed"))
-	continue_button.pressed.connect(func(): emit_signal("continue_pressed"))
+        header_label.text = " GAME OVER "
+        reason_label.text = reason
+
+       # Disable reloading if no valid save slot is active
+       reload_button.disabled = SaveManager.current_slot_id <= 0
+
+
+        delete_button.pressed.connect(func(): emit_signal("delete_save_pressed"))
+        reload_button.pressed.connect(func(): emit_signal("reload_save_pressed"))
+        continue_button.pressed.connect(func(): emit_signal("continue_pressed"))
 	
 	## Spawn Siggy to popup and taunt the player
 	


### PR DESCRIPTION
## Summary
- disable Game Over reload button when no save slot is active
- guard game manager reload handler against missing slot

## Testing
- `godot --headless -s tests/test_runner.gd` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b0028387bc8325984f08e67ca5d4e3