### PR TITLE
Add payday loan bill payable with credit

### DIFF
--- a/autoloads/bill_manager.gd
+++ b/autoloads/bill_manager.gd
@@ -357,26 +357,31 @@ func take_payday_loan(amount: float) -> void:
 	PortfolioManager.add_cash(amount)
 
 func apply_debt_interest() -> void:
-	var changed := false
-	for res in debt_resources:
-		var minutes := int(res.get("compounds_in", 0))
-		if minutes > 0:
-			continue
-		var rate: float = float(res.get("interest_rate", 0.0))
-		var bal: float = float(res.get("balance", 0.0))
-		if rate != 0.0 and bal > 0.0:
-				var new_balance := bal * (1.0 + rate)
-				if res.get("name", "") == "Credit Card":
-						PortfolioManager.set_credit_used(new_balance)
-				else:
-						res["balance"] = new_balance
-						changed = true
-		if res.get("name", "") == "Student Loan":
-			res["compound_interval"] = TimeManager.get_days_in_month(TimeManager.current_month, TimeManager.current_year) * 1440
-		var interval := int(res.get("compound_interval", 0))
-		if res.get("compounds_in", 0) != interval:
-			res["compounds_in"] = interval
-			changed = true
+        var changed := false
+        for res in debt_resources:
+                var minutes := int(res.get("compounds_in", 0))
+                if minutes > 0:
+                        continue
+                var rate: float = float(res.get("interest_rate", 0.0))
+                var bal: float = float(res.get("balance", 0.0))
+                var name := String(res.get("name", ""))
+                if rate != 0.0 and bal > 0.0:
+                                var new_balance := bal * (1.0 + rate)
+                                if name == "Credit Card":
+                                                PortfolioManager.set_credit_used(new_balance)
+                                else:
+                                                res["balance"] = new_balance
+                                                changed = true
+                                if name == "Payday Loan" and new_balance > 0.0:
+                                                _schedule_payday_loan_bill(new_balance)
+                elif name == "Payday Loan" and bal > 0.0:
+                                _schedule_payday_loan_bill(bal)
+                if name == "Student Loan":
+                        res["compound_interval"] = TimeManager.get_days_in_month(TimeManager.current_month, TimeManager.current_year) * 1440
+                var interval := int(res.get("compound_interval", 0))
+                if res.get("compounds_in", 0) != interval:
+                        res["compounds_in"] = interval
+                        changed = true
 	if changed:
 		debt_resources_changed.emit()
 
@@ -396,11 +401,34 @@ func _set_credit_card_balance(used: float, limit: float) -> void:
 			debt_resources_changed.emit()
 			return
 func _set_student_loan_balance(amount: float) -> void:
-	for res in debt_resources:
-		if res.get("name", "") == "Student Loan":
-			res["balance"] = amount
-			debt_resources_changed.emit()
-			return
+        for res in debt_resources:
+                if res.get("name", "") == "Student Loan":
+                        res["balance"] = amount
+                        debt_resources_changed.emit()
+                        return
+
+func reduce_debt_balance(name: String, amount: float) -> void:
+        var res: Dictionary = _get_debt_resource(name)
+        if res.is_empty():
+                return
+        res["balance"] = max(res.get("balance", 0.0) - amount, 0.0)
+        debt_resources_changed.emit()
+
+func _schedule_payday_loan_bill(amount: float) -> void:
+        var today = TimeManager.get_today()
+        var date_key = _format_date_key(today)
+        static_bill_amounts["Payday Loan"] = amount
+        if autopay_enabled and attempt_to_autopay("Payday Loan"):
+                reduce_debt_balance("Payday Loan", amount)
+                mark_bill_paid("Payday Loan", date_key)
+        else:
+                if not pending_bill_data.has(date_key):
+                        pending_bill_data[date_key] = []
+                pending_bill_data[date_key].append({
+                        "bill_name": "Payday Loan",
+                        "amount": amount
+                })
+                show_due_popups()
 
 
 

--- a/components/popups/bill_popup_ui.gd
+++ b/components/popups/bill_popup_ui.gd
@@ -48,27 +48,31 @@ func close() -> void:
 	WindowManager.close_window(get_parent().get_parent().get_parent())
 
 func _on_pay_now_button_pressed() -> void:
-		if PortfolioManager.pay_with_cash(amount):
-				BillManager.mark_bill_paid(bill_name, date_key)
-				close()
-		else:
-				print("❌ Not enough cash")
+                if PortfolioManager.pay_with_cash(amount):
+                                if bill_name == "Payday Loan":
+                                                BillManager.reduce_debt_balance("Payday Loan", amount)
+                                BillManager.mark_bill_paid(bill_name, date_key)
+                                close()
+                else:
+                                print("❌ Not enough cash")
 
 func _on_pay_by_credit_button_pressed() -> void:
 	var required_score = PortfolioManager.CREDIT_REQUIREMENTS.get("bills", 0)
-	if PortfolioManager.credit_score < required_score:
-		print("❌ Credit score too low")
-		WindowManager.focus_window(get_parent().get_parent().get_parent())
-		WindowManager.launch_app_by_name("OwerView")
-		return
+        if PortfolioManager.credit_score < required_score:
+                print("❌ Credit score too low")
+                WindowManager.focus_window(get_parent().get_parent().get_parent())
+                WindowManager.launch_app_by_name("OwerView")
+                return
 
-	if PortfolioManager.pay_with_credit(amount):
-		BillManager.mark_bill_paid(bill_name, date_key)
-		close()
-	else:
-		print("❌ Not enough credit")
-		WindowManager.focus_window(get_parent().get_parent().get_parent())
-		WindowManager.launch_app_by_name("OwerView")
+        if PortfolioManager.pay_with_credit(amount):
+                if bill_name == "Payday Loan":
+                        BillManager.reduce_debt_balance("Payday Loan", amount)
+                BillManager.mark_bill_paid(bill_name, date_key)
+                close()
+        else:
+                print("❌ Not enough credit")
+                WindowManager.focus_window(get_parent().get_parent().get_parent())
+                WindowManager.launch_app_by_name("OwerView")
 
 func _on_autopay_check_box_toggled(toggled_on: bool) -> void:
 		BillManager.autopay_enabled = toggled_on

--- a/tests/payday_loan_bill_credit_pay_test.gd
+++ b/tests/payday_loan_bill_credit_pay_test.gd
@@ -1,0 +1,35 @@
+extends SceneTree
+
+func _ready():
+    var pm = Engine.get_singleton("PortfolioManager")
+    var bm = Engine.get_singleton("BillManager")
+    var tm = Engine.get_singleton("TimeManager")
+    pm.reset()
+    bm.reset()
+    tm.reset()
+    pm.credit_limit = 1000.0
+    pm.credit_used = 0.0
+    pm.credit_interest_rate = 0.0
+    bm.add_debt_resource({
+        "name": "Payday Loan",
+        "balance": 0.0,
+        "interest_rate": 0.0,
+        "compound_interval": 1440,
+        "compounds_in": 1440,
+        "can_borrow": true,
+        "borrow_limit": 1000.0
+    })
+    bm.take_payday_loan(100.0)
+    tm._advance_time(1440)
+    assert(bm.static_bill_amounts.get("Payday Loan", 0.0) == 100.0)
+    var popup = preload("res://components/popups/bill_popup_ui.tscn").instantiate()
+    popup.bill_name = "Payday Loan"
+    popup.amount = bm.get_bill_amount("Payday Loan")
+    popup.date_key = "%d/%d/%d" % [tm.current_day, tm.current_month, tm.current_year]
+    add_child(popup)
+    popup._on_pay_by_credit_button_pressed()
+    var res = bm.get_debt_resources()[0]
+    assert(res.get("balance") == 0.0)
+    assert(pm.credit_used == 100.0)
+    print("payday_loan_bill_credit_pay_test passed")
+    quit()


### PR DESCRIPTION
## Summary
- schedule Payday Loan bill after 24 in-game hours
- allow Payday Loan bills to reduce debt balance when paid, including via credit
- add regression test for paying Payday Loan with credit

## Testing
- ⚠️ `godot3 --headless -s tests/test_runner.gd` (engine version mismatch: project requires Godot 4)


------
https://chatgpt.com/codex/tasks/task_e_68b74ee9ed948325af8339b8cd372f19