### PR TITLE
Animate rainbow hues on OmegaverseLabel

### DIFF
--- a/assets/shaders/wavy_walk_shader.gdshader
+++ b/assets/shaders/wavy_walk_shader.gdshader
@@ -14,25 +14,44 @@ uniform float meltness: hint_range(0.0, 3.0) = 1.0;
 // If it should affect only lower parts of the shader, it also increases the meltness
 uniform float how_low: hint_range(0.0, 5.0) = 1.0;
 
-// How wavy. 
+// How wavy.
 uniform float wave_frequency: hint_range(0.0, 30.0) = 20.0;
 
+// Number of letters in the label. Used to assign rainbow colors per letter.
+uniform float letter_count: hint_range(1.0, 64.0) = 10.0;
+
+// Speed at which the rainbow colors cycle through hues.
+uniform float color_speed: hint_range(0.0, 1.0) = 0.1;
+
 float wave(float x, float phase) {
-	return x - 2.5 + cos(2.0 * PI * phase + wave_frequency * x);
+    return x - 2.5 + cos(2.0 * PI * phase + wave_frequency * x);
+}
+
+vec3 hsv2rgb(vec3 c) {
+    vec4 K = vec4(1.0, 2.0/3.0, 1.0/3.0, 3.0);
+    vec3 p = abs(fract(c.xxx + K.xyz) * 6.0 - K.www);
+    return c.z * mix(K.xxx, clamp(p - K.xxx, 0.0, 1.0), c.y);
 }
 
 void fragment() {
-	vec2 uv = UV;
+    vec2 uv = UV;
 
-	// Animate phase: if speed == 0, fall back to manual progress
-	float phase = (speed > 0.0) ? fract(TIME * speed) : progress;
+    // Animate phase: if speed == 0, fall back to manual progress
+    float phase = (speed > 0.0) ? fract(TIME * speed) : progress;
 
-	uv.y -= pow(uv.y, how_low) * 0.02 * meltness * wave(UV.x - mod(UV.x, TEXTURE_PIXEL_SIZE.x), phase);
+    uv.y -= pow(uv.y, how_low) * 0.02 * meltness * wave(UV.x - mod(UV.x, TEXTURE_PIXEL_SIZE.x), phase);
 
-	COLOR = texture(TEXTURE, uv);
+    vec4 tex = texture(TEXTURE, uv);
 
-	// "delete" pixels out of range
-	if (uv.y <= 0.0 || uv.y >= 1.0) {
-		COLOR.a = 0.0;
-	}
+    // "delete" pixels out of range
+    if (uv.y <= 0.0 || uv.y >= 1.0) {
+        COLOR = vec4(0.0);
+        return;
+    }
+
+    float idx = floor(clamp(UV.x, 0.0, 0.9999) * letter_count);
+    float hue = fract(TIME * color_speed + idx / letter_count);
+    vec3 rgb = hsv2rgb(vec3(hue, 1.0, 1.0));
+
+    COLOR = vec4(rgb, tex.a);
 }

--- a/components/ui/log_in_ui.tscn
+++ b/components/ui/log_in_ui.tscn
@@ -46,6 +46,8 @@ shader_parameter/speed = 0.2
 shader_parameter/meltness = 1.74
 shader_parameter/how_low = 0.897
 shader_parameter/wave_frequency = 30.0
+shader_parameter/letter_count = 10.0
+shader_parameter/color_speed = 0.1
 
 [node name="LogInUI" type="Control"]
 layout_mode = 3


### PR DESCRIPTION
## Summary
- Add per-letter rainbow coloring with animated hue shift to wavy text shader
- Configure login scene label to use rainbow hue animation parameters

## Testing
- `godot3 --headless -s tests/test_runner.gd` *(fails: Can't open project at '/workspace/SigmaSim/project.godot', config_version (5) is from a more recent and incompatible version)*

------
https://chatgpt.com/codex/tasks/task_e_68b0a21aed0c8325933638859a59746c