### PR TITLE
Enforce non-repeating 64px icons for software items

### DIFF
--- a/components/apps/soft_wares/soft_ware_item.gd
+++ b/components/apps/soft_wares/soft_ware_item.gd
@@ -17,7 +17,7 @@ class_name SoftWareItem
 @onready var feedback_label: Label = %FeedbackLabel
 
 func _ready() -> void:
-	icon_rect.texture = app_icon
+	_setup_icon()
 	title_label.text = app_title
 	description_label.text = app_description
 	cost_label.text = "$" + str(app_cost)
@@ -27,6 +27,18 @@ func _ready() -> void:
 	upgrades_button.pressed.connect(_on_upgrades_button_pressed)
 	WindowManager.app_unlocked.connect(_on_app_unlocked)
 
+func _setup_icon() -> void:
+	if app_icon:
+		var image := app_icon.get_image()
+		if image.get_width() != 64 or image.get_height() != 64:
+			image.resize(64, 64)
+			icon_rect.texture = ImageTexture.create_from_image(image)
+		else:
+			icon_rect.texture = app_icon
+	icon_rect.custom_minimum_size = Vector2(64, 64)
+	icon_rect.size = Vector2(64, 64)
+	icon_rect.texture_repeat = CanvasItem.TEXTURE_REPEAT_DISABLED
+	icon_rect.stretch_mode = TextureRect.STRETCH_KEEP_ASPECT_CENTERED
 func _update_action_button() -> void:
 	if WindowManager.is_app_unlocked(app_id):
 		action_button.text = "Launch"


### PR DESCRIPTION
## Summary
- Scale and constrain software item icons to 64×64 and disable texture repeating
- Factor icon setup into helper for cleanliness

## Testing
- `godot4 --headless --path . -s tests/test_runner.gd` *(fails: script doesn't inherit from SceneTree)*
- `godot4 --headless --path . tests/test_runner.tscn` *(fails: missing imported resources)*

------
https://chatgpt.com/codex/tasks/task_e_68b72f998ad483259eead7a05793a1ab