### PR TITLE
Add SoftWares app with unlock system

### DIFF
--- a/autoloads/window_manager.gd
+++ b/autoloads/window_manager.gd
@@ -1,5 +1,7 @@
 extends Node
 
+signal app_unlocked(app_id: String)
+
 var open_windows: Dictionary = {} # key: WindowFrame, value: taskbar Button
 var popup_registry: Dictionary = {}
 
@@ -7,6 +9,13 @@ var taskbar_container: Control = null
 var start_panel = null
 
 var focused_window: WindowFrame = null
+
+var app_unlock_state: Dictionary = {
+        "minerr": false,
+        "earlybird": false,
+        "fumble": false,
+        "brokerage": false
+}
 
 # Preloaded apps
 var app_registry := {
@@ -26,9 +35,10 @@ var app_registry := {
 	"Fumble": preload("res://components/apps/fumble/fumble.tscn"),
 	"Daterbase": preload("res://components/apps/daterbase/daterbase.tscn"),
 	"NewYou": preload("res://components/apps/new_you/new_you.tscn"),
-	"Wallet": preload("res://components/apps/wallet/wallet_ui.tscn"),
-	"Notepad": preload("res://components/apps/app_scenes/notepad.tscn"),
-	"Terminal": preload("res://components/apps/terminal/terminal.tscn"),
+        "Wallet": preload("res://components/apps/wallet/wallet_ui.tscn"),
+        "Notepad": preload("res://components/apps/app_scenes/notepad.tscn"),
+        "Terminal": preload("res://components/apps/terminal/terminal.tscn"),
+        "SoftWares": preload("res://components/apps/app_scenes/soft_wares_app.tscn"),
 
 }
 
@@ -43,14 +53,22 @@ var start_apps := {
 	#"LockedIn": preload("res://components/apps/app_scenes/locked_in.tscn"),
 	#"OwerView": preload("res://components/apps/app_scenes/ower_view.tscn"),
 	#"LifeStylist": preload("res://components/apps/app_scenes/life_stylist.tscn"),
-	"EarlyBird": preload("res://components/apps/early_bird/early_bird.tscn"),
-	"Fumble": preload("res://components/apps/fumble/fumble.tscn"),
-	"Daterbase": preload("res://components/apps/daterbase/daterbase.tscn"),
+        "EarlyBird": preload("res://components/apps/early_bird/early_bird.tscn"),
+        "Fumble": preload("res://components/apps/fumble/fumble.tscn"),
+        "Daterbase": preload("res://components/apps/daterbase/daterbase.tscn"),
+        "SoftWares": preload("res://components/apps/app_scenes/soft_wares_app.tscn"),
 }
 
 
 func _ready() -> void:
-	print("✅ Registered apps:", app_registry.keys())
+        print("✅ Registered apps:", app_registry.keys())
+
+func is_app_unlocked(app_id: String) -> bool:
+        return app_unlock_state.get(app_id, true)
+
+func unlock_app(app_id: String) -> void:
+        app_unlock_state[app_id] = true
+        app_unlocked.emit(app_id)
 
 # --- Main window functions --- #
 
@@ -152,9 +170,19 @@ func close_window(window: WindowFrame) -> void:
 
 # --- Launchers --- #
 
+func launch_app(app_id: String) -> void:
+        var mapping: Dictionary = {
+                "minerr": "Minerr",
+                "brokerage": "BrokeRage",
+                "fumble": "Fumble",
+                "earlybird": "EarlyBird"
+        }
+        var app_name: String = mapping.get(app_id, app_id)
+        launch_app_by_name(app_name)
+
 func launch_app_by_name(app_name: String, setup_args: Variant = null) -> void:
-		var scene: PackedScene = app_registry.get(app_name)
-		if scene:
+                var scene: PackedScene = app_registry.get(app_name)
+                if scene:
 				if setup_args != null:
 						var pane := scene.instantiate() as Pane
 						if not pane:

--- a/components/apps/app_scenes/soft_wares_app.tscn
+++ b/components/apps/app_scenes/soft_wares_app.tscn
@@ -1,0 +1,29 @@
+[gd_scene load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://components/apps/soft_wares/soft_wares_app.gd" id="1"]
+
+[node name="SoftWaresApp" type="Pane"]
+script = ExtResource("1")
+window_title = "Soft Wares"
+
+[node name="VBoxContainer" type="VBoxContainer" parent="."]
+anchor_right = 1.0
+anchor_bottom = 1.0
+size_flags_horizontal = 3
+size_flags_vertical = 3
+theme_override_constants/separation = 10
+
+[node name="TitleLabel" type="Label" parent="VBoxContainer"]
+text = "Soft Wares"
+alignment = 1
+
+[node name="Scroll" type="ScrollContainer" parent="VBoxContainer"]
+anchor_right = 1.0
+anchor_bottom = 1.0
+size_flags_horizontal = 3
+size_flags_vertical = 3
+
+[node name="ItemsContainer" type="VBoxContainer" parent="Scroll"]
+size_flags_horizontal = 3
+size_flags_vertical = 3
+theme_override_constants/separation = 8

--- a/components/apps/soft_wares/soft_ware_item.gd
+++ b/components/apps/soft_wares/soft_ware_item.gd
@@ -1,0 +1,55 @@
+extends HBoxContainer
+class_name SoftWareItem
+
+@export var app_icon: Texture2D
+@export var app_title: String = ""
+@export var app_description: String = ""
+@export var app_cost: int = 0
+@export var has_upgrades: bool = false
+@export var app_id: String = ""
+
+@onready var icon_rect: TextureRect = %Icon
+@onready var title_label: Label = %TitleLabel
+@onready var description_label: Label = %DescriptionLabel
+@onready var cost_label: Label = %CostLabel
+@onready var action_button: Button = %ActionButton
+@onready var upgrades_button: Button = %UpgradesButton
+@onready var feedback_label: Label = %FeedbackLabel
+
+func _ready() -> void:
+    icon_rect.texture = app_icon
+    title_label.text = app_title
+    description_label.text = app_description
+    cost_label.text = "$" + str(app_cost)
+    upgrades_button.visible = has_upgrades
+    _update_action_button()
+    action_button.pressed.connect(_on_action_button_pressed)
+    upgrades_button.pressed.connect(_on_upgrades_button_pressed)
+    WindowManager.app_unlocked.connect(_on_app_unlocked)
+
+func _update_action_button() -> void:
+    if WindowManager.is_app_unlocked(app_id):
+        action_button.text = "Launch"
+    else:
+        action_button.text = "Unlock"
+
+func _on_action_button_pressed() -> void:
+    feedback_label.text = ""
+    feedback_label.remove_theme_color_override("font_color")
+    if WindowManager.is_app_unlocked(app_id):
+        WindowManager.launch_app(app_id)
+        return
+    if PortfolioManager.cash >= float(app_cost):
+        PortfolioManager.cash = PortfolioManager.cash - float(app_cost)
+        WindowManager.unlock_app(app_id)
+        _update_action_button()
+    else:
+        feedback_label.text = "Not enough cash!"
+        feedback_label.add_theme_color_override("font_color", Color.RED)
+
+func _on_upgrades_button_pressed() -> void:
+    UpgradeManager.open_upgrade_pane(app_id)
+
+func _on_app_unlocked(unlocked_id: String) -> void:
+    if unlocked_id == app_id:
+        _update_action_button()

--- a/components/apps/soft_wares/soft_ware_item.tscn
+++ b/components/apps/soft_wares/soft_ware_item.tscn
@@ -1,0 +1,52 @@
+[gd_scene load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://components/apps/soft_wares/soft_ware_item.gd" id="1"]
+
+[sub_resource type="StyleBoxFlat" id="1_style"]
+content_margin_left = 8.0
+content_margin_top = 8.0
+content_margin_right = 8.0
+content_margin_bottom = 8.0
+bg_color = Color(0.1, 0.1, 0.1, 1)
+
+[node name="SoftWareItem" type="HBoxContainer"]
+theme_override_styles/panel = SubResource("1_style")
+theme_override_constants/separation = 10
+script = ExtResource("1")
+
+[node name="Icon" type="TextureRect" parent="."]
+custom_minimum_size = Vector2(64, 64)
+expand_mode = 1
+stretch_mode = 1
+
+[node name="InfoContainer" type="VBoxContainer" parent="."]
+size_flags_horizontal = 3
+size_flags_vertical = 0
+theme_override_constants/separation = 4
+
+[node name="TitleLabel" type="Label" parent="InfoContainer"]
+text = "Title"
+
+[node name="DescriptionLabel" type="Label" parent="InfoContainer"]
+text = "Description"
+autowrap_mode = 3
+
+[node name="CostLabel" type="Label" parent="InfoContainer"]
+text = "$0"
+
+[node name="FeedbackLabel" type="Label" parent="InfoContainer"]
+text = ""
+
+[node name="ButtonsContainer" type="VBoxContainer" parent="."]
+size_flags_horizontal = 0
+size_flags_vertical = 0
+theme_override_constants/separation = 4
+
+[node name="ActionButton" type="Button" parent="ButtonsContainer"]
+text = "Unlock"
+size_flags_horizontal = 1
+
+[node name="UpgradesButton" type="Button" parent="ButtonsContainer"]
+text = "Upgrades"
+visible = false
+size_flags_horizontal = 1

--- a/components/apps/soft_wares/soft_wares_app.gd
+++ b/components/apps/soft_wares/soft_wares_app.gd
@@ -1,0 +1,52 @@
+extends Pane
+class_name SoftWaresApp
+
+const SOFTWARE_ITEM_SCENE: PackedScene = preload("res://components/apps/soft_wares/soft_ware_item.tscn")
+
+var soft_wares_registry: Dictionary = {
+    "minerr": {
+        "title": "Minerr",
+        "description": "Mine cryptos with GPUs and clicks.",
+        "icon": preload("res://assets/icons/minerr.png"),
+        "cost": 100,
+        "has_upgrades": true
+    },
+    "brokerage": {
+        "title": "BrokeRage",
+        "description": "Buy and sell stocks in a chaotic market.",
+        "icon": preload("res://assets/icons/brokerage.png"),
+        "cost": 250,
+        "has_upgrades": true
+    },
+    "fumble": {
+        "title": "Fumble",
+        "description": "Date, swipe, and battle for love.",
+        "icon": preload("res://assets/icons/fumble.png"),
+        "cost": 300,
+        "has_upgrades": false
+    },
+    "earlybird": {
+        "title": "EarlyBird",
+        "description": "Rise early, grind hard, and collect your worms.",
+        "icon": preload("res://assets/icons/earlybird.png"),
+        "cost": 150,
+        "has_upgrades": false
+    }
+}
+
+@onready var items_container: VBoxContainer = %ItemsContainer
+
+func _ready() -> void:
+    _populate_items()
+
+func _populate_items() -> void:
+    for app_id in soft_wares_registry.keys():
+        var data: Dictionary = soft_wares_registry[app_id]
+        var item: SoftWareItem = SOFTWARE_ITEM_SCENE.instantiate() as SoftWareItem
+        item.app_icon = data["icon"]
+        item.app_title = data["title"]
+        item.app_description = data["description"]
+        item.app_cost = int(data["cost"])
+        item.has_upgrades = bool(data["has_upgrades"])
+        item.app_id = app_id
+        items_container.add_child(item)


### PR DESCRIPTION
## Summary
- Introduce SoftWares storefront app showing available apps with costs, descriptions, and upgrade access.
- Add SoftWareItem component handling unlocks, launches, and upgrade pane access.
- Extend WindowManager with app unlock state, unlock logic, and mapping-based launch helper.

## Testing
- `godot4 --headless -s tests/test_runner.gd` *(fails: command not found)*
- `godot --headless -s tests/test_runner.gd` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b713467a888325a528774d7f3c198e