### PR TITLE
Add start screen with fade into login

### DIFF
--- a/components/main.gd
+++ b/components/main.gd
@@ -2,10 +2,16 @@ extends Node
 
 var login_scene := preload("res://components/ui/log_in_ui.tscn")
 var desktop_scene := preload("res://components/desktop_env.tscn")
+var start_scene := preload("res://components/ui/start_screen.tscn")
 var current_screen: Node
+var start_screen: Control
 
 func _ready() -> void:
-	show_login_ui()
+        show_login_ui()
+        current_screen.visible = false
+        start_screen = start_scene.instantiate()
+        add_child(start_screen)
+        start_screen.continue_pressed.connect(_on_start_screen_continue)
 
 func show_login_ui() -> void:
 	_switch_screen(login_scene.instantiate())
@@ -17,7 +23,11 @@ func show_desktop_env(slot_id: int = SaveManager.current_slot_id) -> void:
 	GameManager.in_game = true
 
 func _switch_screen(screen: Node) -> void:
-	if current_screen and is_instance_valid(current_screen):
-		current_screen.queue_free()
-	current_screen = screen
-	add_child(current_screen)
+        if current_screen and is_instance_valid(current_screen):
+                current_screen.queue_free()
+        current_screen = screen
+        add_child(current_screen)
+
+func _on_start_screen_continue() -> void:
+        if current_screen:
+                current_screen.visible = true

--- a/components/ui/start_screen.gd
+++ b/components/ui/start_screen.gd
@@ -1,0 +1,20 @@
+extends Control
+
+## Displays a simple start screen and fades out when any key or mouse button is pressed.
+signal continue_pressed
+
+var _started := false
+
+func _ready() -> void:
+        set_process_input(true)
+
+func _input(event: InputEvent) -> void:
+        if _started:
+                return
+        if event.is_pressed():
+                _started = true
+                emit_signal("continue_pressed")
+                var tween = create_tween()
+                tween.tween_property(self, "modulate:a", 0.0, 0.5)
+                tween.finished.connect(queue_free)
+                set_process_input(false)

--- a/components/ui/start_screen.tscn
+++ b/components/ui/start_screen.tscn
@@ -1,0 +1,30 @@
+[gd_scene load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://components/ui/start_screen.gd" id="1"]
+
+[node name="StartScreen" type="Control"]
+anchor_right = 1.0
+anchor_bottom = 1.0
+script = ExtResource("1")
+
+[node name="ColorRect" type="ColorRect" parent="."]
+anchor_right = 1.0
+anchor_bottom = 1.0
+color = Color(0, 0, 0, 1)
+
+[node name="CenterContainer" type="CenterContainer" parent="."]
+anchor_right = 1.0
+anchor_bottom = 1.0
+
+[node name="VBox" type="VBoxContainer" parent="CenterContainer"]
+alignment = 1
+
+[node name="Title" type="Label" parent="CenterContainer/VBox"]
+text = "SIGMA SIM"
+horizontal_alignment = 1
+theme_override_font_sizes/font_size = 96
+
+[node name="Subtitle" type="Label" parent="CenterContainer/VBox"]
+text = "press any key to continue"
+horizontal_alignment = 1
+theme_override_font_sizes/font_size = 24


### PR DESCRIPTION
## Summary
- Show a start screen with "SIGMA SIM" and "press any key to continue"
- Reveal login UI after start screen fades out

## Testing
- `godot --headless --path . tests/test_runner.tscn` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b0b583db2c832597d5a82379ec191d