### PR TITLE
Prevent credit balance decreasing on credit payments

### DIFF
--- a/autoloads/portfolio_manager.gd
+++ b/autoloads/portfolio_manager.gd
@@ -244,18 +244,21 @@ func pay_with_cash(amount: float) -> bool:
 
 ## --- Credit functions
 func can_pay_with_credit(amount: float) -> bool:
-	return get_credit_used() + amount <= get_credit_limit()
+        if amount <= 0.0:
+                return false
+        return get_credit_used() + amount <= get_credit_limit()
 
 
 func pay_with_credit(amount: float) -> bool:
-		if can_pay_with_credit(amount):
-				var total_with_interest := amount * (1.0 + get_credit_interest_rate())
-				set_credit_used(get_credit_used() + total_with_interest)
-				emit_signal("credit_updated", get_credit_used(), get_credit_limit())
-				emit_signal("resource_changed", "credit_used", get_credit_used())
-				WindowManager.launch_app_by_name("OwerView")
-				return true
-		return false
+                amount = abs(amount)
+                if can_pay_with_credit(amount):
+                                var total_with_interest := amount * (1.0 + get_credit_interest_rate())
+                                set_credit_used(get_credit_used() + total_with_interest)
+                                emit_signal("credit_updated", get_credit_used(), get_credit_limit())
+                                emit_signal("resource_changed", "credit_used", get_credit_used())
+                                WindowManager.launch_app_by_name("OwerView")
+                                return true
+                return false
 
 func get_credit_remaining() -> float:
 		return get_credit_limit() - get_credit_used()


### PR DESCRIPTION
## Summary
- Ignore non-positive amounts when charging purchases to credit
- Normalize credit charges to avoid reducing used balance

## Testing
- `./godot4/Godot_v4.2.1-stable_linux.x86_64 --headless --path . -s tests/pay_with_credit_bill_test.gd` *(fails: missing resources)*

------
https://chatgpt.com/codex/tasks/task_e_68b0b5ef8a348325a1dca07669136839