### PR TITLE
Remove rarity labels from tarot collection previews

### DIFF
--- a/components/apps/tarot/tarot_app.gd
+++ b/components/apps/tarot/tarot_app.gd
@@ -30,12 +30,13 @@ func _build_collection_view() -> void:
 		child.queue_free()
 	card_views.clear()
 	for card in TarotManager.get_all_cards_ordered():
-		var id: String = card.get("id", "")
-		var count: int = TarotManager.get_card_count(id)
-		var view: TarotCardView = TarotManager.instantiate_card_view(id, count)
-		collection_grid.add_child(view)
-		view.texture_rect.custom_minimum_size = Vector2(32, 56)
-		view.card_pressed.connect(card_collection_examiner.show_card)
+                var id: String = card.get("id", "")
+                var count: int = TarotManager.get_card_count(id)
+                var view: TarotCardView = TarotManager.instantiate_card_view(id, count)
+                collection_grid.add_child(view)
+                view.set_rarity_label_visible(false)
+                view.texture_rect.custom_minimum_size = Vector2(32, 56)
+                view.card_pressed.connect(card_collection_examiner.show_card)
 
 		card_views[id] = view
 

--- a/components/apps/tarot/tarot_card_view.gd
+++ b/components/apps/tarot/tarot_card_view.gd
@@ -57,19 +57,24 @@ func setup(data: Dictionary, owned: int) -> void:
 		sell_button.pressed.connect(_on_sell_pressed)
 
 func update_count(new_count: int) -> void:
-		count = new_count
-		count_label.visible = count > 0 and (count > 1 or show_single_count)
-		count_label.text = "x%d" % count
-		sell_button.visible = count > 0
-		texture_rect.modulate = Color(1,1,1,1) if count > 0 else Color(0.5,0.5,0.5,1)
-		if count > 0:
-				sell_button.disabled = false
-				sell_button.text = "Sell for $%d" % int(sell_price)
+                count = new_count
+                count_label.visible = count > 0 and (count > 1 or show_single_count)
+                count_label.text = "x%d" % count
+                sell_button.visible = count > 0
+                texture_rect.modulate = Color(1,1,1,1) if count > 0 else Color(0.5,0.5,0.5,1)
+                if count > 0:
+                                sell_button.disabled = false
+                                sell_button.text = "Sell for $%d" % int(sell_price)
+
+func set_rarity_label_visible(is_visible: bool) -> void:
+                if not is_node_ready():
+                                await ready
+                rarity_label.visible = is_visible
 
 func _on_sell_pressed() -> void:
-		TarotManager.sell_card(card_id, rarity)
-		var new_count = TarotManager.get_card_rarity_count(card_id, rarity)
-		update_count(new_count)
+                TarotManager.sell_card(card_id, rarity)
+                var new_count = TarotManager.get_card_rarity_count(card_id, rarity)
+                update_count(new_count)
 		if mark_sold_on_sell:
 				sell_button.text = "SOLD"
 				sell_button.disabled = true


### PR DESCRIPTION
## Summary
- Add `set_rarity_label_visible` helper on `TarotCardView`
- Hide rarity labels on tarot collection tab while keeping them for draws and examiner

## Testing
- `godot3 --headless -s tests/test_runner.gd` *(fails: Can't open project at '/workspace/SigmaSim/project.godot', its `config_version` (5) is from a more recent and incompatible version of the engine)*

------
https://chatgpt.com/codex/tasks/task_e_68b7650c258c8325a91560629bf0c5ce