### PR TITLE
Remove unused Quick New button from login UI

### DIFF
--- a/components/ui/log_in_ui.gd
+++ b/components/ui/log_in_ui.gd
@@ -2,7 +2,6 @@ extends Control
 
 @export var profile_creation_scene: PackedScene
 @export var settings_panel_scene: PackedScene
-@export var show_quick_new_button: bool = true
 
 @onready var logging_in_panel: Panel = %LoggingInPanel
 @onready var logging_in_label: Label = %LoggingInLabel
@@ -11,19 +10,16 @@ extends Control
 @onready var profile_row: HBoxContainer = %ProfileRow
 
 @onready var settings_button: Button = %SettingsButton
-@onready var quick_new_button: Button = $Panel/ProfilesContainer/ProfileRow/QuickNewButton
 
 
 const UserLoginCardUI = preload("res://components/ui/user_login_card_ui.gd")
 var user_login_card_scene := preload("res://components/ui/user_login_card_ui.tscn")
-const PortraitFactory = preload("res://resources/portraits/portrait_factory.gd")
 
 
 func _ready() -> void:
 	TimeManager.stop_time()
 	logging_in_panel.hide()
 	profile_v_box_container.show()
-	quick_new_button.visible = show_quick_new_button
 
 	load_and_display_saved_profiles()
 
@@ -83,83 +79,6 @@ func _on_new_profile_button_pressed() -> void:
 	profile_creator.connect("new_profile_abandoned", _on_new_profile_abandoned)
 	%AOLLogoHolder.hide()
 	%ProfilesContainer.hide()
-
-func _on_quick_new_button_pressed() -> void:
-	SaveManager.reset_managers()
-	var rng := RandomNumberGenerator.new()
-	rng.randomize()
-
-	var name_data = NameManager.get_npc_name_by_index(rng.randi())
-	var full_name: String = name_data.get("full_name", "Player")
-	var user_data = PlayerManager.user_data
-	user_data["name"] = full_name
-	user_data["username"] = full_name.to_lower().replace(" ", "_")
-	user_data["password"] = ""
-
-	var gender_vec: Vector3 = name_data.get("gender_vector", Vector3.ONE)
-	var total := gender_vec.x + gender_vec.y + gender_vec.z
-	var roll := rng.randf() * total
-	var pronouns := "they/them/theirs"
-	if roll < gender_vec.x:
-			pronouns = "she/her/hers"
-	elif roll < gender_vec.x + gender_vec.y:
-			pronouns = "he/him/his"
-	user_data["pronouns"] = pronouns
-
-	var attractions: Array[String] = []
-	var x := 0.0
-	var y := 0.0
-	var z := 0.0
-	if rng.randf() < 0.5:
-			attractions.append("femmes")
-			x = 100.0
-	if rng.randf() < 0.5:
-			attractions.append("mascs")
-			y = 100.0
-	if rng.randf() < 0.5:
-			attractions.append("enbies")
-			z = 100.0
-	if attractions.is_empty():
-			var choice = rng.randi_range(0, 2)
-			match choice:
-					0:
-							attractions.append("femmes")
-							x = 100.0
-					1:
-							attractions.append("mascs")
-							y = 100.0
-					2:
-							attractions.append("enbies")
-							z = 100.0
-	user_data["attracted_to"] = attractions
-	user_data["fumble_pref_x"] = x
-	user_data["fumble_pref_y"] = y
-	user_data["fumble_pref_z"] = z
-
-	user_data["education_level"] = "Bachelor's Degree"
-	user_data["starting_student_debt"] = 80000.0
-	user_data["starting_credit_limit"] = 10000.0
-
-	var backgrounds = [
-			"The Dropout",
-			"The Burnout",
-			"The Gamer",
-			"The Manager",
-			"The Postgrad",
-			"The Stoic",
-			"Grandma's Favorite",
-			"Pretty Privilege",
-	]
-	var background = backgrounds[rng.randi_range(0, backgrounds.size() - 1)]
-	user_data["background"] = background
-	user_data["background_path"] = ""
-
-	var portrait_cfg = PortraitFactory.generate_config_for_name(full_name)
-	user_data["portrait_config"] = portrait_cfg.to_dict()
-
-	var slot_id = SaveManager.get_next_available_slot()
-	SaveManager.initialize_new_profile(slot_id, user_data)
-	await _on_profile_login_requested(slot_id)
 
 func _on_new_profile_created(slot_id):
 	print("new profile created in slot " + str(slot_id))

--- a/components/ui/log_in_ui.tscn
+++ b/components/ui/log_in_ui.tscn
@@ -150,15 +150,6 @@ size_flags_vertical = 4
 focus_mode = 0
 text = " New Profile "
 
-[node name="QuickNewButton" type="Button" parent="Panel/ProfilesContainer/ProfileRow"]
-visible = false
-custom_minimum_size = Vector2(70, 60)
-layout_mode = 2
-size_flags_horizontal = 4
-size_flags_vertical = 4
-focus_mode = 0
-text = " Quick New "
-
 [node name="ProfileCreationUI" parent="Panel" instance=ExtResource("3_6fwkw")]
 visible = false
 layout_mode = 1
@@ -279,6 +270,5 @@ focus_mode = 0
 text = "Credits"
 
 [connection signal="pressed" from="Panel/ProfilesContainer/ProfileRow/NewProfileButton" to="." method="_on_new_profile_button_pressed"]
-[connection signal="pressed" from="Panel/ProfilesContainer/ProfileRow/QuickNewButton" to="." method="_on_quick_new_button_pressed"]
 [connection signal="pressed" from="AOLLogoHolder/MarginContainer/HBoxContainer/SettingsButton" to="." method="_on_settings_button_pressed"]
 [connection signal="pressed" from="AOLLogoHolder/MarginContainer/HBoxContainer/PowerButton" to="." method="_on_power_button_pressed"]


### PR DESCRIPTION
## Summary
- remove the Quick New profile button from the login UI scene and script
- clean up related quick-create logic and unused preload

## Testing
- `godot3-server --headless --path . -s tests/test_runner.gd` *(fails: Can't open project at '/workspace/SigmaSim/project.godot', its `config_version` (5) is from a more recent and incompatible version of the engine)*

------
https://chatgpt.com/codex/tasks/task_e_68b0ad7ba44c83258fead1aeadc38041