### PR TITLE
Avoid game over when credit can cover bills

### DIFF
--- a/autoloads/bill_manager.gd
+++ b/autoloads/bill_manager.gd
@@ -154,17 +154,14 @@ func attempt_to_autopay(bill_name: String) -> bool:
                        print("❌ Autopay failed for %s" % bill_name)
                        return false
 
-       if PortfolioManager.pay_with_cash(amount):
-               print("✅ Autopaid %s with cash" % bill_name)
+       var required_score := PortfolioManager.CREDIT_REQUIREMENTS.get("bills", 0)
+       if PortfolioManager.attempt_spend(amount, required_score, true):
+               print("✅ Autopaid %s with available funds" % bill_name)
                return true
-       elif PortfolioManager.can_pay_with_credit(amount):
-               PortfolioManager.pay_with_credit(amount)
-               print("✅ Autopaid %s with credit" % bill_name)
-               return true
-       else:
-               print("❌ Autopay failed for %s" % bill_name)
-               # Siggy.activate("bill_unpayable")
-               return false
+
+       print("❌ Autopay failed for %s" % bill_name)
+       # Siggy.activate("bill_unpayable")
+       return false
 
 
 
@@ -229,13 +226,8 @@ func auto_resolve_bills_for_date(date_str: String) -> void:
                                        GameManager.trigger_game_over("Could not pay bill " + str(popup.bill_name))
                                continue
 
-                       if PortfolioManager.pay_with_cash(popup.amount):
-                                       print("✅ Autopaid %s with cash" % popup.amount)
-                                       mark_bill_paid(popup.bill_name, date_str)
-                                       popup.close()
-                                       return
-                       elif PortfolioManager.can_pay_with_credit(popup.amount):
-                                       PortfolioManager.pay_with_credit(popup.amount)
+                       var required_score := PortfolioManager.CREDIT_REQUIREMENTS.get("bills", 0)
+                       if PortfolioManager.attempt_spend(popup.amount, required_score, true):
                                        mark_bill_paid(popup.bill_name, date_str)
                                        popup.close()
                        else:

--- a/tests/bill_credit_game_over_test.gd
+++ b/tests/bill_credit_game_over_test.gd
@@ -1,0 +1,32 @@
+extends SceneTree
+
+func _ready():
+    var pm = Engine.get_singleton("PortfolioManager")
+    pm.reset()
+    pm.credit_used = 0.0
+    pm.credit_limit = 100.0
+    pm.credit_interest_rate = 0.0
+    pm.cash = 50.0
+    pm.credit_score = 800
+
+    var bm = Engine.get_singleton("BillManager")
+    bm.reset()
+
+    var gm = Engine.get_singleton("GameManager")
+    var game_over := false
+    gm.game_over_triggered.connect(func(_reason): game_over = true)
+
+    var popup = preload("res://components/popups/bill_popup_ui.tscn").instantiate()
+    popup.bill_name = "TestBill"
+    popup.amount = 120.0
+    popup.date_key = "1/1/2000"
+    add_child(popup)
+    bm.register_popup(popup, popup.date_key)
+
+    bm.auto_resolve_bills_for_date(popup.date_key)
+
+    assert(pm.cash == 0.0)
+    assert(pm.credit_used == 70.0)
+    assert(!game_over)
+    print("bill_credit_game_over_test passed")
+    quit()


### PR DESCRIPTION
## Summary
- Allow BillManager to combine cash and credit when paying bills
- Add regression test to ensure game over only when both cash and credit are exhausted

## Testing
- `godot --headless -s tests/test_runner.gd` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b13171eec88325980b798f0ae88bc3