### PR TITLE
Handle credit card payments correctly

### DIFF
--- a/tests/bill_manager_auto_resolve_credit_test.gd
+++ b/tests/bill_manager_auto_resolve_credit_test.gd
@@ -1,0 +1,19 @@
+extends SceneTree
+
+func _ready():
+    var pm = Engine.get_singleton("PortfolioManager")
+    var bm = Engine.get_singleton("BillManager")
+    pm.reset()
+    bm.reset()
+    pm.credit_interest_rate = 0.0
+    pm.cash = 0.0
+    var popup = preload("res://components/popups/bill_popup_ui.tscn").instantiate()
+    popup.bill_name = "TestBill"
+    popup.amount = 100.0
+    popup.date_key = "1/1/2000"
+    add_child(popup)
+    bm.register_popup(popup, "1/1/2000")
+    bm.auto_resolve_bills_for_date("1/1/2000")
+    assert(pm.credit_used == 100.0)
+    print("bill_manager_auto_resolve_credit_test passed")
+    quit()


### PR DESCRIPTION
## Summary
- Stop autopay from settling the credit card bill with more credit
- Route credit-payments through PortfolioManager.pay_with_credit
- Add test ensuring auto-resolved bills charge the credit card

## Testing
- `godot --headless -s tests/test_runner.gd` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b1293553c083259d123b46945bf1f3