### PR TITLE
Use app upgrade panes for softwares

### DIFF
--- a/components/apps/soft_wares/soft_ware_item.gd
+++ b/components/apps/soft_wares/soft_ware_item.gd
@@ -5,8 +5,9 @@ class_name SoftWareItem
 @export var app_title: String = ""
 @export var app_description: String = ""
 @export var app_cost: int = 0
-@export var has_upgrades: bool = false
 @export var app_id: String = ""
+
+var upgrade_scene: PackedScene = null
 
 @onready var icon_rect: TextureRect = %Icon
 @onready var title_label: Label = %TitleLabel
@@ -17,15 +18,15 @@ class_name SoftWareItem
 @onready var feedback_label: Label = %FeedbackLabel
 
 func _ready() -> void:
-	icon_rect.texture = app_icon
-	title_label.text = app_title
-	description_label.text = app_description
-	cost_label.text = "$" + str(app_cost)
-	upgrades_button.visible = has_upgrades
-	_update_action_button()
-	action_button.pressed.connect(_on_action_button_pressed)
-	upgrades_button.pressed.connect(_on_upgrades_button_pressed)
-	WindowManager.app_unlocked.connect(_on_app_unlocked)
+        icon_rect.texture = app_icon
+        title_label.text = app_title
+        description_label.text = app_description
+        cost_label.text = "$" + str(app_cost)
+        upgrades_button.visible = upgrade_scene != null
+        _update_action_button()
+        action_button.pressed.connect(_on_action_button_pressed)
+        upgrades_button.pressed.connect(_on_upgrades_button_pressed)
+        WindowManager.app_unlocked.connect(_on_app_unlocked)
 
 func _update_action_button() -> void:
 	if WindowManager.is_app_unlocked(app_id):
@@ -48,7 +49,8 @@ func _on_action_button_pressed() -> void:
                 feedback_label.add_theme_color_override("font_color", Color.RED)
 
 func _on_upgrades_button_pressed() -> void:
-	UpgradeManager.open_upgrade_pane(app_id)
+        if upgrade_scene:
+                WindowManager.launch_popup(upgrade_scene, app_title + "::upgrade")
 
 func _on_app_unlocked(unlocked_id: String) -> void:
 	if unlocked_id == app_id:

--- a/components/apps/soft_wares/soft_wares_app.gd
+++ b/components/apps/soft_wares/soft_wares_app.gd
@@ -4,34 +4,30 @@ class_name SoftWaresApp
 const SOFTWARE_ITEM_SCENE: PackedScene = preload("res://components/apps/soft_wares/soft_ware_item.tscn")
 
 var soft_wares_registry: Dictionary = {
-	"minerr": {
-		"title": "Minerr",
-		"description": "Mine and trade cryptocurrencies.",
-		"icon": preload("res://assets/cursors/pickaxe.png"),
-		"cost": 100,
-		"has_upgrades": true
-	},
-	"brokerage": {
-		"title": "BrokeRage",
-		"description": "Buy and sell stocks in a chaotic market.",
-		"icon": preload("res://assets/logos/brokerage.png"),
-		"cost": 250,
-		"has_upgrades": true
-	},
-	"fumble": {
-		"title": "Fumble",
-		"description": "Date, swipe, and battle for love.",
-		"icon": preload("res://assets/logos/fumble.png"),
-		"cost": 300,
-		"has_upgrades": false
-	},
-	"earlybird": {
-		"title": "EarlyBird",
-		"description": "Rise early and get that worm.",
-		"icon": preload("res://assets/early_bird/worm1.png"),
-		"cost": 150,
-		"has_upgrades": false
-	}
+        "minerr": {
+                "title": "Minerr",
+                "description": "Mine and trade cryptocurrencies.",
+                "icon": preload("res://assets/cursors/pickaxe.png"),
+                "cost": 100
+        },
+        "brokerage": {
+                "title": "BrokeRage",
+                "description": "Buy and sell stocks in a chaotic market.",
+                "icon": preload("res://assets/logos/brokerage.png"),
+                "cost": 250
+        },
+        "fumble": {
+                "title": "Fumble",
+                "description": "Date, swipe, and battle for love.",
+                "icon": preload("res://assets/logos/fumble.png"),
+                "cost": 300
+        },
+        "earlybird": {
+                "title": "EarlyBird",
+                "description": "Rise early and get that worm.",
+                "icon": preload("res://assets/early_bird/worm1.png"),
+                "cost": 150
+        }
 }
 
 @onready var items_container: VBoxContainer = %ItemsContainer
@@ -47,7 +43,23 @@ func _populate_items() -> void:
                 item.app_title = data["title"]
                 item.app_description = data["description"]
                 item.app_cost = int(data["cost"])
-                item.has_upgrades = bool(data["has_upgrades"])
                 item.app_id = app_id
+                item.upgrade_scene = _get_upgrade_scene(app_id)
                 items_container.add_child(item)
-		
+
+func _get_upgrade_scene(app_id: String) -> PackedScene:
+        var mapping: Dictionary = {
+                "minerr": "Minerr",
+                "brokerage": "BrokeRage",
+                "fumble": "Fumble",
+                "earlybird": "EarlyBird"
+        }
+        var app_name: String = mapping.get(app_id, app_id)
+        var scene: PackedScene = WindowManager.app_registry.get(app_name)
+        if scene:
+                var pane := scene.instantiate() as Pane
+                if pane:
+                        var upgrade_scene: PackedScene = pane.upgrade_pane
+                        pane.queue_free()
+                        return upgrade_scene
+        return null


### PR DESCRIPTION
## Summary
- Remove hardcoded has_upgrades flags and inspect each app's pane for an upgrade_pane
- Launch the discovered upgrade pane when pressing the Upgrades button in SoftWares

## Testing
- `godot --headless -s tests/test_runner.gd` *(fails: command not found)*
- `apt-get install -y godot4` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b7305a5e388325a46d0ba2c761508f