### PR TITLE
Ensure FumbleProfileUI layout before entrance animation

### DIFF
--- a/components/apps/fumble/fumble_profile.gd
+++ b/components/apps/fumble/fumble_profile.gd
@@ -60,10 +60,11 @@ func _ready() -> void:
 		_apply_colors()
 
 func load_npc(npc: NPC, npc_idx: int = -1) -> void:
-	visible = false
-	portrait.apply_config(npc.portrait_config)
-	portrait.portrait_creator_enabled = true
-	portrait.subject_npc_idx = npc_idx
+        # Keep the root visible so layout calculations can occur, but hide visually
+        modulate.a = 0.0
+        portrait.apply_config(npc.portrait_config)
+        portrait.portrait_creator_enabled = true
+        portrait.subject_npc_idx = npc_idx
 
 	var dime_status: String
 	if Engine.has_singleton("NPCManager"):
@@ -87,13 +88,14 @@ func load_npc(npc: NPC, npc_idx: int = -1) -> void:
 	_populate_astrology(npc)
 	_populate_greek(npc)
 	_populate_wealth(npc)
-	_populate_mbti(npc)
-	_populate_ocean(npc)
+        _populate_mbti(npc)
+        _populate_ocean(npc)
 
-	await _await_layout_ready()
-	visible = true
-	profile_loaded.emit()
-	_run_entrance_animation()
+        visible = true
+        await _await_layout_ready()
+        modulate.a = 1.0
+        profile_loaded.emit()
+        _run_entrance_animation()
 
 func _apply_colors() -> void:
 	var root_style: StyleBoxFlat = get_theme_stylebox("panel").duplicate() as StyleBoxFlat


### PR DESCRIPTION
## Summary
- Keep FumbleProfileUI visible for layout and hide via alpha
- Reveal profile after layout then run entrance animation

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b0a440746c832584c9fef096286a1b