### PR TITLE
Fix blank NPC responses in battle UI

### DIFF
--- a/components/apps/fumble/fumble_battle/battle_ui.gd
+++ b/components/apps/fumble/fumble_battle/battle_ui.gd
@@ -771,21 +771,30 @@ func process_npc_response(move_type, response_id, success: bool) -> ChatBox:
 		key = "TRUE"
 
 	var entry = null
-	if response_id and RizzBattleData.npc_responses.has(response_id):
-		var pool = RizzBattleData.npc_responses[response_id][key]
-		if pool.size() > 0:
-			entry = pool[rng.randi() % pool.size()]
-			var has_alt: bool = false
-			for p in pool:
-				if str(p.response_line) != last_npc_core_line:
-					has_alt = true
-					break
-			if has_alt:
-				var attempts: int = 0
-				while str(entry.response_line) == last_npc_core_line and attempts < 10:
-					entry = pool[rng.randi() % pool.size()]
-					attempts += 1
-			core = str(entry.response_line)
+        if response_id and RizzBattleData.npc_responses.has(response_id):
+                var pool = RizzBattleData.npc_responses[response_id][key]
+                if pool.size() > 0:
+                        entry = pool[rng.randi() % pool.size()]
+                        var has_alt: bool = false
+                        for p in pool:
+                                if str(p.response_line) != last_npc_core_line:
+                                        has_alt = true
+                                        break
+                        if has_alt:
+                                var attempts: int = 0
+                                while str(entry.response_line) == last_npc_core_line and attempts < 10:
+                                        entry = pool[rng.randi() % pool.size()]
+                                        attempts += 1
+                        core = str(entry.response_line)
+                        var prefix: String = ""
+                        var suffix: String = ""
+                        if entry.has("response_prefix") and entry.response_prefix is Array and entry.response_prefix.size() > 0:
+                                var pref_pool = entry.response_prefix
+                                prefix = pref_pool[rng.randi() % pref_pool.size()]
+                        if entry.has("response_suffix") and entry.response_suffix is Array and entry.response_suffix.size() > 0:
+                                var suf_pool = entry.response_suffix
+                                suffix = suf_pool[rng.randi() % suf_pool.size()]
+                        response_text = str(prefix) + core + str(suffix)
 
 	elif RizzBattleData.npc_generic_responses.has(move_type):
 		var pool = RizzBattleData.npc_generic_responses[move_type][key]


### PR DESCRIPTION
## Summary
- ensure NPC response text is constructed when using response_id to avoid blank chat lines

## Testing
- `godot3 --headless -s tests/test_runner.gd` (fails: Can't open project; config version from a more recent engine)
- `apt-get install -y godot4` (fails: Unable to locate package godot4)


------
https://chatgpt.com/codex/tasks/task_e_68b0811965588325b8e66ebb95daa9b6