### PR TITLE
Refactor debt compounding timers

### DIFF
--- a/tests/credit_card_next_due_test.gd
+++ b/tests/credit_card_next_due_test.gd
@@ -7,13 +7,14 @@ func _ready():
     tm.reset()
     bm.add_debt_resource({
         "name": "Credit Card",
-        "balance": 0.0
+        "balance": 0.0,
     })
     var res = bm.get_debt_resources()[0]
+    assert(res.get("compound_interval") == 7 * 1440)
+    assert(res.get("compounds_in") == 7 * 1440)
     var day = tm.current_day
     var month = tm.current_month
     var year = tm.current_year
-    var days_ahead = 0
     var expected := ""
     while true:
         var bills = bm.get_due_bills_for_date(day, month, year)
@@ -28,8 +29,6 @@ func _ready():
             if month > 12:
                 month = 1
                 year += 1
-        days_ahead += 1
-    assert(res.get("days_until_due") == days_ahead)
     var summary = bm.get_credit_summary()
     assert(summary.get("next_due") == expected)
     print("credit_card_next_due_test passed")

--- a/tests/debt_days_tickdown_test.gd
+++ b/tests/debt_days_tickdown_test.gd
@@ -8,11 +8,12 @@ func _ready():
     bm.add_debt_resource({
         "name": "Test Debt",
         "balance": 0.0,
-        "days_until_due": 5
+        "compounds_in": 5 * 1440,
+        "compound_interval": 5 * 1440,
     })
     tm._advance_time(1440)
     var res = bm.get_debt_resources()[0]
-    assert(res.get("days_until_due") == 4)
+    assert(res.get("compounds_in") == 4 * 1440)
     print("debt_days_tickdown_test passed")
     quit()
 

--- a/tests/debt_time_tickdown_test.gd
+++ b/tests/debt_time_tickdown_test.gd
@@ -8,13 +8,14 @@ func _ready():
     bm.add_debt_resource({
         "name": "Timed Debt",
         "balance": 0.0,
-        "minutes_until_due": 90
+        "compounds_in": 90,
+        "compound_interval": 90,
     })
     tm._advance_time(60)
     var res = bm.get_debt_resources()[0]
-    assert(res.get("minutes_until_due") == 30)
+    assert(res.get("compounds_in") == 30)
     tm._advance_time(30)
     res = bm.get_debt_resources()[0]
-    assert(res.get("minutes_until_due") == 0)
+    assert(res.get("compounds_in") == 0)
     print("debt_time_tickdown_test passed")
     quit()


### PR DESCRIPTION
## Summary
- track debt interest with `compounds_in` and `compound_interval`
- tick down and apply interest when timers expire
- persist new timer fields and update tests

## Testing
- `godot3 --headless --path . tests/test_runner.tscn` *(fails: Can't open project ... config_version (5) is from a more recent and incompatible version of the engine)*

------
https://chatgpt.com/codex/tasks/task_e_68b0dfd26a1c83259cf7a43cb5a60e62