### PR TITLE
Fix fumble profile UI layout

### DIFF
--- a/components/apps/fumble/fumble_profile.gd
+++ b/components/apps/fumble/fumble_profile.gd
@@ -251,12 +251,18 @@ func _run_entrance_animation() -> void:
 
 
 func _await_layout_ready() -> void:
-		await get_tree().process_frame
-		await get_tree().process_frame
-		var attempts := 0
-		while stats_grid.position.y == 0 and attempts < 10:
-				await get_tree().process_frame
-				attempts += 1
+                await get_tree().process_frame
+                await get_tree().process_frame
+                var attempts := 0
+                while stats_grid.position.y == 0 and attempts < 10:
+                                # Force the parent containers to recalculate their
+                                # layout so the profile sections aren't stacked at
+                                # the top when first loaded.
+                                var parent_container := stats_grid.get_parent()
+                                if parent_container is Control:
+                                                parent_container.queue_sort()
+                                await get_tree().process_frame
+                                attempts += 1
 
 
 func _clear_children(container: Node) -> void:


### PR DESCRIPTION
## Summary
- ensure FumbleProfile UI containers re-sort before entrance animation to prevent content from piling at the top

## Testing
- `godot3 --headless --path . -s tests/test_runner.gd` *(fails: Can't open project at '/workspace/SigmaSim/project.godot', its `config_version` (5) is from a more recent and incompatible version of the engine)*

------
https://chatgpt.com/codex/tasks/task_e_68b096afb5a48325903170f9526c607b