### PR TITLE
Ensure newly loaded FumbleProfile cards lay out correctly

### DIFF
--- a/components/apps/fumble/fumble.gd
+++ b/components/apps/fumble/fumble.gd
@@ -124,10 +124,10 @@ func _setup_over_frames() -> void:
 
 
 func add_npc_profile_to_top(idx: int) -> void:
-		while card_stack == null:
-				await get_tree().process_frame
-		show_swipes_tab()
-		card_stack.add_card_to_top(idx)
+	while card_stack == null:
+		await get_tree().process_frame
+	show_swipes_tab()
+	await card_stack.add_card_to_top(idx)
 
 
 func _on_card_swiped_left(npc_idx):

--- a/components/apps/fumble/profile_card_stack.gd
+++ b/components/apps/fumble/profile_card_stack.gd
@@ -37,19 +37,20 @@ func load_initial_cards() -> void:
 
 
 func _add_card_at_top(idx: int) -> void:
-		var card = profile_card_scene.instantiate()
-		card.set("npc_idx", idx)
-		var npc = NPCManager.get_npc_by_index(idx)
-		add_child(card)
-		card.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
-		card.call_deferred("load_npc", npc)
-		cards.append(card)
-		npc_indices.append(idx)
-		_update_card_positions()
+	var card = profile_card_scene.instantiate()
+	card.set("npc_idx", idx)
+	var npc = NPCManager.get_npc_by_index(idx)
+	add_child(card)
+	card.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
+	await card.ready
+	card.load_npc(npc)
+	cards.append(card)
+	npc_indices.append(idx)
+	_update_card_positions()
 
 
 func add_card_to_top(idx: int) -> void:
-		_add_card_at_top(idx)
+	await _add_card_at_top(idx)
 
 
 func _add_card_at_bottom(idx: int) -> void:
@@ -58,7 +59,8 @@ func _add_card_at_bottom(idx: int) -> void:
 	var npc = NPCManager.get_npc_by_index(idx)
 	add_child(card)
 	card.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
-	card.call_deferred("load_npc", npc)
+	await card.ready
+	card.load_npc(npc)
 	cards.insert(0, card)
 	npc_indices.insert(0, idx)
 	_update_card_positions()
@@ -113,7 +115,7 @@ func _after_swipe() -> void:
 		await _refill_swipe_pool_async()
 	var idx: int = await _fetch_next_index_from_pool()
 	if idx != -1:
-		_add_card_at_bottom(idx)
+		await _add_card_at_bottom(idx)
 
 
 func clear_cards() -> void:
@@ -166,10 +168,10 @@ func _populate_cards_over_frames(count: int, add_at_top: bool = true) -> void:
 		if idx == -1:
 			break
 		if add_at_top:
-			_add_card_at_top(idx)
+			await _add_card_at_top(idx)
 		else:
-			_add_card_at_bottom(idx)
-		await get_tree().process_frame  # Spread out the work
+			await _add_card_at_bottom(idx)
+		await get_tree().process_frame	# Spread out the work
 
 func _ensure_card_count_async(add_at_top: bool = true) -> void:
 	while cards.size() < CARD_VISIBLE_COUNT:
@@ -178,9 +180,9 @@ func _ensure_card_count_async(add_at_top: bool = true) -> void:
 			await get_tree().process_frame
 			continue
 		if add_at_top:
-			_add_card_at_top(idx)
+			await _add_card_at_top(idx)
 		else:
-			_add_card_at_bottom(idx)
+			await _add_card_at_bottom(idx)
 		await get_tree().process_frame
 
 


### PR DESCRIPTION
## Summary
- wait for card nodes to be ready before populating profile data
- load new cards sequentially and await card creation when adding or swiping
- await card addition in Fumble UI when injecting a profile at the top

## Testing
- `godot3-server --headless -s tests/test_runner.gd` *(fails: Can't open project, expected config version 4)*

------
https://chatgpt.com/codex/tasks/task_e_68b098424d88832590d75cf215d62215