### PR TITLE
Await layout before showing Fumble profile UI

### DIFF
--- a/components/apps/fumble/fumble_battle/battle_ui.gd
+++ b/components/apps/fumble/fumble_battle/battle_ui.gd
@@ -743,9 +743,9 @@ func animate_success_or_fail(success: bool):
 
 
 
-func _on_npc_profile_button_pressed():
-		profile_center_container.show()
-		fumble_profile.load_npc(npc, npc_idx)
+func _on_npc_profile_button_pressed() -> void:
+	await fumble_profile.load_npc(npc, npc_idx)
+	profile_center_container.show()
 
 
 func _on_close_fumble_profile_button_pressed():

--- a/components/apps/fumble/fumble_match_profile.gd
+++ b/components/apps/fumble/fumble_match_profile.gd
@@ -11,12 +11,11 @@ var npc: NPC
 var npc_idx
 
 
-func set_profile(profile_npc, profile_idx):
+func set_profile(profile_npc, profile_idx) -> void:
 	npc = profile_npc
 	npc_idx = profile_idx
-	fumble_profile.call_deferred("load_npc", npc, npc_idx)
-	
-	
+	await fumble_profile.load_npc(npc, npc_idx)
+
 	var already_in_battle = FumbleManager.has_active_battle(npc_idx)
 	chat_button.visible = not already_in_battle
 

--- a/components/apps/fumble/fumble_profile.gd
+++ b/components/apps/fumble/fumble_profile.gd
@@ -1,5 +1,6 @@
 class_name FumbleProfileUI
 extends PanelContainer
+signal profile_loaded
 
 @export var profile_bg_color: Color = Color(0.147672, 0.147672, 0.147672, 1.0)
 @export var section_bg_color: Color = Color(1, 1, 1, 0.05)
@@ -59,6 +60,7 @@ func _ready() -> void:
 		_apply_colors()
 
 func load_npc(npc: NPC, npc_idx: int = -1) -> void:
+	visible = false
 	portrait.apply_config(npc.portrait_config)
 	portrait.portrait_creator_enabled = true
 	portrait.subject_npc_idx = npc_idx
@@ -88,7 +90,10 @@ func load_npc(npc: NPC, npc_idx: int = -1) -> void:
 	_populate_mbti(npc)
 	_populate_ocean(npc)
 
-	call_deferred("_run_entrance_animation")
+	await _await_layout_ready()
+	visible = true
+	profile_loaded.emit()
+	_run_entrance_animation()
 
 func _apply_colors() -> void:
 	var root_style: StyleBoxFlat = get_theme_stylebox("panel").duplicate() as StyleBoxFlat
@@ -231,14 +236,12 @@ func _populate_ocean(npc: NPC) -> void:
 
 
 func _run_entrance_animation() -> void:
-	await _await_layout_ready()
-
 	portrait.modulate.a = 0.0
 	var p_tween: Tween = create_tween()
 	var py: float = portrait.position.y
 	p_tween.tween_property(portrait, "modulate:a", 1.0, 0.25)
 	p_tween.parallel().tween_property(portrait, "position:y", py, 0.25).from(py - 20.0)
-
+	
 	var root_tween: Tween = create_tween()
 	var delay_step: float = 0.06
 	var index: int = 0


### PR DESCRIPTION
## Summary
- hide Fumble profile UI until data loads and layout is ready, then emit `profile_loaded`
- await profile loading in battle and match profile UIs before displaying

## Testing
- `godot --headless --script tests/test_runner.gd` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b0a04da1c08325bec7d87014aa1197