### PR TITLE
Fix cyclic reference when accessing app registry in SoftWaresApp

### DIFF
--- a/components/apps/soft_wares/soft_wares_app.gd
+++ b/components/apps/soft_wares/soft_wares_app.gd
@@ -54,12 +54,19 @@ func _get_upgrade_scene(app_id: String) -> PackedScene:
                 "fumble": "Fumble",
                 "earlybird": "EarlyBird"
         }
-        var app_name: String = mapping.get(app_id, app_id)
-        var scene: PackedScene = WindowManager.app_registry.get(app_name)
-        if scene:
-                var pane := scene.instantiate() as Pane
-                if pane:
-                        var upgrade_scene: PackedScene = pane.upgrade_pane
-                        pane.queue_free()
-                        return upgrade_scene
-        return null
+       var app_name: String = mapping.get(app_id, app_id)
+       var scene: PackedScene = null
+
+       var wm := get_tree().root.get_node("WindowManager")
+       if wm:
+               var registry = wm.get("app_registry")
+               if registry is Dictionary:
+                       scene = registry.get(app_name)
+
+       if scene:
+               var pane := scene.instantiate() as Pane
+               if pane:
+                       var upgrade_scene: PackedScene = pane.upgrade_pane
+                       pane.queue_free()
+                       return upgrade_scene
+       return null


### PR DESCRIPTION
## Summary
- Avoid direct `WindowManager.app_registry` access in `SoftWaresApp` to prevent cyclic reference errors by retrieving the app registry via the runtime node

## Testing
- `godot4 --headless -s tests/test_runner.gd` *(fails: command not found)*
- `apt-get install -y godot4` *(fails: unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68b73988f3008325b3d725bdf08566ee