### PR TITLE
Anchor start menu panel to start button

### DIFF
--- a/components/start_panel_window.tscn
+++ b/components/start_panel_window.tscn
@@ -20,12 +20,12 @@ border_color = Color(0, 0, 0, 1)
 [node name="StartPanel" type="Panel"]
 unique_name_in_owner = true
 visible = false
-anchors_preset = 2
-anchor_top = 1.0
-anchor_bottom = 1.0
-offset_top = -525.0
+anchors_preset = 0
+anchor_top = 0.0
+anchor_bottom = 0.0
+offset_top = 0.0
 offset_right = 328.0
-offset_bottom = -185.0
+offset_bottom = 340.0
 grow_vertical = 0
 scale = Vector2(1.4, 1.4)
 theme_override_styles/panel = SubResource("1")

--- a/scripts/desktop_env.gd
+++ b/scripts/desktop_env.gd
@@ -3,6 +3,7 @@ extends Control
 @onready var start_panel: StartPanelWindow = %StartPanel
 @onready var taskbar: Control = %Taskbar
 @onready var trash_window: Pane = %TrashWindow
+@onready var start_button: Button = $TaskbarLayer/TaskbarWrapper/MarginContainer/TaskbarRow/StartButton
 
 @onready var icons_layer: Control = self
 const APP_SHORTCUT_SCENE: PackedScene = preload("res://components/desktop/app_shortcut.tscn")
@@ -134,7 +135,10 @@ func hide_all_windows_and_panels() -> void:
 # ----------------------------- #
 
 func _on_start_button_pressed() -> void:
-	start_panel.toggle_start_panel()
+        var button_pos: Vector2 = start_button.global_position
+        var panel_height: float = start_panel.size.y * start_panel.scale.y
+        start_panel.global_position = button_pos - Vector2(0, panel_height)
+        start_panel.toggle_start_panel()
 
 func _on_trash_button_pressed() -> void:
 	open_trash_folder()


### PR DESCRIPTION
## Summary
- Anchor start menu panel to top-left of start button
- Calculate start panel position dynamically before showing

## Testing
- `godot --headless -s tests/test_runner.gd` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b7128ec4308325b8869cbd0e25f13a