### PR TITLE
Fix game over screen lingering after deleting save

### DIFF
--- a/autoloads/game_manager.gd
+++ b/autoloads/game_manager.gd
@@ -59,6 +59,13 @@ func _on_delete_save():
 
 	load_login_screen()
 
+	# Close Game Over screen
+	for child in get_tree().get_root().get_children():
+		if child is GameOverPopup:
+			child.queue_free()
+			break
+
+
 func reset_managers() -> void:
 	StatManager.reset()
 	PortfolioManager.reset()


### PR DESCRIPTION
## Summary
- Close the Game Over popup when the save slot is deleted

## Testing
- `godot/Godot_v4.3-stable_linux.x86_64 --headless --path . -s tests/test_runner.gd` *(fails: Can't load the script tests/test_runner.gd as it doesn't inherit from SceneTree or MainLoop)*

------
https://chatgpt.com/codex/tasks/task_e_68b13e992bf0832582f1c44fe35fbd70