### PR TITLE
Center profile labels in fumble_profile_ui

### DIFF
--- a/components/apps/fumble/fumble_profile_ui.tscn
+++ b/components/apps/fumble/fumble_profile_ui.tscn
@@ -75,6 +75,7 @@ size_flags_horizontal = 4
 [node name="DimeStatusLabel" type="Label" parent="Scroll/VBoxContainer/Margin/VBox"]
 unique_name_in_owner = true
 layout_mode = 2
+size_flags_horizontal = 4
 theme_override_colors/font_color = Color(0, 0, 0, 1)
 theme_override_font_sizes/font_size = 26
 text = "🔥 0.0/10"
@@ -83,6 +84,7 @@ horizontal_alignment = 1
 [node name="NameLabel" type="Label" parent="Scroll/VBoxContainer/Margin/VBox"]
 unique_name_in_owner = true
 layout_mode = 2
+size_flags_horizontal = 4
 theme_override_colors/font_color = Color(0, 0, 0, 1)
 theme_override_font_sizes/font_size = 24
 text = "Name"


### PR DESCRIPTION
## Summary
- ensure dime status and name labels use centered size flags in the Fumble profile UI

## Testing
- `godot --headless -s tests/test_runner.gd` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b0a97c8d948325bbbece14f43adc35