### PR TITLE
Replace stock quantity spinbox with option menu

### DIFF
--- a/components/apps/broke_rage/stock_row.tscn
+++ b/components/apps/broke_rage/stock_row.tscn
@@ -69,10 +69,11 @@ theme_override_styles/pressed = SubResource("StyleBoxTexture_8c4aw")
 theme_override_styles/normal = SubResource("StyleBoxTexture_lqo4w")
 text = " SELL "
 
-[node name="QuantitySpinBox" type="SpinBox" parent="."]
+[node name="QuantityOption" type="OptionButton" parent="."]
 layout_mode = 2
-min_value = 1.0
-value = 1.0
+size_flags_horizontal = 4
+focus_mode = 0
+theme_override_font_sizes/font_size = 10
 
 [node name="Control" type="Control" parent="."]
 layout_mode = 2


### PR DESCRIPTION
## Summary
- replace stock quantity SpinBox with OptionButton in Broke Rage stock row
- allow selecting 1, 10, 100, or MAX shares and compute MAX based on available cash

## Testing
- `godot3-server --path . -s tests/test_runner.gd` *(fails: Can't open project ... expected config version 4)*

------
https://chatgpt.com/codex/tasks/task_e_68b750565dcc8325abc19a5f9f89dc6d