### PR TITLE
Add card collection examiner with rarity-specific selling

### DIFF
--- a/components/apps/app_scenes/tarot_app.tscn
+++ b/components/apps/app_scenes/tarot_app.tscn
@@ -1,8 +1,9 @@
-[gd_scene load_steps=4 format=3 uid="uid://ba3fd3816f1fd"]
+[gd_scene load_steps=5 format=3 uid="uid://ba3fd3816f1fd"]
 
 [ext_resource type="Theme" uid="uid://cesgvqexxaqev" path="res://assets/themes/windows_95_theme.tres" id="1"]
 [ext_resource type="Script" uid="uid://cvgwn14oqkvd5" path="res://components/apps/tarot/tarot_app.gd" id="2"]
 [ext_resource type="Texture2D" uid="uid://b8cd5rom7n7tl" path="res://assets/sigma.png" id="3"]
+[ext_resource type="PackedScene" path="res://components/apps/tarot/card_collection_examiner.tscn" id="4"]
 
 [node name="TarotApp" type="MarginContainer"]
 anchors_preset = 15
@@ -71,3 +72,5 @@ layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
 columns = 6
+
+[node name="CardCollectionExaminer" parent="." instance=ExtResource("4")]

--- a/components/apps/tarot/card_collection_examiner.gd
+++ b/components/apps/tarot/card_collection_examiner.gd
@@ -1,0 +1,38 @@
+extends CenterContainer
+class_name CardCollectionExaminer
+
+const CARD_VIEW_SCENE = preload("res://components/apps/tarot/tarot_card_view.tscn")
+
+@onready var card_holder: HBoxContainer = %CardHolder
+@onready var close_button: Button = %CloseButton
+
+var current_card_id: String = ""
+
+func _ready() -> void:
+        visible = false
+        close_button.pressed.connect(hide)
+        TarotManager.collection_changed.connect(_on_collection_changed)
+
+func show_card(card_id: String) -> void:
+        current_card_id = card_id
+        for child in card_holder.get_children():
+                child.queue_free()
+        var base = TarotManager.deck.get_card(card_id)
+        if base.is_empty():
+                return
+        for rarity in [1,2,3,4,5]:
+                var data = base.duplicate()
+                data["rarity"] = rarity
+                var count = TarotManager.get_card_rarity_count(card_id, rarity)
+                var view: TarotCardView = CARD_VIEW_SCENE.instantiate()
+                view.show_single_count = true
+                view.setup(data, count)
+                card_holder.add_child(view)
+        show()
+
+func _on_collection_changed(card_id: String, _count: int) -> void:
+        if not visible or card_id != current_card_id:
+                return
+        for view in card_holder.get_children():
+                var rarity = view.rarity
+                view.update_count(TarotManager.get_card_rarity_count(card_id, rarity))

--- a/components/apps/tarot/card_collection_examiner.tscn
+++ b/components/apps/tarot/card_collection_examiner.tscn
@@ -1,0 +1,19 @@
+[gd_scene load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://components/apps/tarot/card_collection_examiner.gd" id="1"]
+
+[node name="CardCollectionExaminer" type="CenterContainer"]
+unique_name_in_owner = true
+visible = false
+script = ExtResource("1")
+
+[node name="Panel" type="PanelContainer" parent="."]
+
+[node name="VBox" type="VBoxContainer" parent="Panel"]
+
+[node name="CardHolder" type="HBoxContainer" parent="Panel/VBox"]
+unique_name_in_owner = true
+
+[node name="CloseButton" type="Button" parent="Panel/VBox"]
+unique_name_in_owner = true
+text = "Close"

--- a/components/apps/tarot/tarot_app.gd
+++ b/components/apps/tarot/tarot_app.gd
@@ -9,6 +9,7 @@ class_name TarotApp
 @onready var draw_view: VBoxContainer = %DrawView
 @onready var collection_view: ScrollContainer = %CollectionView
 @onready var collection_grid: GridContainer = %CollectionGrid
+@onready var card_collection_examiner: CardCollectionExaminer = %CardCollectionExaminer
 
 var card_views: Dictionary = {}
 var _active_tab: StringName = &"Draw"
@@ -31,10 +32,11 @@ func _build_collection_view() -> void:
 		var id: String = card.get("id", "")
 		var count: int = TarotManager.get_card_count(id)
                var view: TarotCardView = TarotManager.instantiate_card_view(id, count)
-		collection_grid.add_child(view)
-		view.texture_rect.custom_minimum_size = Vector2(32, 56)
-		
-		card_views[id] = view
+                collection_grid.add_child(view)
+                view.texture_rect.custom_minimum_size = Vector2(32, 56)
+                view.card_pressed.connect(card_collection_examiner.show_card)
+
+                card_views[id] = view
 
 func _on_collection_changed(card_id: String, count: int) -> void:
 	var view = card_views.get(card_id)
@@ -49,8 +51,11 @@ func _on_draw_button_pressed() -> void:
 	for child in draw_result.get_children():
 		child.queue_free()
 	var id = card.get("id", "")
-       var view = TarotManager.instantiate_card_view(id, TarotManager.get_card_count(id), true)
-	draw_result.add_child(view)
+       var rarity = int(card.get("rarity", 1))
+       var count_for_rarity = TarotManager.get_card_rarity_count(id, rarity)
+       var view = TarotManager.instantiate_card_view(id, count_for_rarity, true, rarity)
+       view.show_single_count = true
+        draw_result.add_child(view)
 	_update_cooldown_label()
 
 func _update_cooldown_label() -> void:

--- a/components/apps/tarot/tarot_card_view.gd
+++ b/components/apps/tarot/tarot_card_view.gd
@@ -6,6 +6,9 @@ var rarity: int = 1
 var count: int = 0
 var sell_price: float = 0.0
 var mark_sold_on_sell: bool = false
+var show_single_count: bool = false
+
+signal card_pressed(card_id: String)
 
 @onready var texture_rect: TextureRect = %TextureRect
 @onready var name_label: Label = %NameLabel
@@ -19,7 +22,7 @@ func setup(data: Dictionary, owned: int) -> void:
         card_id = data.get("id", "")
         name_label.text = data.get("name", "")
         rarity = int(data.get("rarity", 1))
-        sell_price = float(rarity)
+        sell_price = TarotManager.get_sell_price(rarity)
         var tex_path: String = data.get("texture_path", "")
         var tex = load(tex_path)
         if tex:
@@ -29,9 +32,9 @@ func setup(data: Dictionary, owned: int) -> void:
         sell_button.pressed.connect(_on_sell_pressed)
 
 func update_count(new_count: int) -> void:
-	count = new_count
-	count_label.visible = count > 1
-	count_label.text = "x%d" % count
+        count = new_count
+        count_label.visible = count > 0 and (count > 1 or show_single_count)
+        count_label.text = "x%d" % count
         sell_button.visible = count > 0
         texture_rect.modulate = Color(1,1,1,1) if count > 0 else Color(0.5,0.5,0.5,1)
         if count > 0:
@@ -39,10 +42,19 @@ func update_count(new_count: int) -> void:
                 sell_button.text = "Sell for $%d" % int(sell_price)
 
 func _on_sell_pressed() -> void:
-        TarotManager.sell_card(card_id)
-        var new_count := TarotManager.get_card_count(card_id)
+        TarotManager.sell_card(card_id, rarity)
+        var new_count := TarotManager.get_card_rarity_count(card_id, rarity)
         update_count(new_count)
         if mark_sold_on_sell:
                 sell_button.text = "SOLD"
                 sell_button.disabled = true
                 sell_button.visible = true
+
+func _ready() -> void:
+        texture_rect.mouse_filter = Control.MOUSE_FILTER_PASS
+        name_label.mouse_filter = Control.MOUSE_FILTER_PASS
+        count_label.mouse_filter = Control.MOUSE_FILTER_PASS
+
+func _gui_input(event: InputEvent) -> void:
+        if event is InputEventMouseButton and event.pressed and event.button_index == MOUSE_BUTTON_LEFT:
+                card_pressed.emit(card_id)

--- a/components/apps/tarot/tarot_deck.gd
+++ b/components/apps/tarot/tarot_deck.gd
@@ -31,8 +31,10 @@ func load_from_file(path: String) -> void:
 func get_card(id: String) -> Dictionary:
     return card_map.get(id, {})
 
-func instantiate_card_view(id: String, count: int = 0, mark_sold_on_sell: bool = false) -> TarotCardView:
-    var data = get_card(id)
+func instantiate_card_view(id: String, count: int = 0, mark_sold_on_sell: bool = false, rarity: int = -1) -> TarotCardView:
+    var data = get_card(id).duplicate()
+    if rarity > 0:
+        data["rarity"] = rarity
     var view: TarotCardView = CARD_VIEW_SCENE.instantiate()
     view.mark_sold_on_sell = mark_sold_on_sell
     view.setup(data, count)


### PR DESCRIPTION
## Summary
- Track tarot card collection by rarity and define sell values per rarity
- Add CardCollectionExaminer overlay that shows all five rarities of a selected card
- Enable TarotCardView clicks, per-rarity counts, and selling with updated prices

## Testing
- `godot3 --headless --script tests/test_runner.gd` *(fails: project uses Godot 4 config)*
- `apt-get install -y godot4` *(fails: Unable to locate package)*
- `wget https://downloads.tuxfamily.org/godotengine/4.2.2/Godot_v4.2.2-stable_linux.x86_64.tar.xz` *(fails: 503 Service Unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68b74b830828832594720a89c1500269