### PR TITLE
Add detailed market event logging

### DIFF
--- a/resources/market_events/market_event.gd
+++ b/resources/market_events/market_event.gd
@@ -32,107 +32,127 @@ var _dump_multiplier: float = 1.0
 enum State { PENDING, PUMPING, DUMPING, FINISHED }
 var _state: State = State.PENDING
 
+# Log current market prices for debugging
+func _print_market_snapshot(label: String) -> void:
+    var stock_parts: Array = []
+    for s in MarketManager.stock_market.values():
+        stock_parts.append("%s:%.2f" % [s.symbol, s.price])
+    var crypto_parts: Array = []
+    for c in MarketManager.crypto_market.values():
+        crypto_parts.append("%s:%.2f" % [c.symbol, c.price])
+    print("market snapshot ", label,
+        ": stocks=", ", ", ".join(stock_parts),
+        " cryptos=", ", ", ".join(crypto_parts))
+
 # Schedule the event using current time and RNG for randomness
 func schedule(now_minutes: int, rng: RandomNumberGenerator) -> void:
-	var start_delay: int = rng.randi_range(start_min_minutes, start_max_minutes)
-	_start_time = now_minutes + start_delay
-	var pump_duration: int = rng.randi_range(pump_duration_min, pump_duration_max)
-	var dump_duration: int = rng.randi_range(dump_duration_min, dump_duration_max)
-	_pump_end_time = _start_time + pump_duration
-	_dump_end_time = _pump_end_time + dump_duration
-	_pump_multiplier = rng.randf_range(pump_multiplier_min, pump_multiplier_max)
-	_dump_multiplier = rng.randf_range(dump_multiplier_min, dump_multiplier_max)
-	_state = State.PENDING
+    var start_delay: int = rng.randi_range(start_min_minutes, start_max_minutes)
+    _start_time = now_minutes + start_delay
+    var pump_duration: int = rng.randi_range(pump_duration_min, pump_duration_max)
+    var dump_duration: int = rng.randi_range(dump_duration_min, dump_duration_max)
+    _pump_end_time = _start_time + pump_duration
+    _dump_end_time = _pump_end_time + dump_duration
+    _pump_multiplier = rng.randf_range(pump_multiplier_min, pump_multiplier_max)
+    _dump_multiplier = rng.randf_range(dump_multiplier_min, dump_multiplier_max)
+    _state = State.PENDING
 
-	print("market event scheduled:",
-		" symbol=", target_symbol,
-		" type=", target_type,
-		" start_time=", _start_time,
-		" pump_end=", _pump_end_time,
-		" dump_end=", _dump_end_time,
-		" pump_mult=", _pump_multiplier,
-		" dump_mult=", _dump_multiplier
-	)
+    print("market event scheduled:",
+        " symbol=", target_symbol,
+        " type=", target_type,
+        " start_time=", _start_time,
+        " pump_end=", _pump_end_time,
+        " dump_end=", _dump_end_time,
+        " pump_mult=", _pump_multiplier,
+        " dump_mult=", _dump_multiplier
+    )
 
 func is_active() -> bool:
-	return _state == State.PUMPING or _state == State.DUMPING
+    return _state == State.PUMPING or _state == State.DUMPING
 
 func is_finished() -> bool:
-	return _state == State.FINISHED
+    return _state == State.FINISHED
 
 # Process the event, updating the asset price if necessary
 func process(now_minutes: int, asset) -> void:
-	if _state == State.FINISHED:
-		return
+    if _state == State.FINISHED:
+        return
 
-	if _state == State.PENDING and now_minutes >= _start_time:
-		_state = State.PUMPING
-		_starting_price = asset.price
-		print("market event started pump:",
-			" symbol=", target_symbol,
-			" starting_price=", _starting_price,
-			" time=", now_minutes
-		)
+    if _state == State.PENDING and now_minutes >= _start_time:
+        _state = State.PUMPING
+        _starting_price = asset.price
+        print("market event start:",
+            " symbol=", target_symbol,
+            " type=", target_type,
+            " pump_mult=", _pump_multiplier,
+            " dump_mult=", _dump_multiplier,
+            " pump_dur=", _pump_end_time - _start_time,
+            " dump_dur=", _dump_end_time - _pump_end_time,
+            " starting_price=", _starting_price,
+            " time=", now_minutes
+        )
+        _print_market_snapshot("start")
 
-	if _state == State.PUMPING:
-		var target_price: float = _starting_price * _pump_multiplier
-		var t: float = float(now_minutes - _start_time) / max(1.0, float(_pump_end_time - _start_time))
-		t = clamp(t, 0.0, 1.0)
-		var new_price: float = lerp(_starting_price, target_price, t)
-		var prev: float = asset.price
-		asset.price = new_price
-		asset.last_price = prev
-		if asset.price_history.size() > 0:
-			asset.price_history[asset.price_history.size() - 1] = asset.price
-		else:
-			asset.price_history.append(asset.price)
-		asset.all_time_high = max(asset.all_time_high, asset.price)
+    if _state == State.PUMPING:
+        var target_price: float = _starting_price * _pump_multiplier
+        var t: float = float(now_minutes - _start_time) / max(1.0, float(_pump_end_time - _start_time))
+        t = clamp(t, 0.0, 1.0)
+        var new_price: float = lerp(_starting_price, target_price, t)
+        var prev: float = asset.price
+        asset.price = new_price
+        asset.last_price = prev
+        if asset.price_history.size() > 0:
+            asset.price_history[asset.price_history.size() - 1] = asset.price
+        else:
+            asset.price_history.append(asset.price)
+        asset.all_time_high = max(asset.all_time_high, asset.price)
 
-		print("market event pumping:",
-			" symbol=", target_symbol,
-			" prev_price=", prev,
-			" new_price=", asset.price,
-			" target=", target_price,
-			" t=", t,
-			" time=", now_minutes
-		)
+        print("market event pumping:",
+            " symbol=", target_symbol,
+            " prev_price=", prev,
+            " new_price=", asset.price,
+            " target=", target_price,
+            " t=", t,
+            " time=", now_minutes
+        )
 
-		if now_minutes >= _pump_end_time:
-			_state = State.DUMPING
-			print("market event entered dumping:",
-				" symbol=", target_symbol,
-				" pump_peak=", asset.price,
-				" time=", now_minutes
-			)
+        if now_minutes >= _pump_end_time:
+            _state = State.DUMPING
+            print("market event peak:",
+                " symbol=", target_symbol,
+                " price=", asset.price,
+                " time=", now_minutes
+            )
+            _print_market_snapshot("peak")
 
-	elif _state == State.DUMPING:
-		var pump_price: float = _starting_price * _pump_multiplier
-		var target_price: float = _starting_price * _dump_multiplier
-		var t: float = float(now_minutes - _pump_end_time) / max(1.0, float(_dump_end_time - _pump_end_time))
-		t = clamp(t, 0.0, 1.0)
-		var new_price: float = lerp(pump_price, target_price, t)
-		var prev: float = asset.price
-		asset.price = new_price
-		asset.last_price = prev
-		if asset.price_history.size() > 0:
-			asset.price_history[asset.price_history.size() - 1] = asset.price
-		else:
-			asset.price_history.append(asset.price)
-		asset.all_time_high = max(asset.all_time_high, asset.price)
+    elif _state == State.DUMPING:
+        var pump_price: float = _starting_price * _pump_multiplier
+        var target_price: float = _starting_price * _dump_multiplier
+        var t: float = float(now_minutes - _pump_end_time) / max(1.0, float(_dump_end_time - _pump_end_time))
+        t = clamp(t, 0.0, 1.0)
+        var new_price: float = lerp(pump_price, target_price, t)
+        var prev: float = asset.price
+        asset.price = new_price
+        asset.last_price = prev
+        if asset.price_history.size() > 0:
+            asset.price_history[asset.price_history.size() - 1] = asset.price
+        else:
+            asset.price_history.append(asset.price)
+        asset.all_time_high = max(asset.all_time_high, asset.price)
 
-		print("market event dumping:",
-			" symbol=", target_symbol,
-			" prev_price=", prev,
-			" new_price=", asset.price,
-			" target=", target_price,
-			" t=", t,
-			" time=", now_minutes
-		)
+        print("market event dumping:",
+            " symbol=", target_symbol,
+            " prev_price=", prev,
+            " new_price=", asset.price,
+            " target=", target_price,
+            " t=", t,
+            " time=", now_minutes
+        )
 
-		if now_minutes >= _dump_end_time:
-			_state = State.FINISHED
-			print("market event finished:",
-				" symbol=", target_symbol,
-				" final_price=", asset.price,
-				" time=", now_minutes
-			)
+        if now_minutes >= _dump_end_time:
+            _state = State.FINISHED
+            print("market event end:",
+                " symbol=", target_symbol,
+                " final_price=", asset.price,
+                " time=", now_minutes
+            )
+            _print_market_snapshot("end")


### PR DESCRIPTION
## Summary
- Add market snapshot helper to log current stock and crypto prices
- Print market snapshots when events start, reach peak, and end

## Testing
- `godot --headless -s res://tests/test_runner.gd` *(fails: command not found)*
- `apt-get install -y godot` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68b085981e08832582d915f433ac5fd9