### PR TITLE
Display login profiles by save age

### DIFF
--- a/autoloads/save_manager.gd
+++ b/autoloads/save_manager.gd
@@ -166,21 +166,23 @@ func save_to_slot(slot_id: int) -> void:
 	file.store_string(JSON.stringify(data, "\t"))
 	file.close()
 
-	var metadata = load_slot_metadata()
-	var slot_key = "slot_%d" % slot_id
-	if not metadata.has(slot_key):
-		metadata[slot_key] = {}
+        var metadata = load_slot_metadata()
+        var slot_key = "slot_%d" % slot_id
+        if not metadata.has(slot_key):
+                metadata[slot_key] = {}
 
 	var player_data = PlayerManager.get_save_data()
 	metadata[slot_key]["name"] = player_data.get("name", "Unnamed")
 	metadata[slot_key]["username"] = player_data.get("username", "user")
 	metadata[slot_key]["password"] = player_data.get("password", "")
 	metadata[slot_key]["using_random_seed"] = player_data.get("using_random_seed", false)
-	metadata[slot_key]["portrait_config"] = player_data.get("portrait_config", {})
-	metadata[slot_key]["background_path"] = player_data.get("background_path", "")
-	metadata[slot_key]["last_played"] = Time.get_datetime_string_from_system()
-	metadata[slot_key]["cash"] = PortfolioManager.cash
-	metadata[slot_key]["net_worth"] = PortfolioManager.get_balance()
+        metadata[slot_key]["portrait_config"] = player_data.get("portrait_config", {})
+        metadata[slot_key]["background_path"] = player_data.get("background_path", "")
+        if not metadata[slot_key].has("created_at"):
+                metadata[slot_key]["created_at"] = Time.get_unix_time_from_system()
+        metadata[slot_key]["last_played"] = Time.get_datetime_string_from_system()
+        metadata[slot_key]["cash"] = PortfolioManager.cash
+        metadata[slot_key]["net_worth"] = PortfolioManager.get_balance()
 
 	save_slot_metadata(metadata)
 	if DBManager != null:

--- a/components/ui/log_in_ui.gd
+++ b/components/ui/log_in_ui.gd
@@ -25,24 +25,34 @@ func _ready() -> void:
 
 
 func load_and_display_saved_profiles():
-	for child in %ProfileRow.get_children():
-		if child is UserLoginCardUI:
-			child.queue_free()
+        for child in %ProfileRow.get_children():
+                if child is UserLoginCardUI:
+                        child.queue_free()
 
-	var metadata = SaveManager.load_slot_metadata()
-	for key in metadata.keys():
-		var slot_id := int(key.trim_prefix("slot_"))
-		var data = metadata[key]
+        var metadata = SaveManager.load_slot_metadata()
+        var entries: Array = []
+        for key in metadata.keys():
+                var slot_id := int(key.trim_prefix("slot_"))
+                var data = metadata[key]
 
-		if typeof(data) != TYPE_DICTIONARY or data.is_empty():
-			print("⚠️ Skipping invalid profile slot:", slot_id)
-			continue  # skip malformed or empty profiles
+                if typeof(data) != TYPE_DICTIONARY or data.is_empty():
+                        print("⚠️ Skipping invalid profile slot:", slot_id)
+                        continue  # skip malformed or empty profiles
 
-		var panel = user_login_card_scene.instantiate()
-		profile_row.add_child(panel)
-		panel.login_requested.connect(_on_profile_login_requested)
-		panel.card_selected.connect(_on_card_selected)
-		panel.set_profile_data(data, slot_id)
+                var created_at := int(data.get("created_at", 0))
+                var last_played_str: String = data.get("last_played", "")
+                var last_played := last_played_str == "" ? 0 : Time.get_unix_time_from_datetime_string(last_played_str)
+                var sort_time = created_at != 0 ? created_at : last_played
+                entries.append({"slot_id": slot_id, "data": data, "sort_time": sort_time})
+
+        entries.sort_custom(func(a, b): return a.sort_time < b.sort_time)
+
+        for entry in entries:
+                var panel = user_login_card_scene.instantiate()
+                profile_row.add_child(panel)
+                panel.login_requested.connect(_on_profile_login_requested)
+                panel.card_selected.connect(_on_card_selected)
+                panel.set_profile_data(entry.data, entry.slot_id)
 
 
 

--- a/components/ui/login_settings_panel_container.gd
+++ b/components/ui/login_settings_panel_container.gd
@@ -21,11 +21,23 @@ func _ready():
 	_update_selector()
 
 func _update_selector():
-	profile_selector.clear()
-	for key in slot_metadata.keys():
-		var slot_id = int(key.trim_prefix("slot_"))
-		var name = slot_metadata[key].get("name", "Unnamed")
-		profile_selector.add_item("Slot %d: %s" % [slot_id, name], slot_id)
+       profile_selector.clear()
+       var entries: Array = []
+       for key in slot_metadata.keys():
+               var slot_id = int(key.trim_prefix("slot_"))
+               var data = slot_metadata[key]
+               var created_at := int(data.get("created_at", 0))
+               var last_played_str: String = data.get("last_played", "")
+               var last_played := last_played_str == "" ? 0 : Time.get_unix_time_from_datetime_string(last_played_str)
+               var sort_time = created_at != 0 ? created_at : last_played
+               entries.append({
+                       "slot_id": slot_id,
+                       "name": data.get("name", "Unnamed"),
+                       "sort_time": sort_time,
+               })
+       entries.sort_custom(func(a, b): return a.sort_time < b.sort_time)
+       for entry in entries:
+               profile_selector.add_item("Slot %d: %s" % [entry.slot_id, entry.name], entry.slot_id)
 
 func _on_delete_pressed():
 	var slot_id = profile_selector.get_selected_id()


### PR DESCRIPTION
## Summary
- track `created_at` for each save slot
- sort login and settings profiles using creation time so older saves stay on the left

## Testing
- `godot3 --headless -s tests/test_runner.gd` *(fails: Can't open project at '/workspace/SigmaSim/project.godot', its `config_version` (5) is from a more recent and incompatible version of the engine)*

------
https://chatgpt.com/codex/tasks/task_e_68b6fa07d914832597fbdeab8d4ab824