### PR TITLE
Constrain AppShortcut icon size

### DIFF
--- a/components/desktop/app_shortcut.tscn
+++ b/components/desktop/app_shortcut.tscn
@@ -15,6 +15,9 @@ unique_name_in_owner = true
 layout_mode = 0
 offset_right = 64.0
 offset_bottom = 64.0
+custom_minimum_size = Vector2(64, 64)
+expand_mode = 1
+stretch_mode = 5
 
 [node name="Title" type="Label" parent="."]
 unique_name_in_owner = true


### PR DESCRIPTION
## Summary
- Constrain AppShortcut icons to 64×64 using minimum size, expand, and stretch settings

## Testing
- `godot --headless --path . --run tests/test_runner.tscn` *(fails: resources missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b13bea609c8325ba9a64ebd6997076