### PR TITLE
refactor: extract start panel scene

### DIFF
--- a/components/desktop_env.tscn
+++ b/components/desktop_env.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=55 format=3 uid="uid://dkhodakv1x0h7"]
+[gd_scene load_steps=52 format=3 uid="uid://dkhodakv1x0h7"]
 
 [ext_resource type="Theme" uid="uid://dyhdr7sojcl5h" path="res://assets/themes/windows_xp_theme.tres" id="1_0utxc"]
 [ext_resource type="Script" uid="uid://x031tiyraogl" path="res://scripts/desktop_env.gd" id="1_lpqk7"]
@@ -24,12 +24,11 @@
 [ext_resource type="Texture2D" uid="uid://mpip7wcjjyrr" path="res://assets/logos/pdficon.png" id="11_6x3lq"]
 [ext_resource type="Texture2D" uid="uid://hi7ldhid6blr" path="res://assets/ui/buttons/tangelo_down_white.png" id="13_bnui0"]
 [ext_resource type="Texture2D" uid="uid://bu12v0yfad1ai" path="res://assets/ui/buttons/lilac_normal.png" id="13_m483i"]
-[ext_resource type="PackedScene" uid="uid://5euld8tsq4yj" path="res://components/siggy/siggy.tscn" id="13_xcmse"]
 [ext_resource type="Script" uid="uid://jj0g0vk3lpc2" path="res://components/trash.gd" id="14_m483i"]
 [ext_resource type="Texture2D" uid="uid://c6q0iyjglvflr" path="res://assets/ui/buttons/dodger_blue_down_gray.png" id="14_xcmse"]
 [ext_resource type="PackedScene" uid="uid://674hnm8vwbpn" path="res://components/popups/calendar_popup_ui.tscn" id="16_g75lf"]
 [ext_resource type="PackedScene" uid="uid://bxbwmaa2wwr33" path="res://components/calendar/calendar_day_panel.tscn" id="20_vxmwr"]
-[ext_resource type="Script" uid="uid://cmmevgi7d0n3h" path="res://components/start_panel_window.gd" id="23_dik0q"]
+[ext_resource type="PackedScene" path="res://components/start_panel_window.tscn" id="23_dik0q"]
 [ext_resource type="Script" uid="uid://c7t01yq8wloqf" path="res://components/desktop_background.gd" id="24_jkb4t"]
 [ext_resource type="Shader" uid="uid://biinvb18hl7lc" path="res://assets/shaders/flat_color_background.gdshader" id="25_flat"]
 
@@ -186,17 +185,6 @@ texture_margin_left = 2.0
 texture_margin_top = 2.0
 texture_margin_right = 2.0
 texture_margin_bottom = 2.0
-
-[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_m483i"]
-bg_color = Color(0.0705882, 0, 0.407843, 0.815686)
-
-[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_6x3lq"]
-bg_color = Color(0.306923, 0.306923, 0.306923, 1)
-border_width_left = 2
-border_width_top = 2
-border_width_right = 2
-border_width_bottom = 2
-border_color = Color(0, 0, 0, 1)
 
 [sub_resource type="StyleBoxTexture" id="StyleBoxTexture_5eiy6"]
 texture = ExtResource("13_bnui0")
@@ -726,160 +714,8 @@ size_flags_horizontal = 3
 size_flags_vertical = 8
 theme_override_styles/panel = SubResource("StyleBoxTexture_vxmwr")
 
-[node name="StartPanel" type="Panel" parent="TaskbarLayer/TaskbarWrapper"]
+[node name="StartPanel" parent="TaskbarLayer/TaskbarWrapper" instance=ExtResource("23_dik0q")]
 unique_name_in_owner = true
-visible = false
-layout_mode = 1
-anchors_preset = 2
-anchor_top = 1.0
-anchor_bottom = 1.0
-offset_top = -525.0
-offset_right = 328.0
-offset_bottom = -185.0
-grow_vertical = 0
-scale = Vector2(1.4, 1.4)
-theme_override_styles/panel = SubResource("StyleBoxFlat_m483i")
-script = ExtResource("23_dik0q")
-siggy_scene = ExtResource("13_xcmse")
-
-[node name="MarginContainer" type="MarginContainer" parent="TaskbarLayer/TaskbarWrapper/StartPanel"]
-layout_mode = 1
-anchors_preset = 15
-anchor_right = 1.0
-anchor_bottom = 1.0
-grow_horizontal = 2
-grow_vertical = 2
-theme_override_constants/margin_left = 25
-theme_override_constants/margin_top = 15
-
-[node name="VBoxContainer" type="VBoxContainer" parent="TaskbarLayer/TaskbarWrapper/StartPanel/MarginContainer"]
-layout_mode = 2
-theme = ExtResource("1_0utxc")
-
-[node name="Panel" type="Panel" parent="TaskbarLayer/TaskbarWrapper/StartPanel/MarginContainer/VBoxContainer"]
-visible = false
-z_as_relative = false
-custom_minimum_size = Vector2(0, 30)
-layout_mode = 2
-theme_override_styles/panel = SubResource("StyleBoxFlat_6x3lq")
-
-[node name="Label" type="Label" parent="TaskbarLayer/TaskbarWrapper/StartPanel/MarginContainer/VBoxContainer/Panel"]
-layout_mode = 1
-anchors_preset = 8
-anchor_left = 0.5
-anchor_top = 0.5
-anchor_right = 0.5
-anchor_bottom = 0.5
-offset_left = -38.5
-offset_top = -10.0
-offset_right = 38.5
-offset_bottom = 10.0
-grow_horizontal = 2
-grow_vertical = 2
-size_flags_horizontal = 4
-theme_override_fonts/font = ExtResource("1_lx1wk")
-text = "S I G M A"
-
-[node name="HBoxContainer" type="HBoxContainer" parent="TaskbarLayer/TaskbarWrapper/StartPanel/MarginContainer/VBoxContainer"]
-layout_mode = 2
-size_flags_vertical = 3
-size_flags_stretch_ratio = 4.0
-
-[node name="VBoxContainer" type="VBoxContainer" parent="TaskbarLayer/TaskbarWrapper/StartPanel/MarginContainer/VBoxContainer/HBoxContainer"]
-layout_mode = 2
-size_flags_horizontal = 3
-
-[node name="MarginContainer" type="MarginContainer" parent="TaskbarLayer/TaskbarWrapper/StartPanel/MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer"]
-layout_mode = 2
-size_flags_vertical = 3
-theme_override_constants/margin_left = 10
-theme_override_constants/margin_top = 10
-theme_override_constants/margin_right = 10
-theme_override_constants/margin_bottom = 10
-
-[node name="ScrollContainer" type="ScrollContainer" parent="TaskbarLayer/TaskbarWrapper/StartPanel/MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer/MarginContainer"]
-layout_mode = 2
-horizontal_scroll_mode = 0
-
-[node name="AppListContainer" type="VBoxContainer" parent="TaskbarLayer/TaskbarWrapper/StartPanel/MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer/MarginContainer/ScrollContainer"]
-unique_name_in_owner = true
-layout_mode = 2
-theme_override_constants/separation = 4
-
-[node name="MarginContainer" type="MarginContainer" parent="TaskbarLayer/TaskbarWrapper/StartPanel/MarginContainer/VBoxContainer/HBoxContainer"]
-layout_mode = 2
-theme_override_constants/margin_left = 10
-theme_override_constants/margin_top = 10
-theme_override_constants/margin_right = 20
-theme_override_constants/margin_bottom = 10
-
-[node name="Favorites" type="VBoxContainer" parent="TaskbarLayer/TaskbarWrapper/StartPanel/MarginContainer/VBoxContainer/HBoxContainer/MarginContainer"]
-layout_mode = 2
-alignment = 2
-
-[node name="SiggyButton" type="Button" parent="TaskbarLayer/TaskbarWrapper/StartPanel/MarginContainer/VBoxContainer/HBoxContainer/MarginContainer/Favorites"]
-layout_mode = 2
-focus_mode = 0
-theme_override_font_sizes/font_size = 6
-text = "Siggy"
-
-[node name="LoadButton" type="Button" parent="TaskbarLayer/TaskbarWrapper/StartPanel/MarginContainer/VBoxContainer/HBoxContainer/MarginContainer/Favorites"]
-layout_mode = 2
-focus_mode = 0
-theme_override_colors/font_color = Color(0.729169, 0.47256, 0, 1)
-theme_override_font_sizes/font_size = 14
-text = "Load"
-
-[node name="SaveButton" type="Button" parent="TaskbarLayer/TaskbarWrapper/StartPanel/MarginContainer/VBoxContainer/HBoxContainer/MarginContainer/Favorites"]
-layout_mode = 2
-focus_mode = 0
-theme_override_colors/font_color = Color(0.843137, 0.827451, 0.121569, 1)
-theme_override_font_sizes/font_size = 14
-text = "Save"
-
-[node name="SleepButton" type="Button" parent="TaskbarLayer/TaskbarWrapper/StartPanel/MarginContainer/VBoxContainer/HBoxContainer/MarginContainer/Favorites"]
-layout_mode = 2
-focus_mode = 0
-mouse_filter = 1
-theme_override_fonts/font = ExtResource("1_lx1wk")
-theme_override_font_sizes/font_size = 14
-text = " sleep "
-
-[node name="SleepButton2" type="Button" parent="TaskbarLayer/TaskbarWrapper/StartPanel/MarginContainer/VBoxContainer/HBoxContainer/MarginContainer/Favorites"]
-layout_mode = 2
-focus_mode = 0
-mouse_filter = 1
-theme_override_colors/font_disabled_color = Color(0, 0, 0, 1)
-theme_override_colors/font_hover_pressed_color = Color(0, 0, 0, 1)
-theme_override_colors/font_hover_color = Color(0, 0, 0, 1)
-theme_override_colors/icon_disabled_color = Color(0, 0, 0, 1)
-theme_override_colors/icon_hover_pressed_color = Color(0, 0, 0, 1)
-theme_override_colors/icon_hover_color = Color(0, 0, 0, 1)
-theme_override_colors/icon_pressed_color = Color(0, 0, 0, 1)
-theme_override_colors/icon_focus_color = Color(0, 0, 0, 1)
-theme_override_colors/icon_normal_color = Color(0, 0, 0, 1)
-theme_override_colors/font_outline_color = Color(0, 0, 0, 1)
-theme_override_colors/font_color = Color(0, 0, 0, 1)
-theme_override_colors/font_focus_color = Color(0, 0, 0, 1)
-theme_override_colors/font_pressed_color = Color(0, 0, 0, 1)
-theme_override_fonts/font = ExtResource("1_lx1wk")
-theme_override_font_sizes/font_size = 14
-text = "week sleep "
-
-[node name="LogoutButton" type="Button" parent="TaskbarLayer/TaskbarWrapper/StartPanel/MarginContainer/VBoxContainer/HBoxContainer/MarginContainer/Favorites"]
-unique_name_in_owner = true
-layout_mode = 2
-focus_mode = 0
-theme_override_colors/font_color = Color(0, 0, 0, 1)
-theme_override_font_sizes/font_size = 14
-text = "Logout"
-
-[node name="SettingsButton" type="Button" parent="TaskbarLayer/TaskbarWrapper/StartPanel/MarginContainer/VBoxContainer/HBoxContainer/MarginContainer/Favorites"]
-layout_mode = 2
-size_flags_horizontal = 4
-focus_mode = 0
-theme = ExtResource("1_0utxc")
-icon = ExtResource("10_0utxc")
 
 [node name="MarginContainer" type="MarginContainer" parent="TaskbarLayer/TaskbarWrapper"]
 layout_mode = 1
@@ -987,14 +823,8 @@ day_panel_scene = ExtResource("20_vxmwr")
 
 [connection signal="pressed" from="ColorRect/VBoxContainer/Button" to="ColorRect" method="_on_button_pressed"]
 [connection signal="pressed" from="MarginContainer/GridContainer/TrashButton" to="." method="_on_trash_button_pressed"]
-[connection signal="mouse_exited" from="TaskbarLayer/TaskbarWrapper/StartPanel" to="TaskbarLayer/TaskbarWrapper/StartPanel" method="_on_mouse_exited"]
-[connection signal="pressed" from="TaskbarLayer/TaskbarWrapper/StartPanel/MarginContainer/VBoxContainer/HBoxContainer/MarginContainer/Favorites/SiggyButton" to="TaskbarLayer/TaskbarWrapper/StartPanel" method="_on_siggy_button_pressed"]
-[connection signal="pressed" from="TaskbarLayer/TaskbarWrapper/StartPanel/MarginContainer/VBoxContainer/HBoxContainer/MarginContainer/Favorites/LoadButton" to="." method="_on_load_button_pressed"]
-[connection signal="pressed" from="TaskbarLayer/TaskbarWrapper/StartPanel/MarginContainer/VBoxContainer/HBoxContainer/MarginContainer/Favorites/SaveButton" to="." method="_on_save_button_pressed"]
-[connection signal="pressed" from="TaskbarLayer/TaskbarWrapper/StartPanel/MarginContainer/VBoxContainer/HBoxContainer/MarginContainer/Favorites/SleepButton" to="TaskbarLayer/TaskbarWrapper/StartPanel" method="_on_sleep_button_pressed"]
-[connection signal="pressed" from="TaskbarLayer/TaskbarWrapper/StartPanel/MarginContainer/VBoxContainer/HBoxContainer/MarginContainer/Favorites/SleepButton2" to="TaskbarLayer/TaskbarWrapper/StartPanel" method="_on_sleep_button_2_pressed"]
-[connection signal="pressed" from="TaskbarLayer/TaskbarWrapper/StartPanel/MarginContainer/VBoxContainer/HBoxContainer/MarginContainer/Favorites/LogoutButton" to="TaskbarLayer/TaskbarWrapper/StartPanel" method="_on_logout_button_pressed"]
-[connection signal="pressed" from="TaskbarLayer/TaskbarWrapper/StartPanel/MarginContainer/VBoxContainer/HBoxContainer/MarginContainer/Favorites/SettingsButton" to="TaskbarLayer/TaskbarWrapper/StartPanel" method="_on_settings_button_pressed"]
+[connection signal="save_pressed" from="TaskbarLayer/TaskbarWrapper/StartPanel" to="." method="_on_save_button_pressed"]
+[connection signal="load_pressed" from="TaskbarLayer/TaskbarWrapper/StartPanel" to="." method="_on_load_button_pressed"]
 [connection signal="pressed" from="TaskbarLayer/TaskbarWrapper/MarginContainer/TaskbarRow/StartButton" to="." method="_on_start_button_pressed"]
 [connection signal="pressed" from="TaskbarLayer/TaskbarWrapper/MarginContainer/TaskbarRow/ScrollContainer/Taskbar/SettingsButton2" to="TaskbarLayer/TaskbarWrapper/StartPanel" method="_on_settings_button_pressed"]
 [connection signal="gui_input" from="TaskbarLayer/TaskbarWrapper/MarginContainer/TaskbarRow/TimePanel" to="TaskbarLayer/TaskbarWrapper/MarginContainer/TaskbarRow/TimePanel" method="_on_gui_input"]

--- a/components/start_panel_window.gd
+++ b/components/start_panel_window.gd
@@ -5,6 +5,9 @@ class_name StartPanelWindow
 
 @export var siggy_scene: PackedScene
 
+signal save_pressed
+signal load_pressed
+
 var listening_for_clicks := false
 
 
@@ -86,10 +89,18 @@ func _on_sleep_button_2_pressed() -> void:
 
 
 func _on_siggy_button_pressed() -> void:
-	var siggy = siggy_scene.instantiate()
-	
-	get_tree().get_root().add_child(siggy)
+        var siggy = siggy_scene.instantiate()
+
+        get_tree().get_root().add_child(siggy)
 
 
 func _on_logout_button_pressed() -> void:
-	GameManager._on_pause_logout()
+        GameManager._on_pause_logout()
+
+
+func _on_save_button_pressed() -> void:
+        save_pressed.emit()
+
+
+func _on_load_button_pressed() -> void:
+        load_pressed.emit()

--- a/components/start_panel_window.tscn
+++ b/components/start_panel_window.tscn
@@ -1,0 +1,180 @@
+[gd_scene load_steps=7 format=3]
+
+[ext_resource type="Theme" path="res://assets/themes/windows_95_theme.tres" id="1"]
+[ext_resource type="FontFile" path="res://assets/fonts/Chicago.ttf" id="2"]
+[ext_resource type="Texture2D" path="res://assets/logos/mycog.png" id="3"]
+[ext_resource type="PackedScene" path="res://components/siggy/siggy.tscn" id="4"]
+[ext_resource type="Script" path="res://components/start_panel_window.gd" id="5"]
+
+[sub_resource type="StyleBoxFlat" id="1"]
+bg_color = Color(0.0705882, 0, 0.407843, 0.815686)
+
+[sub_resource type="StyleBoxFlat" id="2"]
+bg_color = Color(0.306923, 0.306923, 0.306923, 1)
+border_width_left = 2
+border_width_top = 2
+border_width_right = 2
+border_width_bottom = 2
+border_color = Color(0, 0, 0, 1)
+
+[node name="StartPanel" type="Panel"]
+unique_name_in_owner = true
+visible = false
+anchors_preset = 2
+anchor_top = 1.0
+anchor_bottom = 1.0
+offset_top = -525.0
+offset_right = 328.0
+offset_bottom = -185.0
+grow_vertical = 0
+scale = Vector2(1.4, 1.4)
+theme_override_styles/panel = SubResource("1")
+script = ExtResource("5")
+siggy_scene = ExtResource("4")
+
+[node name="MarginContainer" type="MarginContainer" parent="."]
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_constants/margin_left = 25
+theme_override_constants/margin_top = 15
+
+[node name="VBoxContainer" type="VBoxContainer" parent="MarginContainer"]
+layout_mode = 2
+theme = ExtResource("1")
+
+[node name="Panel" type="Panel" parent="MarginContainer/VBoxContainer"]
+visible = false
+z_as_relative = false
+custom_minimum_size = Vector2(0, 30)
+layout_mode = 2
+theme_override_styles/panel = SubResource("2")
+
+[node name="Label" type="Label" parent="MarginContainer/VBoxContainer/Panel"]
+layout_mode = 1
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -38.5
+offset_top = -10.0
+offset_right = 38.5
+offset_bottom = 10.0
+grow_horizontal = 2
+grow_vertical = 2
+size_flags_horizontal = 4
+theme_override_fonts/font = ExtResource("2")
+text = "S I G M A"
+
+[node name="HBoxContainer" type="HBoxContainer" parent="MarginContainer/VBoxContainer"]
+layout_mode = 2
+size_flags_vertical = 3
+size_flags_stretch_ratio = 4.0
+
+[node name="VBoxContainer" type="VBoxContainer" parent="MarginContainer/VBoxContainer/HBoxContainer"]
+layout_mode = 2
+size_flags_horizontal = 3
+
+[node name="MarginContainer" type="MarginContainer" parent="MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer"]
+layout_mode = 2
+size_flags_vertical = 3
+theme_override_constants/margin_left = 10
+theme_override_constants/margin_top = 10
+theme_override_constants/margin_right = 10
+theme_override_constants/margin_bottom = 10
+
+[node name="ScrollContainer" type="ScrollContainer" parent="MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer/MarginContainer"]
+layout_mode = 2
+horizontal_scroll_mode = 0
+
+[node name="AppListContainer" type="VBoxContainer" parent="MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer/MarginContainer/ScrollContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+theme_override_constants/separation = 4
+
+[node name="MarginContainer" type="MarginContainer" parent="MarginContainer/VBoxContainer/HBoxContainer"]
+layout_mode = 2
+theme_override_constants/margin_left = 10
+theme_override_constants/margin_top = 10
+theme_override_constants/margin_right = 20
+theme_override_constants/margin_bottom = 10
+
+[node name="Favorites" type="VBoxContainer" parent="MarginContainer/VBoxContainer/HBoxContainer/MarginContainer"]
+layout_mode = 2
+alignment = 2
+
+[node name="SiggyButton" type="Button" parent="MarginContainer/VBoxContainer/HBoxContainer/MarginContainer/Favorites"]
+layout_mode = 2
+focus_mode = 0
+theme_override_font_sizes/font_size = 6
+text = "Siggy"
+
+[node name="LoadButton" type="Button" parent="MarginContainer/VBoxContainer/HBoxContainer/MarginContainer/Favorites"]
+layout_mode = 2
+focus_mode = 0
+theme_override_colors/font_color = Color(0.729169, 0.47256, 0, 1)
+theme_override_font_sizes/font_size = 14
+text = "Load"
+
+[node name="SaveButton" type="Button" parent="MarginContainer/VBoxContainer/HBoxContainer/MarginContainer/Favorites"]
+layout_mode = 2
+focus_mode = 0
+theme_override_colors/font_color = Color(0.843137, 0.827451, 0.121569, 1)
+theme_override_font_sizes/font_size = 14
+text = "Save"
+
+[node name="SleepButton" type="Button" parent="MarginContainer/VBoxContainer/HBoxContainer/MarginContainer/Favorites"]
+layout_mode = 2
+focus_mode = 0
+mouse_filter = 1
+theme_override_fonts/font = ExtResource("2")
+theme_override_font_sizes/font_size = 14
+text = " sleep "
+
+[node name="SleepButton2" type="Button" parent="MarginContainer/VBoxContainer/HBoxContainer/MarginContainer/Favorites"]
+layout_mode = 2
+focus_mode = 0
+mouse_filter = 1
+theme_override_colors/font_disabled_color = Color(0, 0, 0, 1)
+theme_override_colors/font_hover_pressed_color = Color(0, 0, 0, 1)
+theme_override_colors/font_hover_color = Color(0, 0, 0, 1)
+theme_override_colors/icon_disabled_color = Color(0, 0, 0, 1)
+theme_override_colors/icon_hover_pressed_color = Color(0, 0, 0, 1)
+theme_override_colors/icon_hover_color = Color(0, 0, 0, 1)
+theme_override_colors/icon_pressed_color = Color(0, 0, 0, 1)
+theme_override_colors/icon_focus_color = Color(0, 0, 0, 1)
+theme_override_colors/icon_normal_color = Color(0, 0, 0, 1)
+theme_override_colors/font_outline_color = Color(0, 0, 0, 1)
+theme_override_colors/font_color = Color(0, 0, 0, 1)
+theme_override_colors/font_focus_color = Color(0, 0, 0, 1)
+theme_override_colors/font_pressed_color = Color(0, 0, 0, 1)
+theme_override_fonts/font = ExtResource("2")
+theme_override_font_sizes/font_size = 14
+text = "week sleep "
+
+[node name="LogoutButton" type="Button" parent="MarginContainer/VBoxContainer/HBoxContainer/MarginContainer/Favorites"]
+unique_name_in_owner = true
+layout_mode = 2
+focus_mode = 0
+theme_override_colors/font_color = Color(0, 0, 0, 1)
+theme_override_font_sizes/font_size = 14
+text = "Logout"
+
+[node name="SettingsButton" type="Button" parent="MarginContainer/VBoxContainer/HBoxContainer/MarginContainer/Favorites"]
+layout_mode = 2
+size_flags_horizontal = 4
+focus_mode = 0
+theme = ExtResource("1")
+icon = ExtResource("3")
+
+[connection signal="mouse_exited" from="." to="." method="_on_mouse_exited"]
+[connection signal="pressed" from="MarginContainer/VBoxContainer/HBoxContainer/MarginContainer/Favorites/SiggyButton" to="." method="_on_siggy_button_pressed"]
+[connection signal="pressed" from="MarginContainer/VBoxContainer/HBoxContainer/MarginContainer/Favorites/LoadButton" to="." method="_on_load_button_pressed"]
+[connection signal="pressed" from="MarginContainer/VBoxContainer/HBoxContainer/MarginContainer/Favorites/SaveButton" to="." method="_on_save_button_pressed"]
+[connection signal="pressed" from="MarginContainer/VBoxContainer/HBoxContainer/MarginContainer/Favorites/SleepButton" to="." method="_on_sleep_button_pressed"]
+[connection signal="pressed" from="MarginContainer/VBoxContainer/HBoxContainer/MarginContainer/Favorites/SleepButton2" to="." method="_on_sleep_button_2_pressed"]
+[connection signal="pressed" from="MarginContainer/VBoxContainer/HBoxContainer/MarginContainer/Favorites/LogoutButton" to="." method="_on_logout_button_pressed"]
+[connection signal="pressed" from="MarginContainer/VBoxContainer/HBoxContainer/MarginContainer/Favorites/SettingsButton" to="." method="_on_settings_button_pressed"]


### PR DESCRIPTION
## Summary
- extract StartPanel from desktop_env into its own scene
- emit save/load signals from StartPanelWindow
- wire desktop env to new StartPanel signals

## Testing
- `godot3 --headless --path . --quiet tests/test_runner.tscn` *(fails: project requires newer Godot engine)*

------
https://chatgpt.com/codex/tasks/task_e_68b70fc36ff08325b1cca17ad713286b