### PR TITLE
Scale software item icons and prevent repeats

### DIFF
--- a/components/apps/soft_wares/soft_ware_item.gd
+++ b/components/apps/soft_wares/soft_ware_item.gd
@@ -18,15 +18,25 @@ var upgrade_scene: PackedScene = null
 @onready var feedback_label: Label = %FeedbackLabel
 
 func _ready() -> void:
-		icon_rect.texture = app_icon
-		title_label.text = app_title
-		description_label.text = app_description
-		cost_label.text = "$" + str(app_cost)
-		upgrades_button.visible = upgrade_scene != null
-		_update_action_button()
-		action_button.pressed.connect(_on_action_button_pressed)
-		upgrades_button.pressed.connect(_on_upgrades_button_pressed)
-		WindowManager.app_unlocked.connect(_on_app_unlocked)
+                icon_rect.texture = _prepare_icon(app_icon)
+                icon_rect.stretch_mode = TextureRect.STRETCH_SCALE
+                icon_rect.texture_repeat = CanvasItem.TEXTURE_REPEAT_DISABLED
+                title_label.text = app_title
+                description_label.text = app_description
+                cost_label.text = "$" + str(app_cost)
+                upgrades_button.visible = upgrade_scene != null
+                _update_action_button()
+                action_button.pressed.connect(_on_action_button_pressed)
+                upgrades_button.pressed.connect(_on_upgrades_button_pressed)
+                WindowManager.app_unlocked.connect(_on_app_unlocked)
+
+func _prepare_icon(source: Texture2D) -> Texture2D:
+        if source == null:
+                return null
+        var img: Image = source.get_image()
+        if img.get_width() != 64 or img.get_height() != 64:
+                img.resize(64, 64, Image.INTERPOLATE_LANCZOS)
+        return ImageTexture.create_from_image(img)
 
 func _update_action_button() -> void:
 	if WindowManager.is_app_unlocked(app_id):

--- a/components/apps/soft_wares/soft_wares_app.gd
+++ b/components/apps/soft_wares/soft_wares_app.gd
@@ -36,16 +36,22 @@ func _ready() -> void:
 	_populate_items()
 
 func _populate_items() -> void:
-		for app_id in soft_wares_registry.keys():
-				var data: Dictionary = soft_wares_registry[app_id]
-				var item: SoftWareItem = SOFTWARE_ITEM_SCENE.instantiate() as SoftWareItem
-				item.app_icon = data["icon"]
-				item.app_title = data["title"]
-				item.app_description = data["description"]
-				item.app_cost = int(data["cost"])
-				item.app_id = app_id
-				item.upgrade_scene = _get_upgrade_scene(app_id)
-				items_container.add_child(item)
+                var used_icons: Dictionary = {}
+                for app_id in soft_wares_registry.keys():
+                                var data: Dictionary = soft_wares_registry[app_id]
+                                var icon: Texture2D = data["icon"]
+                                var icon_path: String = icon.resource_path
+                                if used_icons.has(icon_path):
+                                                continue
+                                used_icons[icon_path] = true
+                                var item: SoftWareItem = SOFTWARE_ITEM_SCENE.instantiate() as SoftWareItem
+                                item.app_icon = icon
+                                item.app_title = data["title"]
+                                item.app_description = data["description"]
+                                item.app_cost = int(data["cost"])
+                                item.app_id = app_id
+                                item.upgrade_scene = _get_upgrade_scene(app_id)
+                                items_container.add_child(item)
 
 func _get_upgrade_scene(app_id: String) -> PackedScene:
 		var mapping: Dictionary = {


### PR DESCRIPTION
## Summary
- Resize software item icons to 64x64 and disable texture repeating
- Skip duplicate icons when building the software list

## Testing
- `godot3-server --headless --path . -s tests/test_runner.gd` *(fails: Can't open project at '/workspace/SigmaSim/project.godot', config_version 5)*

------
https://chatgpt.com/codex/tasks/task_e_68b739e496f08325806eb03ee97d16a5