### PR TITLE
feat: add charts tab to minerr

### DIFF
--- a/components/apps/app_scenes/minerr.tscn
+++ b/components/apps/app_scenes/minerr.tscn
@@ -70,40 +70,67 @@ theme_override_fonts/font = ExtResource("8_x88rl")
 theme_override_font_sizes/font_size = 36
 text = " Minerr"
 
-[node name="HBoxContainer" type="HBoxContainer" parent="MarginContainer/VBoxContainer"]
+[node name="MineView" type="VBoxContainer" parent="MarginContainer/VBoxContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_vertical = 3
+theme_override_constants/separation = 8
+
+[node name="MineTopBar" type="HBoxContainer" parent="MarginContainer/VBoxContainer/MineView"]
+layout_mode = 2
+
+[node name="MineTabButton" type="Button" parent="MarginContainer/VBoxContainer/MineView/MineTopBar"]
+unique_name_in_owner = true
+layout_mode = 2
+focus_mode = 0
+toggle_mode = true
+text = "Mine"
+
+[node name="ChartsTabButton" type="Button" parent="MarginContainer/VBoxContainer/MineView/MineTopBar"]
+unique_name_in_owner = true
+layout_mode = 2
+focus_mode = 0
+toggle_mode = true
+text = "Charts"
+
+[node name="Control" type="Control" parent="MarginContainer/VBoxContainer/MineView"]
+custom_minimum_size = Vector2(0, 6)
+layout_mode = 2
+
+[node name="HBoxContainer" type="HBoxContainer" parent="MarginContainer/VBoxContainer/MineView"]
 layout_mode = 2
 size_flags_vertical = 3
 
-[node name="LeftColumnVBox" type="VBoxContainer" parent="MarginContainer/VBoxContainer/HBoxContainer"]
+[node name="LeftColumnVBox" type="VBoxContainer" parent="MarginContainer/VBoxContainer/MineView/HBoxContainer"]
 layout_mode = 2
 size_flags_horizontal = 6
 size_flags_stretch_ratio = 0.0
 
-[node name="SortHBoxContainer" type="HBoxContainer" parent="MarginContainer/VBoxContainer/HBoxContainer/LeftColumnVBox"]
+[node name="SortHBoxContainer" type="HBoxContainer" parent="MarginContainer/VBoxContainer/MineView/HBoxContainer/LeftColumnVBox"]
 unique_name_in_owner = true
 layout_mode = 2
 
-[node name="SortPropertyOption" type="OptionButton" parent="MarginContainer/VBoxContainer/HBoxContainer/LeftColumnVBox/SortHBoxContainer"]
+[node name="SortPropertyOption" type="OptionButton" parent="MarginContainer/VBoxContainer/MineView/HBoxContainer/LeftColumnVBox/SortHBoxContainer"]
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 3
 
-[node name="SortDirectionButton" type="Button" parent="MarginContainer/VBoxContainer/HBoxContainer/LeftColumnVBox/SortHBoxContainer"]
+[node name="SortDirectionButton" type="Button" parent="MarginContainer/VBoxContainer/MineView/HBoxContainer/LeftColumnVBox/SortHBoxContainer"]
 unique_name_in_owner = true
 layout_mode = 2
 text = " "
 
-[node name="Control" type="Control" parent="MarginContainer/VBoxContainer/HBoxContainer/LeftColumnVBox"]
+[node name="Control" type="Control" parent="MarginContainer/VBoxContainer/MineView/HBoxContainer/LeftColumnVBox"]
 custom_minimum_size = Vector2(0, 45)
 layout_mode = 2
 size_flags_vertical = 3
 
-[node name="VBoxContainer" type="VBoxContainer" parent="MarginContainer/VBoxContainer/HBoxContainer/LeftColumnVBox"]
+[node name="VBoxContainer" type="VBoxContainer" parent="MarginContainer/VBoxContainer/MineView/HBoxContainer/LeftColumnVBox"]
 layout_mode = 2
 size_flags_horizontal = 4
 size_flags_vertical = 3
 
-[node name="GPUsLabel" type="Label" parent="MarginContainer/VBoxContainer/HBoxContainer/LeftColumnVBox/VBoxContainer"]
+[node name="GPUsLabel" type="Label" parent="MarginContainer/VBoxContainer/MineView/HBoxContainer/LeftColumnVBox/VBoxContainer"]
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 4
@@ -113,37 +140,37 @@ Free/Owned:
 0/0"
 horizontal_alignment = 1
 
-[node name="Control" type="Control" parent="MarginContainer/VBoxContainer/HBoxContainer/LeftColumnVBox/VBoxContainer"]
+[node name="Control" type="Control" parent="MarginContainer/VBoxContainer/MineView/HBoxContainer/LeftColumnVBox/VBoxContainer"]
 custom_minimum_size = Vector2(0, 25)
 layout_mode = 2
 size_flags_horizontal = 4
 
-[node name="BuGPUsVBoxContainer" type="VBoxContainer" parent="MarginContainer/VBoxContainer/HBoxContainer/LeftColumnVBox/VBoxContainer"]
+[node name="BuGPUsVBoxContainer" type="VBoxContainer" parent="MarginContainer/VBoxContainer/MineView/HBoxContainer/LeftColumnVBox/VBoxContainer"]
 layout_mode = 2
 size_flags_horizontal = 4
 size_flags_vertical = 4
 size_flags_stretch_ratio = 0.35
 
-[node name="VBoxContainer" type="VBoxContainer" parent="MarginContainer/VBoxContainer/HBoxContainer/LeftColumnVBox/VBoxContainer/BuGPUsVBoxContainer"]
+[node name="VBoxContainer" type="VBoxContainer" parent="MarginContainer/VBoxContainer/MineView/HBoxContainer/LeftColumnVBox/VBoxContainer/BuGPUsVBoxContainer"]
 layout_mode = 2
 
-[node name="BuyNewGPUButton" type="Button" parent="MarginContainer/VBoxContainer/HBoxContainer/LeftColumnVBox/VBoxContainer/BuGPUsVBoxContainer/VBoxContainer"]
+[node name="BuyNewGPUButton" type="Button" parent="MarginContainer/VBoxContainer/MineView/HBoxContainer/LeftColumnVBox/VBoxContainer/BuGPUsVBoxContainer/VBoxContainer"]
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 6
 focus_mode = 0
 text = "Buy New GPU"
 
-[node name="NewGPUPriceLabel" type="Label" parent="MarginContainer/VBoxContainer/HBoxContainer/LeftColumnVBox/VBoxContainer/BuGPUsVBoxContainer/VBoxContainer"]
+[node name="NewGPUPriceLabel" type="Label" parent="MarginContainer/VBoxContainer/MineView/HBoxContainer/LeftColumnVBox/VBoxContainer/BuGPUsVBoxContainer/VBoxContainer"]
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 4
 
-[node name="VBoxContainer2" type="VBoxContainer" parent="MarginContainer/VBoxContainer/HBoxContainer/LeftColumnVBox/VBoxContainer/BuGPUsVBoxContainer"]
+[node name="VBoxContainer2" type="VBoxContainer" parent="MarginContainer/VBoxContainer/MineView/HBoxContainer/LeftColumnVBox/VBoxContainer/BuGPUsVBoxContainer"]
 visible = false
 layout_mode = 2
 
-[node name="BuyUsedGPUButton" type="Button" parent="MarginContainer/VBoxContainer/HBoxContainer/LeftColumnVBox/VBoxContainer/BuGPUsVBoxContainer/VBoxContainer2"]
+[node name="BuyUsedGPUButton" type="Button" parent="MarginContainer/VBoxContainer/MineView/HBoxContainer/LeftColumnVBox/VBoxContainer/BuGPUsVBoxContainer/VBoxContainer2"]
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 3
@@ -151,21 +178,65 @@ tooltip_text = "Used GPUs have a chance of burning out"
 focus_mode = 0
 text = "Buy Used GPU"
 
-[node name="UsedGPUPriceLabel" type="Label" parent="MarginContainer/VBoxContainer/HBoxContainer/LeftColumnVBox/VBoxContainer/BuGPUsVBoxContainer/VBoxContainer2"]
+[node name="UsedGPUPriceLabel" type="Label" parent="MarginContainer/VBoxContainer/MineView/HBoxContainer/LeftColumnVBox/VBoxContainer/BuGPUsVBoxContainer/VBoxContainer2"]
 unique_name_in_owner = true
 layout_mode = 2
 
-[node name="ScrollContainer" type="ScrollContainer" parent="MarginContainer/VBoxContainer/HBoxContainer"]
+[node name="ScrollContainer" type="ScrollContainer" parent="MarginContainer/VBoxContainer/MineView/HBoxContainer"]
 layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
 
-[node name="CryptoContainer" type="HBoxContainer" parent="MarginContainer/VBoxContainer/HBoxContainer/ScrollContainer"]
+[node name="CryptoContainer" type="HBoxContainer" parent="MarginContainer/VBoxContainer/MineView/HBoxContainer/ScrollContainer"]
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 6
 size_flags_vertical = 3
 theme = ExtResource("9_0t4uf")
 
-[connection signal="pressed" from="MarginContainer/VBoxContainer/HBoxContainer/LeftColumnVBox/VBoxContainer/BuGPUsVBoxContainer/VBoxContainer/BuyNewGPUButton" to="." method="_on_buy_new_gpu_button_pressed"]
-[connection signal="pressed" from="MarginContainer/VBoxContainer/HBoxContainer/LeftColumnVBox/VBoxContainer/BuGPUsVBoxContainer/VBoxContainer2/BuyUsedGPUButton" to="." method="_on_buy_used_gpu_button_pressed"]
+[node name="ChartsView" type="VBoxContainer" parent="MarginContainer/VBoxContainer"]
+unique_name_in_owner = true
+visible = false
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+theme_override_constants/separation = 8
+
+[node name="ChartsTopBar" type="HBoxContainer" parent="MarginContainer/VBoxContainer/ChartsView"]
+layout_mode = 2
+size_flags_horizontal = 3
+
+[node name="MineTabButtonCharts" type="Button" parent="MarginContainer/VBoxContainer/ChartsView/ChartsTopBar"]
+unique_name_in_owner = true
+layout_mode = 2
+focus_mode = 0
+toggle_mode = true
+text = "Mine"
+
+[node name="ChartsTabButtonCharts" type="Button" parent="MarginContainer/VBoxContainer/ChartsView/ChartsTopBar"]
+unique_name_in_owner = true
+layout_mode = 2
+focus_mode = 0
+toggle_mode = true
+text = "Charts"
+
+[node name="ChartsCashLabel" type="Label" parent="MarginContainer/VBoxContainer/ChartsView/ChartsTopBar"]
+unique_name_in_owner = true
+layout_mode = 2
+text = "Cash: $"
+
+[node name="ChartsCryptoLabel" type="Label" parent="MarginContainer/VBoxContainer/ChartsView/ChartsTopBar"]
+unique_name_in_owner = true
+layout_mode = 2
+text = "Crypto: $"
+
+[node name="Control" type="Control" parent="MarginContainer/VBoxContainer/ChartsView"]
+custom_minimum_size = Vector2(0, 18)
+layout_mode = 2
+
+[connection signal="pressed" from="MarginContainer/VBoxContainer/MineView/HBoxContainer/LeftColumnVBox/VBoxContainer/BuGPUsVBoxContainer/VBoxContainer/BuyNewGPUButton" to="." method="_on_buy_new_gpu_button_pressed"]
+[connection signal="pressed" from="MarginContainer/VBoxContainer/MineView/HBoxContainer/LeftColumnVBox/VBoxContainer/BuGPUsVBoxContainer/VBoxContainer2/BuyUsedGPUButton" to="." method="_on_buy_used_gpu_button_pressed"]
+[connection signal="pressed" from="MarginContainer/VBoxContainer/MineView/MineTopBar/MineTabButton" to="." method="_on_mine_tab_pressed"]
+[connection signal="pressed" from="MarginContainer/VBoxContainer/MineView/MineTopBar/ChartsTabButton" to="." method="_on_charts_tab_pressed"]
+[connection signal="pressed" from="MarginContainer/VBoxContainer/ChartsView/ChartsTopBar/MineTabButtonCharts" to="." method="_on_mine_tab_pressed"]
+[connection signal="pressed" from="MarginContainer/VBoxContainer/ChartsView/ChartsTopBar/ChartsTabButtonCharts" to="." method="_on_charts_tab_pressed"]


### PR DESCRIPTION
## Summary
- Add a Mine/Charts tab bar to Minerr and reorganize existing UI under Mine view
- Implement charts view that lists CryptoPopupUI for each crypto and tab switching logic

## Testing
- `./tmp/godot/Godot_v4.3-stable_linux.x86_64 --headless --path . --scene tests/test_runner.tscn` *(fails: Error loading custom project theme)*

------
https://chatgpt.com/codex/tasks/task_e_68b0f9f2628c8325abb9ca43ae79f678