### PR TITLE
feat: add tarot app with deck and collection

### DIFF
--- a/autoloads/save_manager.gd
+++ b/autoloads/save_manager.gd
@@ -157,10 +157,11 @@ func save_to_slot(slot_id: int) -> void:
 		"bills": BillManager.get_save_data(),
 		"gpus": GPUManager.get_save_data(),
 		"upgrades": UpgradeManager.get_save_data(),
-		"history": HistoryManager.get_save_data(),
-		"windows": WindowManager.get_save_data(),
-		"desktop": DesktopLayoutManager.get_save_data(),
-		}
+               "history": HistoryManager.get_save_data(),
+               "tarot": TarotManager.get_save_data(),
+               "windows": WindowManager.get_save_data(),
+               "desktop": DesktopLayoutManager.get_save_data(),
+               }
 
 	var file := FileAccess.open(get_slot_path(slot_id), FileAccess.WRITE)
 	file.store_string(JSON.stringify(data, "\t"))
@@ -254,8 +255,11 @@ func load_from_slot(slot_id: int) -> void:
 	if data.has("market"):
 		MarketManager.load_from_data(data["market"])
 
-	if data.has("history"):
-		HistoryManager.load_from_data(data["history"])
+        if data.has("history"):
+                HistoryManager.load_from_data(data["history"])
+
+        if data.has("tarot"):
+                TarotManager.load_from_data(data["tarot"])
 
 	if data.has("workers"):
 		WorkerManager.load_from_data(data["workers"])
@@ -302,10 +306,11 @@ func reset_game_state() -> void:
 	UpgradeManager.reset()
 	WorkerManager.reset()
 	MarketManager.reset()
-	GPUManager.reset()
-	BillManager.reset()
-	NPCManager.reset()
-	DesktopLayoutManager.reset()
+        GPUManager.reset()
+        BillManager.reset()
+        NPCManager.reset()
+        DesktopLayoutManager.reset()
+        TarotManager.reset()
 
 func reset_managers():
 	PlayerManager.reset()
@@ -317,10 +322,11 @@ func reset_managers():
 	WorkerManager.reset()
 	TaskManager.reset()
 	UpgradeManager.reset()
-	GPUManager.reset()
-	BillManager.reset()
-	NPCManager.reset()
-	DesktopLayoutManager.reset()
+        GPUManager.reset()
+        BillManager.reset()
+        NPCManager.reset()
+        DesktopLayoutManager.reset()
+        TarotManager.reset()
 
 func delete_save(slot_id: int) -> void:
 	if slot_id == current_slot_id:

--- a/autoloads/tarot_manager.gd
+++ b/autoloads/tarot_manager.gd
@@ -1,0 +1,89 @@
+extends Node
+class_name TarotManager
+
+const TarotDeck = preload("res://components/apps/tarot/tarot_deck.gd")
+const TarotCardView = preload("res://components/apps/tarot/tarot_card_view.gd")
+
+signal collection_changed(card_id: String, count: int)
+
+const DATA_PATH := "res://data/tarot_cards.json"
+const COOLDOWN_MINUTES := 24 * 60
+
+var deck: TarotDeck = TarotDeck.new()
+var collection: Dictionary = {}
+var last_draw_minutes: int = -COOLDOWN_MINUTES
+var draw_cost: float = 1.0
+
+func _ready() -> void:
+    deck.load_from_file(DATA_PATH)
+
+func reset() -> void:
+    collection.clear()
+    last_draw_minutes = -COOLDOWN_MINUTES
+    deck.load_from_file(DATA_PATH)
+
+func get_save_data() -> Dictionary:
+    return {
+        "collection": collection,
+        "last_draw": last_draw_minutes
+    }
+
+func load_from_data(data: Dictionary) -> void:
+    collection = data.get("collection", {}).duplicate()
+    last_draw_minutes = int(data.get("last_draw", -COOLDOWN_MINUTES))
+    deck.load_from_file(DATA_PATH)
+
+func get_card_count(id: String) -> int:
+    return int(collection.get(id, 0))
+
+func get_all_cards_ordered() -> Array:
+    return deck.get_all_cards_ordered()
+
+func instantiate_card_view(id: String, count: int = 0) -> TarotCardView:
+    return deck.instantiate_card_view(id, count)
+
+func time_until_next_draw() -> int:
+    var now = TimeManager.get_now_minutes()
+    return max(0, COOLDOWN_MINUTES - (now - last_draw_minutes))
+
+func can_draw() -> bool:
+    return time_until_next_draw() == 0
+
+func _roll_rarity(rng: RandomNumberGenerator) -> int:
+    var weights := {1:80, 2:12, 3:5, 4:2, 5:1}
+    var r := rng.randi_range(1, 100)
+    var cumulative := 0
+    for rarity in [1,2,3,4,5]:
+        cumulative += weights.get(rarity, 0)
+        if r <= cumulative:
+            return rarity
+    return 1
+
+func draw_card() -> Dictionary:
+    if not can_draw():
+        return {}
+    if not PortfolioManager.try_spend_cash(draw_cost):
+        return {}
+    var rng := RNGManager.get_rng()
+    var rarity := _roll_rarity(rng)
+    var pool: Array = deck.cards_by_rarity.get(rarity, [])
+    if pool.is_empty():
+        return {}
+    var card: Dictionary = pool[rng.randi_range(0, pool.size() - 1)]
+    var id: String = card.get("id", "")
+    collection[id] = get_card_count(id) + 1
+    last_draw_minutes = TimeManager.get_now_minutes()
+    collection_changed.emit(id, collection[id])
+    return card
+
+func sell_card(card_id: String) -> void:
+    var count := get_card_count(card_id)
+    if count <= 0:
+        return
+    var card := deck.get_card(card_id)
+    collection[card_id] = count - 1
+    if collection[card_id] <= 0:
+        collection.erase(card_id)
+    var price := float(card.get("rarity", 1))
+    PortfolioManager.add_cash(price)
+    collection_changed.emit(card_id, get_card_count(card_id))

--- a/autoloads/window_manager.gd
+++ b/autoloads/window_manager.gd
@@ -39,6 +39,7 @@ var app_registry := {
         "Notepad": preload("res://components/apps/app_scenes/notepad.tscn"),
         "Terminal": preload("res://components/apps/terminal/terminal.tscn"),
         "SoftWares": preload("res://components/apps/app_scenes/soft_wares_app.tscn"),
+        "TarotApp": preload("res://components/apps/app_scenes/tarot_app.tscn"),
 
 }
 
@@ -57,6 +58,7 @@ var start_apps := {
         "Fumble": preload("res://components/apps/fumble/fumble.tscn"),
         "Daterbase": preload("res://components/apps/daterbase/daterbase.tscn"),
         "SoftWares": preload("res://components/apps/app_scenes/soft_wares_app.tscn"),
+        "TarotApp": preload("res://components/apps/app_scenes/tarot_app.tscn"),
 }
 
 

--- a/components/apps/app_scenes/tarot_app.tscn
+++ b/components/apps/app_scenes/tarot_app.tscn
@@ -1,0 +1,59 @@
+[gd_scene load_steps=4 format=3 uid="uid://93fd3816f1fd"]
+
+[ext_resource type="Theme" uid="uid://cesgvqexxaqev" path="res://assets/themes/windows_95_theme.tres" id="1"]
+[ext_resource type="Script" uid="uid://7511226d6221" path="res://components/apps/tarot/tarot_app.gd" id="2"]
+[ext_resource type="Texture2D" uid="uid://b8cd5rom7n7tl" path="res://assets/sigma.png" id="3"]
+
+[node name="TarotApp" type="MarginContainer"]
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+theme = ExtResource("1")
+script = ExtResource("2")
+window_title = "Tarot"
+window_icon = ExtResource("3")
+default_window_size = Vector2(600, 600)
+
+[node name="VBox" type="VBoxContainer" parent="."]
+layout_mode = 2
+theme_override_constants/separation = 8
+
+[node name="TabButtons" type="HBoxContainer" parent="VBox"]
+layout_mode = 2
+theme_override_constants/separation = 4
+
+[node name="DrawTabButton" type="Button" parent="VBox/TabButtons"]
+unique_name_in_owner = true
+text = "Draw"
+
+[node name="CollectionTabButton" type="Button" parent="VBox/TabButtons"]
+unique_name_in_owner = true
+text = "Collection"
+
+[node name="DrawView" type="VBoxContainer" parent="VBox"]
+unique_name_in_owner = true
+layout_mode = 2
+theme_override_constants/separation = 8
+
+[node name="DrawButton" type="Button" parent="VBox/DrawView"]
+unique_name_in_owner = true
+text = "Daily Draw"
+
+[node name="CooldownLabel" type="Label" parent="VBox/DrawView"]
+unique_name_in_owner = true
+text = ""
+
+[node name="DrawResult" type="HBoxContainer" parent="VBox/DrawView"]
+unique_name_in_owner = true
+layout_mode = 2
+
+[node name="CollectionView" type="ScrollContainer" parent="VBox"]
+unique_name_in_owner = true
+layout_mode = 2
+visible = false
+
+[node name="CollectionGrid" type="GridContainer" parent="VBox/CollectionView"]
+unique_name_in_owner = true
+columns = 6

--- a/components/apps/tarot/tarot_app.gd
+++ b/components/apps/tarot/tarot_app.gd
@@ -1,0 +1,84 @@
+extends Pane
+class_name TarotApp
+
+@onready var draw_button: Button = %DrawButton
+@onready var cooldown_label: Label = %CooldownLabel
+@onready var draw_result: Control = %DrawResult
+@onready var draw_tab_button: Button = %DrawTabButton
+@onready var collection_tab_button: Button = %CollectionTabButton
+@onready var draw_view: VBoxContainer = %DrawView
+@onready var collection_view: ScrollContainer = %CollectionView
+@onready var collection_grid: GridContainer = %CollectionGrid
+
+var card_views: Dictionary = {}
+var _active_tab: StringName = &"Draw"
+
+func _ready() -> void:
+    draw_button.pressed.connect(_on_draw_button_pressed)
+    draw_tab_button.pressed.connect(_on_draw_tab_pressed)
+    collection_tab_button.pressed.connect(_on_collection_tab_pressed)
+    TarotManager.collection_changed.connect(_on_collection_changed)
+    TimeManager.minute_passed.connect(_on_minute_passed)
+    _build_collection_view()
+    _update_cooldown_label()
+    _activate_tab(&"Draw")
+
+func _build_collection_view() -> void:
+    for child in collection_grid.get_children():
+        child.queue_free()
+    card_views.clear()
+    for card in TarotManager.get_all_cards_ordered():
+        var id: String = card.get("id", "")
+        var count: int = TarotManager.get_card_count(id)
+        var view: TarotCardView = TarotManager.instantiate_card_view(id, count)
+        collection_grid.add_child(view)
+        card_views[id] = view
+
+func _on_collection_changed(card_id: String, count: int) -> void:
+    var view = card_views.get(card_id)
+    if view:
+        view.update_count(count)
+
+func _on_draw_button_pressed() -> void:
+    var card = TarotManager.draw_card()
+    if card.is_empty():
+        return
+    for child in draw_result.get_children():
+        child.queue_free()
+    var id = card.get("id", "")
+    var view = TarotManager.instantiate_card_view(id, TarotManager.get_card_count(id))
+    draw_result.add_child(view)
+    _update_cooldown_label()
+
+func _update_cooldown_label() -> void:
+    var remaining = TarotManager.time_until_next_draw()
+    if remaining <= 0:
+        cooldown_label.text = "Ready to draw"
+        draw_button.disabled = false
+    else:
+        var hours = remaining / 60
+        var minutes = remaining % 60
+        cooldown_label.text = "%02dh %02dm" % [hours, minutes]
+        draw_button.disabled = true
+
+func _on_minute_passed(_total_minutes: int) -> void:
+    _update_cooldown_label()
+
+func _activate_tab(tab_name: StringName) -> void:
+    if tab_name == &"Draw":
+        draw_tab_button.set_pressed(true)
+        collection_tab_button.set_pressed(false)
+        draw_view.visible = true
+        collection_view.visible = false
+    else:
+        draw_tab_button.set_pressed(false)
+        collection_tab_button.set_pressed(true)
+        draw_view.visible = false
+        collection_view.visible = true
+    _active_tab = tab_name
+
+func _on_draw_tab_pressed() -> void:
+    _activate_tab(&"Draw")
+
+func _on_collection_tab_pressed() -> void:
+    _activate_tab(&"Collection")

--- a/components/apps/tarot/tarot_card_view.gd
+++ b/components/apps/tarot/tarot_card_view.gd
@@ -1,0 +1,32 @@
+extends VBoxContainer
+class_name TarotCardView
+
+var card_id: String = ""
+var rarity: int = 1
+var count: int = 0
+
+@onready var texture_rect: TextureRect = %TextureRect
+@onready var name_label: Label = %NameLabel
+@onready var count_label: Label = %CountLabel
+@onready var sell_button: Button = %SellButton
+
+func setup(data: Dictionary, owned: int) -> void:
+    card_id = data.get("id", "")
+    name_label.text = data.get("name", "")
+    rarity = int(data.get("rarity", 1))
+    var tex_path: String = data.get("texture_path", "")
+    var tex = load(tex_path)
+    if tex:
+        texture_rect.texture = tex
+    update_count(owned)
+    sell_button.pressed.connect(_on_sell_pressed)
+
+func update_count(new_count: int) -> void:
+    count = new_count
+    count_label.visible = count > 1
+    count_label.text = "x%d" % count
+    sell_button.visible = count > 0
+    texture_rect.modulate = Color(1,1,1,1) if count > 0 else Color(0.5,0.5,0.5,1)
+
+func _on_sell_pressed() -> void:
+    TarotManager.sell_card(card_id)

--- a/components/apps/tarot/tarot_card_view.tscn
+++ b/components/apps/tarot/tarot_card_view.tscn
@@ -1,0 +1,28 @@
+[gd_scene load_steps=3 format=3]
+
+[ext_resource type="Theme" uid="uid://cesgvqexxaqev" path="res://assets/themes/windows_95_theme.tres" id="1"]
+[ext_resource type="Script" uid="uid://eb104edcb043" path="res://components/apps/tarot/tarot_card_view.gd" id="2"]
+
+[node name="TarotCardView" type="VBoxContainer"]
+theme = ExtResource("1")
+script = ExtResource("2")
+
+[node name="TextureRect" type="TextureRect" parent="."]
+unique_name_in_owner = true
+custom_minimum_size = Vector2(200, 350)
+expand_mode = 1
+stretch_mode = 5
+
+[node name="NameLabel" type="Label" parent="."]
+unique_name_in_owner = true
+horizontal_alignment = 1
+
+[node name="CountLabel" type="Label" parent="."]
+unique_name_in_owner = true
+visible = false
+horizontal_alignment = 1
+
+[node name="SellButton" type="Button" parent="."]
+unique_name_in_owner = true
+text = "Sell"
+visible = false

--- a/components/apps/tarot/tarot_deck.gd
+++ b/components/apps/tarot/tarot_deck.gd
@@ -1,0 +1,57 @@
+extends Resource
+class_name TarotDeck
+
+const CARD_VIEW_SCENE = preload("res://components/apps/tarot/tarot_card_view.tscn")
+
+var cards: Array = []
+var card_map: Dictionary = {}
+var cards_by_rarity: Dictionary = {}
+
+func load_from_file(path: String) -> void:
+    cards.clear()
+    card_map.clear()
+    cards_by_rarity.clear()
+    if not FileAccess.file_exists(path):
+        return
+    var file := FileAccess.open(path, FileAccess.READ)
+    var text := file.get_as_text()
+    file.close()
+    var data = JSON.parse_string(text)
+    if typeof(data) != TYPE_ARRAY:
+        return
+    cards = data
+    for card in cards:
+        var id: String = card.get("id", "")
+        card_map[id] = card
+        var rarity: int = int(card.get("rarity", 1))
+        if not cards_by_rarity.has(rarity):
+            cards_by_rarity[rarity] = []
+        cards_by_rarity[rarity].append(card)
+
+func get_card(id: String) -> Dictionary:
+    return card_map.get(id, {})
+
+func instantiate_card_view(id: String, count: int = 0) -> TarotCardView:
+    var data = get_card(id)
+    var view: TarotCardView = CARD_VIEW_SCENE.instantiate()
+    view.setup(data, count)
+    return view
+
+func _compare_cards(a: Dictionary, b: Dictionary) -> bool:
+    var order = {
+        "major": 0,
+        "wands": 1,
+        "cups": 2,
+        "swords": 3,
+        "pentacles": 4
+    }
+    var sa = order.get(a.get("suit", "major"), 99)
+    var sb = order.get(b.get("suit", "major"), 99)
+    if sa == sb:
+        return int(a.get("number", 0)) < int(b.get("number", 0))
+    return sa < sb
+
+func get_all_cards_ordered() -> Array:
+    var arr = cards.duplicate()
+    arr.sort_custom(Callable(self, "_compare_cards"))
+    return arr

--- a/data/tarot_cards.json
+++ b/data/tarot_cards.json
@@ -1,0 +1,626 @@
+[
+  {
+    "id": "major_0",
+    "name": "The Fool",
+    "suit": "major",
+    "number": 0,
+    "rarity": 5,
+    "texture_path": "res://cards/tarot/rider_waite_tarot_deck/major_0.png"
+  },
+  {
+    "id": "major_1",
+    "name": "The Magician",
+    "suit": "major",
+    "number": 1,
+    "rarity": 4,
+    "texture_path": "res://cards/tarot/rider_waite_tarot_deck/major_1.png"
+  },
+  {
+    "id": "major_2",
+    "name": "The High Priestess",
+    "suit": "major",
+    "number": 2,
+    "rarity": 4,
+    "texture_path": "res://cards/tarot/rider_waite_tarot_deck/major_2.png"
+  },
+  {
+    "id": "major_3",
+    "name": "The Empress",
+    "suit": "major",
+    "number": 3,
+    "rarity": 3,
+    "texture_path": "res://cards/tarot/rider_waite_tarot_deck/major_3.png"
+  },
+  {
+    "id": "major_4",
+    "name": "The Emperor",
+    "suit": "major",
+    "number": 4,
+    "rarity": 3,
+    "texture_path": "res://cards/tarot/rider_waite_tarot_deck/major_4.png"
+  },
+  {
+    "id": "major_5",
+    "name": "The Hierophant",
+    "suit": "major",
+    "number": 5,
+    "rarity": 3,
+    "texture_path": "res://cards/tarot/rider_waite_tarot_deck/major_5.png"
+  },
+  {
+    "id": "major_6",
+    "name": "The Lovers",
+    "suit": "major",
+    "number": 6,
+    "rarity": 3,
+    "texture_path": "res://cards/tarot/rider_waite_tarot_deck/major_6.png"
+  },
+  {
+    "id": "major_7",
+    "name": "The Chariot",
+    "suit": "major",
+    "number": 7,
+    "rarity": 2,
+    "texture_path": "res://cards/tarot/rider_waite_tarot_deck/major_7.png"
+  },
+  {
+    "id": "major_8",
+    "name": "Strength",
+    "suit": "major",
+    "number": 8,
+    "rarity": 2,
+    "texture_path": "res://cards/tarot/rider_waite_tarot_deck/major_8.png"
+  },
+  {
+    "id": "major_9",
+    "name": "The Hermit",
+    "suit": "major",
+    "number": 9,
+    "rarity": 2,
+    "texture_path": "res://cards/tarot/rider_waite_tarot_deck/major_9.png"
+  },
+  {
+    "id": "major_10",
+    "name": "Wheel of Fortune",
+    "suit": "major",
+    "number": 10,
+    "rarity": 2,
+    "texture_path": "res://cards/tarot/rider_waite_tarot_deck/major_10.png"
+  },
+  {
+    "id": "major_11",
+    "name": "Justice",
+    "suit": "major",
+    "number": 11,
+    "rarity": 2,
+    "texture_path": "res://cards/tarot/rider_waite_tarot_deck/major_11.png"
+  },
+  {
+    "id": "major_12",
+    "name": "The Hanged Man",
+    "suit": "major",
+    "number": 12,
+    "rarity": 2,
+    "texture_path": "res://cards/tarot/rider_waite_tarot_deck/major_12.png"
+  },
+  {
+    "id": "major_13",
+    "name": "Death",
+    "suit": "major",
+    "number": 13,
+    "rarity": 2,
+    "texture_path": "res://cards/tarot/rider_waite_tarot_deck/major_13.png"
+  },
+  {
+    "id": "major_14",
+    "name": "Temperance",
+    "suit": "major",
+    "number": 14,
+    "rarity": 2,
+    "texture_path": "res://cards/tarot/rider_waite_tarot_deck/major_14.png"
+  },
+  {
+    "id": "major_15",
+    "name": "The Devil",
+    "suit": "major",
+    "number": 15,
+    "rarity": 2,
+    "texture_path": "res://cards/tarot/rider_waite_tarot_deck/major_15.png"
+  },
+  {
+    "id": "major_16",
+    "name": "The Tower",
+    "suit": "major",
+    "number": 16,
+    "rarity": 1,
+    "texture_path": "res://cards/tarot/rider_waite_tarot_deck/major_16.png"
+  },
+  {
+    "id": "major_17",
+    "name": "The Star",
+    "suit": "major",
+    "number": 17,
+    "rarity": 1,
+    "texture_path": "res://cards/tarot/rider_waite_tarot_deck/major_17.png"
+  },
+  {
+    "id": "major_18",
+    "name": "The Moon",
+    "suit": "major",
+    "number": 18,
+    "rarity": 1,
+    "texture_path": "res://cards/tarot/rider_waite_tarot_deck/major_18.png"
+  },
+  {
+    "id": "major_19",
+    "name": "The Sun",
+    "suit": "major",
+    "number": 19,
+    "rarity": 1,
+    "texture_path": "res://cards/tarot/rider_waite_tarot_deck/major_19.png"
+  },
+  {
+    "id": "major_20",
+    "name": "Judgement",
+    "suit": "major",
+    "number": 20,
+    "rarity": 1,
+    "texture_path": "res://cards/tarot/rider_waite_tarot_deck/major_20.png"
+  },
+  {
+    "id": "major_21",
+    "name": "The World",
+    "suit": "major",
+    "number": 21,
+    "rarity": 1,
+    "texture_path": "res://cards/tarot/rider_waite_tarot_deck/major_21.png"
+  },
+  {
+    "id": "wands_1",
+    "name": "Ace of Wands",
+    "suit": "wands",
+    "number": 1,
+    "rarity": 1,
+    "texture_path": "res://cards/tarot/rider_waite_tarot_deck/wands_1.png"
+  },
+  {
+    "id": "wands_2",
+    "name": "Two of Wands",
+    "suit": "wands",
+    "number": 2,
+    "rarity": 1,
+    "texture_path": "res://cards/tarot/rider_waite_tarot_deck/wands_2.png"
+  },
+  {
+    "id": "wands_3",
+    "name": "Three of Wands",
+    "suit": "wands",
+    "number": 3,
+    "rarity": 1,
+    "texture_path": "res://cards/tarot/rider_waite_tarot_deck/wands_3.png"
+  },
+  {
+    "id": "wands_4",
+    "name": "Four of Wands",
+    "suit": "wands",
+    "number": 4,
+    "rarity": 1,
+    "texture_path": "res://cards/tarot/rider_waite_tarot_deck/wands_4.png"
+  },
+  {
+    "id": "wands_5",
+    "name": "Five of Wands",
+    "suit": "wands",
+    "number": 5,
+    "rarity": 1,
+    "texture_path": "res://cards/tarot/rider_waite_tarot_deck/wands_5.png"
+  },
+  {
+    "id": "wands_6",
+    "name": "Six of Wands",
+    "suit": "wands",
+    "number": 6,
+    "rarity": 1,
+    "texture_path": "res://cards/tarot/rider_waite_tarot_deck/wands_6.png"
+  },
+  {
+    "id": "wands_7",
+    "name": "Seven of Wands",
+    "suit": "wands",
+    "number": 7,
+    "rarity": 1,
+    "texture_path": "res://cards/tarot/rider_waite_tarot_deck/wands_7.png"
+  },
+  {
+    "id": "wands_8",
+    "name": "Eight of Wands",
+    "suit": "wands",
+    "number": 8,
+    "rarity": 1,
+    "texture_path": "res://cards/tarot/rider_waite_tarot_deck/wands_8.png"
+  },
+  {
+    "id": "wands_9",
+    "name": "Nine of Wands",
+    "suit": "wands",
+    "number": 9,
+    "rarity": 1,
+    "texture_path": "res://cards/tarot/rider_waite_tarot_deck/wands_9.png"
+  },
+  {
+    "id": "wands_10",
+    "name": "Ten of Wands",
+    "suit": "wands",
+    "number": 10,
+    "rarity": 1,
+    "texture_path": "res://cards/tarot/rider_waite_tarot_deck/wands_10.png"
+  },
+  {
+    "id": "wands_11",
+    "name": "Page of Wands",
+    "suit": "wands",
+    "number": 11,
+    "rarity": 1,
+    "texture_path": "res://cards/tarot/rider_waite_tarot_deck/wands_11.png"
+  },
+  {
+    "id": "wands_12",
+    "name": "Knight of Wands",
+    "suit": "wands",
+    "number": 12,
+    "rarity": 1,
+    "texture_path": "res://cards/tarot/rider_waite_tarot_deck/wands_12.png"
+  },
+  {
+    "id": "wands_13",
+    "name": "Queen of Wands",
+    "suit": "wands",
+    "number": 13,
+    "rarity": 1,
+    "texture_path": "res://cards/tarot/rider_waite_tarot_deck/wands_13.png"
+  },
+  {
+    "id": "wands_14",
+    "name": "King of Wands",
+    "suit": "wands",
+    "number": 14,
+    "rarity": 1,
+    "texture_path": "res://cards/tarot/rider_waite_tarot_deck/wands_14.png"
+  },
+  {
+    "id": "cups_1",
+    "name": "Ace of Cups",
+    "suit": "cups",
+    "number": 1,
+    "rarity": 1,
+    "texture_path": "res://cards/tarot/rider_waite_tarot_deck/cups_1.png"
+  },
+  {
+    "id": "cups_2",
+    "name": "Two of Cups",
+    "suit": "cups",
+    "number": 2,
+    "rarity": 1,
+    "texture_path": "res://cards/tarot/rider_waite_tarot_deck/cups_2.png"
+  },
+  {
+    "id": "cups_3",
+    "name": "Three of Cups",
+    "suit": "cups",
+    "number": 3,
+    "rarity": 1,
+    "texture_path": "res://cards/tarot/rider_waite_tarot_deck/cups_3.png"
+  },
+  {
+    "id": "cups_4",
+    "name": "Four of Cups",
+    "suit": "cups",
+    "number": 4,
+    "rarity": 1,
+    "texture_path": "res://cards/tarot/rider_waite_tarot_deck/cups_4.png"
+  },
+  {
+    "id": "cups_5",
+    "name": "Five of Cups",
+    "suit": "cups",
+    "number": 5,
+    "rarity": 1,
+    "texture_path": "res://cards/tarot/rider_waite_tarot_deck/cups_5.png"
+  },
+  {
+    "id": "cups_6",
+    "name": "Six of Cups",
+    "suit": "cups",
+    "number": 6,
+    "rarity": 1,
+    "texture_path": "res://cards/tarot/rider_waite_tarot_deck/cups_6.png"
+  },
+  {
+    "id": "cups_7",
+    "name": "Seven of Cups",
+    "suit": "cups",
+    "number": 7,
+    "rarity": 1,
+    "texture_path": "res://cards/tarot/rider_waite_tarot_deck/cups_7.png"
+  },
+  {
+    "id": "cups_8",
+    "name": "Eight of Cups",
+    "suit": "cups",
+    "number": 8,
+    "rarity": 1,
+    "texture_path": "res://cards/tarot/rider_waite_tarot_deck/cups_8.png"
+  },
+  {
+    "id": "cups_9",
+    "name": "Nine of Cups",
+    "suit": "cups",
+    "number": 9,
+    "rarity": 1,
+    "texture_path": "res://cards/tarot/rider_waite_tarot_deck/cups_9.png"
+  },
+  {
+    "id": "cups_10",
+    "name": "Ten of Cups",
+    "suit": "cups",
+    "number": 10,
+    "rarity": 1,
+    "texture_path": "res://cards/tarot/rider_waite_tarot_deck/cups_10.png"
+  },
+  {
+    "id": "cups_11",
+    "name": "Page of Cups",
+    "suit": "cups",
+    "number": 11,
+    "rarity": 1,
+    "texture_path": "res://cards/tarot/rider_waite_tarot_deck/cups_11.png"
+  },
+  {
+    "id": "cups_12",
+    "name": "Knight of Cups",
+    "suit": "cups",
+    "number": 12,
+    "rarity": 1,
+    "texture_path": "res://cards/tarot/rider_waite_tarot_deck/cups_12.png"
+  },
+  {
+    "id": "cups_13",
+    "name": "Queen of Cups",
+    "suit": "cups",
+    "number": 13,
+    "rarity": 1,
+    "texture_path": "res://cards/tarot/rider_waite_tarot_deck/cups_13.png"
+  },
+  {
+    "id": "cups_14",
+    "name": "King of Cups",
+    "suit": "cups",
+    "number": 14,
+    "rarity": 1,
+    "texture_path": "res://cards/tarot/rider_waite_tarot_deck/cups_14.png"
+  },
+  {
+    "id": "swords_1",
+    "name": "Ace of Swords",
+    "suit": "swords",
+    "number": 1,
+    "rarity": 1,
+    "texture_path": "res://cards/tarot/rider_waite_tarot_deck/swords_1.png"
+  },
+  {
+    "id": "swords_2",
+    "name": "Two of Swords",
+    "suit": "swords",
+    "number": 2,
+    "rarity": 1,
+    "texture_path": "res://cards/tarot/rider_waite_tarot_deck/swords_2.png"
+  },
+  {
+    "id": "swords_3",
+    "name": "Three of Swords",
+    "suit": "swords",
+    "number": 3,
+    "rarity": 1,
+    "texture_path": "res://cards/tarot/rider_waite_tarot_deck/swords_3.png"
+  },
+  {
+    "id": "swords_4",
+    "name": "Four of Swords",
+    "suit": "swords",
+    "number": 4,
+    "rarity": 1,
+    "texture_path": "res://cards/tarot/rider_waite_tarot_deck/swords_4.png"
+  },
+  {
+    "id": "swords_5",
+    "name": "Five of Swords",
+    "suit": "swords",
+    "number": 5,
+    "rarity": 1,
+    "texture_path": "res://cards/tarot/rider_waite_tarot_deck/swords_5.png"
+  },
+  {
+    "id": "swords_6",
+    "name": "Six of Swords",
+    "suit": "swords",
+    "number": 6,
+    "rarity": 1,
+    "texture_path": "res://cards/tarot/rider_waite_tarot_deck/swords_6.png"
+  },
+  {
+    "id": "swords_7",
+    "name": "Seven of Swords",
+    "suit": "swords",
+    "number": 7,
+    "rarity": 1,
+    "texture_path": "res://cards/tarot/rider_waite_tarot_deck/swords_7.png"
+  },
+  {
+    "id": "swords_8",
+    "name": "Eight of Swords",
+    "suit": "swords",
+    "number": 8,
+    "rarity": 1,
+    "texture_path": "res://cards/tarot/rider_waite_tarot_deck/swords_8.png"
+  },
+  {
+    "id": "swords_9",
+    "name": "Nine of Swords",
+    "suit": "swords",
+    "number": 9,
+    "rarity": 1,
+    "texture_path": "res://cards/tarot/rider_waite_tarot_deck/swords_9.png"
+  },
+  {
+    "id": "swords_10",
+    "name": "Ten of Swords",
+    "suit": "swords",
+    "number": 10,
+    "rarity": 1,
+    "texture_path": "res://cards/tarot/rider_waite_tarot_deck/swords_10.png"
+  },
+  {
+    "id": "swords_11",
+    "name": "Page of Swords",
+    "suit": "swords",
+    "number": 11,
+    "rarity": 1,
+    "texture_path": "res://cards/tarot/rider_waite_tarot_deck/swords_11.png"
+  },
+  {
+    "id": "swords_12",
+    "name": "Knight of Swords",
+    "suit": "swords",
+    "number": 12,
+    "rarity": 1,
+    "texture_path": "res://cards/tarot/rider_waite_tarot_deck/swords_12.png"
+  },
+  {
+    "id": "swords_13",
+    "name": "Queen of Swords",
+    "suit": "swords",
+    "number": 13,
+    "rarity": 1,
+    "texture_path": "res://cards/tarot/rider_waite_tarot_deck/swords_13.png"
+  },
+  {
+    "id": "swords_14",
+    "name": "King of Swords",
+    "suit": "swords",
+    "number": 14,
+    "rarity": 1,
+    "texture_path": "res://cards/tarot/rider_waite_tarot_deck/swords_14.png"
+  },
+  {
+    "id": "pentacles_1",
+    "name": "Ace of Pentacles",
+    "suit": "pentacles",
+    "number": 1,
+    "rarity": 1,
+    "texture_path": "res://cards/tarot/rider_waite_tarot_deck/pentacles_1.png"
+  },
+  {
+    "id": "pentacles_2",
+    "name": "Two of Pentacles",
+    "suit": "pentacles",
+    "number": 2,
+    "rarity": 1,
+    "texture_path": "res://cards/tarot/rider_waite_tarot_deck/pentacles_2.png"
+  },
+  {
+    "id": "pentacles_3",
+    "name": "Three of Pentacles",
+    "suit": "pentacles",
+    "number": 3,
+    "rarity": 1,
+    "texture_path": "res://cards/tarot/rider_waite_tarot_deck/pentacles_3.png"
+  },
+  {
+    "id": "pentacles_4",
+    "name": "Four of Pentacles",
+    "suit": "pentacles",
+    "number": 4,
+    "rarity": 1,
+    "texture_path": "res://cards/tarot/rider_waite_tarot_deck/pentacles_4.png"
+  },
+  {
+    "id": "pentacles_5",
+    "name": "Five of Pentacles",
+    "suit": "pentacles",
+    "number": 5,
+    "rarity": 1,
+    "texture_path": "res://cards/tarot/rider_waite_tarot_deck/pentacles_5.png"
+  },
+  {
+    "id": "pentacles_6",
+    "name": "Six of Pentacles",
+    "suit": "pentacles",
+    "number": 6,
+    "rarity": 1,
+    "texture_path": "res://cards/tarot/rider_waite_tarot_deck/pentacles_6.png"
+  },
+  {
+    "id": "pentacles_7",
+    "name": "Seven of Pentacles",
+    "suit": "pentacles",
+    "number": 7,
+    "rarity": 1,
+    "texture_path": "res://cards/tarot/rider_waite_tarot_deck/pentacles_7.png"
+  },
+  {
+    "id": "pentacles_8",
+    "name": "Eight of Pentacles",
+    "suit": "pentacles",
+    "number": 8,
+    "rarity": 1,
+    "texture_path": "res://cards/tarot/rider_waite_tarot_deck/pentacles_8.png"
+  },
+  {
+    "id": "pentacles_9",
+    "name": "Nine of Pentacles",
+    "suit": "pentacles",
+    "number": 9,
+    "rarity": 1,
+    "texture_path": "res://cards/tarot/rider_waite_tarot_deck/pentacles_9.png"
+  },
+  {
+    "id": "pentacles_10",
+    "name": "Ten of Pentacles",
+    "suit": "pentacles",
+    "number": 10,
+    "rarity": 1,
+    "texture_path": "res://cards/tarot/rider_waite_tarot_deck/pentacles_10.png"
+  },
+  {
+    "id": "pentacles_11",
+    "name": "Page of Pentacles",
+    "suit": "pentacles",
+    "number": 11,
+    "rarity": 1,
+    "texture_path": "res://cards/tarot/rider_waite_tarot_deck/pentacles_11.png"
+  },
+  {
+    "id": "pentacles_12",
+    "name": "Knight of Pentacles",
+    "suit": "pentacles",
+    "number": 12,
+    "rarity": 1,
+    "texture_path": "res://cards/tarot/rider_waite_tarot_deck/pentacles_12.png"
+  },
+  {
+    "id": "pentacles_13",
+    "name": "Queen of Pentacles",
+    "suit": "pentacles",
+    "number": 13,
+    "rarity": 1,
+    "texture_path": "res://cards/tarot/rider_waite_tarot_deck/pentacles_13.png"
+  },
+  {
+    "id": "pentacles_14",
+    "name": "King of Pentacles",
+    "suit": "pentacles",
+    "number": 14,
+    "rarity": 1,
+    "texture_path": "res://cards/tarot/rider_waite_tarot_deck/pentacles_14.png"
+  }
+]

--- a/project.godot
+++ b/project.godot
@@ -53,6 +53,7 @@ TerminalManager="*res://autoload/terminal_manager.gd"
 DesktopLayoutManager="*res://autoloads/desktop_layout_manager.gd"
 SoundManager="*res://autoloads/sound_manager.gd"
 TraumaManager="*res://autoloads/TraumaManager.gd"
+TarotManager="*res://autoloads/tarot_manager.gd"
 
 [display]
 


### PR DESCRIPTION
## Summary
- add full 78-card tarot dataset
- implement TarotManager, TarotDeck, and TarotCardView
- create TarotApp with Draw and Collection tabs and integrate into save/load
- remove placeholder tarot textures and uid files; reference existing deck textures and sigma icon

## Testing
- `godot3-server --headless --script tests/test_runner.gd` *(fails: Can't open project at '/workspace/SigmaSim/project.godot', its `config_version` (5) is from a more recent and incompatible version of the engine. Expected config version: 4.)*

------
https://chatgpt.com/codex/tasks/task_e_68b7289d67f48325a7d06cd91ace4af3