### PR TITLE
Enable credit purchase for software items

### DIFF
--- a/components/apps/soft_wares/soft_ware_item.gd
+++ b/components/apps/soft_wares/soft_ware_item.gd
@@ -34,18 +34,18 @@ func _update_action_button() -> void:
 		action_button.text = "Unlock"
 
 func _on_action_button_pressed() -> void:
-	feedback_label.text = ""
-	feedback_label.remove_theme_color_override("font_color")
-	if WindowManager.is_app_unlocked(app_id):
-		WindowManager.launch_app(app_id)
-		return
-	if PortfolioManager.cash >= float(app_cost):
-		PortfolioManager.cash = PortfolioManager.cash - float(app_cost)
-		WindowManager.unlock_app(app_id)
-		_update_action_button()
-	else:
-		feedback_label.text = "Not enough cash!"
-		feedback_label.add_theme_color_override("font_color", Color.RED)
+        feedback_label.text = ""
+        feedback_label.remove_theme_color_override("font_color")
+        if WindowManager.is_app_unlocked(app_id):
+                WindowManager.launch_app(app_id)
+                return
+        var required_score: int = PortfolioManager.CREDIT_REQUIREMENTS.get(app_title, 0)
+        if PortfolioManager.attempt_spend(float(app_cost), required_score):
+                WindowManager.unlock_app(app_id)
+                _update_action_button()
+        else:
+                feedback_label.text = "Not enough funds!"
+                feedback_label.add_theme_color_override("font_color", Color.RED)
 
 func _on_upgrades_button_pressed() -> void:
 	UpgradeManager.open_upgrade_pane(app_id)

--- a/components/apps/soft_wares/soft_wares_app.gd
+++ b/components/apps/soft_wares/soft_wares_app.gd
@@ -40,14 +40,14 @@ func _ready() -> void:
 	_populate_items()
 
 func _populate_items() -> void:
-	for app_id in soft_wares_registry.keys():
-		var data: Dictionary = soft_wares_registry[app_id]
-		var item: SoftWareItem = SOFTWARE_ITEM_SCENE.instantiate() as SoftWareItem
-		items_container.add_child(item)
-		item.app_icon = data["icon"]
-		item.app_title = data["title"]
-		item.app_description = data["description"]
-		item.app_cost = int(data["cost"])
-		item.has_upgrades = bool(data["has_upgrades"])
-		item.app_id = app_id
+        for app_id in soft_wares_registry.keys():
+                var data: Dictionary = soft_wares_registry[app_id]
+                var item: SoftWareItem = SOFTWARE_ITEM_SCENE.instantiate() as SoftWareItem
+                item.app_icon = data["icon"]
+                item.app_title = data["title"]
+                item.app_description = data["description"]
+                item.app_cost = int(data["cost"])
+                item.has_upgrades = bool(data["has_upgrades"])
+                item.app_id = app_id
+                items_container.add_child(item)
 		


### PR DESCRIPTION
## Summary
- set software item properties before adding to scene so details display correctly
- use PortfolioManager.attempt_spend to allow buying apps with cash or credit

## Testing
- `godot4 --headless -s tests/test_runner.gd` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b72caeb1b48325b45df12a8be27e0d