### PR TITLE
Show sell price for daily tarot cards

### DIFF
--- a/autoloads/tarot_manager.gd
+++ b/autoloads/tarot_manager.gd
@@ -39,8 +39,8 @@ func get_card_count(id: String) -> int:
 func get_all_cards_ordered() -> Array:
 	return deck.get_all_cards_ordered()
 
-func instantiate_card_view(id: String, count: int = 0) -> TarotCardView:
-	return deck.instantiate_card_view(id, count)
+func instantiate_card_view(id: String, count: int = 0, mark_sold_on_sell: bool = false) -> TarotCardView:
+        return deck.instantiate_card_view(id, count, mark_sold_on_sell)
 
 func time_until_next_draw() -> int:
 	var now = TimeManager.get_now_minutes()

--- a/components/apps/tarot/tarot_app.gd
+++ b/components/apps/tarot/tarot_app.gd
@@ -30,7 +30,7 @@ func _build_collection_view() -> void:
 	for card in TarotManager.get_all_cards_ordered():
 		var id: String = card.get("id", "")
 		var count: int = TarotManager.get_card_count(id)
-		var view: TarotCardView = TarotManager.instantiate_card_view(id, count)
+               var view: TarotCardView = TarotManager.instantiate_card_view(id, count)
 		collection_grid.add_child(view)
 		card_views[id] = view
 
@@ -46,7 +46,7 @@ func _on_draw_button_pressed() -> void:
 	for child in draw_result.get_children():
 		child.queue_free()
 	var id = card.get("id", "")
-	var view = TarotManager.instantiate_card_view(id, TarotManager.get_card_count(id))
+       var view = TarotManager.instantiate_card_view(id, TarotManager.get_card_count(id), true)
 	draw_result.add_child(view)
 	_update_cooldown_label()
 

--- a/components/apps/tarot/tarot_card_view.gd
+++ b/components/apps/tarot/tarot_card_view.gd
@@ -4,6 +4,8 @@ class_name TarotCardView
 var card_id: String = ""
 var rarity: int = 1
 var count: int = 0
+var sell_price: float = 0.0
+var mark_sold_on_sell: bool = false
 
 @onready var texture_rect: TextureRect = %TextureRect
 @onready var name_label: Label = %NameLabel
@@ -14,22 +16,33 @@ func setup(data: Dictionary, owned: int) -> void:
 	if not is_node_ready():
 		await ready
 	
-	card_id = data.get("id", "")
-	name_label.text = data.get("name", "")
-	rarity = int(data.get("rarity", 1))
-	var tex_path: String = data.get("texture_path", "")
-	var tex = load(tex_path)
-	if tex:
-		texture_rect.texture = tex
-	update_count(owned)
-	sell_button.pressed.connect(_on_sell_pressed)
+        card_id = data.get("id", "")
+        name_label.text = data.get("name", "")
+        rarity = int(data.get("rarity", 1))
+        sell_price = float(rarity)
+        var tex_path: String = data.get("texture_path", "")
+        var tex = load(tex_path)
+        if tex:
+                texture_rect.texture = tex
+        update_count(owned)
+        sell_button.text = "Sell for $%d" % int(sell_price)
+        sell_button.pressed.connect(_on_sell_pressed)
 
 func update_count(new_count: int) -> void:
 	count = new_count
 	count_label.visible = count > 1
 	count_label.text = "x%d" % count
-	sell_button.visible = count > 0
-	texture_rect.modulate = Color(1,1,1,1) if count > 0 else Color(0.5,0.5,0.5,1)
+        sell_button.visible = count > 0
+        texture_rect.modulate = Color(1,1,1,1) if count > 0 else Color(0.5,0.5,0.5,1)
+        if count > 0:
+                sell_button.disabled = false
+                sell_button.text = "Sell for $%d" % int(sell_price)
 
 func _on_sell_pressed() -> void:
-	TarotManager.sell_card(card_id)
+        TarotManager.sell_card(card_id)
+        var new_count := TarotManager.get_card_count(card_id)
+        update_count(new_count)
+        if mark_sold_on_sell:
+                sell_button.text = "SOLD"
+                sell_button.disabled = true
+                sell_button.visible = true

--- a/components/apps/tarot/tarot_deck.gd
+++ b/components/apps/tarot/tarot_deck.gd
@@ -31,9 +31,10 @@ func load_from_file(path: String) -> void:
 func get_card(id: String) -> Dictionary:
     return card_map.get(id, {})
 
-func instantiate_card_view(id: String, count: int = 0) -> TarotCardView:
+func instantiate_card_view(id: String, count: int = 0, mark_sold_on_sell: bool = false) -> TarotCardView:
     var data = get_card(id)
     var view: TarotCardView = CARD_VIEW_SCENE.instantiate()
+    view.mark_sold_on_sell = mark_sold_on_sell
     view.setup(data, count)
     return view
 


### PR DESCRIPTION
## Summary
- Display sell value on tarot card buttons
- Mark daily draw cards as sold after selling
- Support passing sold-state flag through tarot deck and manager

## Testing
- `godot --headless -s tests/test_runner.gd` *(fails: script doesn't inherit from SceneTree or MainLoop)*

------
https://chatgpt.com/codex/tasks/task_e_68b74288dd1c8325bfc463f17afc8533