### PR TITLE
Add paid tarot readings and free daily draw

### DIFF
--- a/autoloads/tarot_manager.gd
+++ b/autoloads/tarot_manager.gd
@@ -15,7 +15,7 @@ var collection: Dictionary = {}
 var last_draw_minutes: int = -COOLDOWN_MINUTES
 var last_card_id: String = ""
 var last_card_rarity: int = 0
-var draw_cost: float = 1.0
+var reading_cost: float = 1.0
 
 func _ready() -> void:
 	deck.load_from_file(DATA_PATH)
@@ -86,25 +86,45 @@ func _roll_rarity(rng: RandomNumberGenerator) -> int:
 	return 1
 
 func draw_card() -> Dictionary:
-	if not can_draw():
-			return {}
-	if not PortfolioManager.try_spend_cash(draw_cost):
-			return {}
-	var rng := RNGManager.get_rng()
-	var rarity := _roll_rarity(rng)
-	var pool: Array = deck.cards_by_rarity.get(rarity, [])
-	if pool.is_empty():
-		return {}
-	var card: Dictionary = pool[rng.randi_range(0, pool.size() - 1)]
-	var id: String = card.get("id", "")
-	var rarities: Dictionary = collection.get(id, {})
-	rarities[rarity] = int(rarities.get(rarity, 0)) + 1
-	collection[id] = rarities
-	last_draw_minutes = TimeManager.get_now_minutes()
-	last_card_id = id
-	last_card_rarity = rarity
-	collection_changed.emit(id, get_card_count(id))
-	return card
+       if not can_draw():
+                       return {}
+       var rng := RNGManager.get_rng()
+       var rarity := _roll_rarity(rng)
+       var pool: Array = deck.cards_by_rarity.get(rarity, [])
+       if pool.is_empty():
+               return {}
+       var card: Dictionary = pool[rng.randi_range(0, pool.size() - 1)]
+       var id: String = card.get("id", "")
+       var rarities: Dictionary = collection.get(id, {})
+       rarities[rarity] = int(rarities.get(rarity, 0)) + 1
+       collection[id] = rarities
+       last_draw_minutes = TimeManager.get_now_minutes()
+       last_card_id = id
+       last_card_rarity = rarity
+       collection_changed.emit(id, get_card_count(id))
+       return card
+
+func draw_reading(count: int) -> Array:
+       var total_cost := reading_cost * count
+       if total_cost > 0.0 and not PortfolioManager.try_spend_cash(total_cost):
+               return []
+       var rng := RNGManager.get_rng()
+       var results: Array = []
+       for i in range(count):
+               var rarity := _roll_rarity(rng)
+               var pool: Array = deck.cards_by_rarity.get(rarity, [])
+               if pool.is_empty():
+                       continue
+               var card: Dictionary = pool[rng.randi_range(0, pool.size() - 1)]
+               var id: String = card.get("id", "")
+               var rarities: Dictionary = collection.get(id, {})
+               rarities[rarity] = int(rarities.get(rarity, 0)) + 1
+               collection[id] = rarities
+               last_card_id = id
+               last_card_rarity = rarity
+               collection_changed.emit(id, get_card_count(id))
+               results.append({"id": id, "rarity": rarity})
+       return results
 
 func sell_card(card_id: String, rarity: int) -> void:
 		var rarities: Dictionary = collection.get(card_id, {})

--- a/components/apps/app_scenes/tarot_app.tscn
+++ b/components/apps/app_scenes/tarot_app.tscn
@@ -5,6 +5,7 @@
 [ext_resource type="Texture2D" uid="uid://b8cd5rom7n7tl" path="res://assets/sigma.png" id="3"]
 [ext_resource type="PackedScene" uid="uid://b07dutwaw54gq" path="res://components/apps/tarot/card_collection_examiner.tscn" id="4"]
 [ext_resource type="Shader" uid="uid://dp2anhkkaegyq" path="res://assets/shaders/constellation_shader.gdshader" id="4_8tbyh"]
+[ext_resource type="PackedScene" uid="uid://cbg1lx9h31ou3" path="res://components/apps/tarot/tarot_upgrades.tscn" id="5"]
 
 [sub_resource type="ShaderMaterial" id="ShaderMaterial_6i816"]
 shader = ExtResource("4_8tbyh")
@@ -26,6 +27,7 @@ script = ExtResource("2")
 window_title = "Tarot"
 window_icon = ExtResource("3")
 default_window_size = Vector2(600, 600)
+upgrade_pane = ExtResource("5")
 
 [node name="PanelContainer" type="PanelContainer" parent="."]
 material = SubResource("ShaderMaterial_6i816")
@@ -44,6 +46,11 @@ theme_override_constants/separation = 4
 unique_name_in_owner = true
 layout_mode = 2
 text = "Draw"
+
+[node name="ReadingsTabButton" type="Button" parent="VBox/TabButtons"]
+unique_name_in_owner = true
+layout_mode = 2
+text = "Readings"
 
 [node name="CollectionTabButton" type="Button" parent="VBox/TabButtons"]
 unique_name_in_owner = true
@@ -68,6 +75,29 @@ size_flags_horizontal = 4
 text = "  Daily Draw  "
 
 [node name="CooldownLabel" type="Label" parent="VBox/DrawView"]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 4
+
+[node name="ReadingsView" type="VBoxContainer" parent="VBox"]
+unique_name_in_owner = true
+visible = false
+layout_mode = 2
+theme_override_constants/separation = 8
+
+[node name="ReadingResult" type="HBoxContainer" parent="VBox/ReadingsView"]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_vertical = 3
+alignment = 1
+
+[node name="ReadingButton" type="Button" parent="VBox/ReadingsView"]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 4
+text = "  Paid Reading  "
+
+[node name="ReadingCostLabel" type="Label" parent="VBox/ReadingsView"]
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 4

--- a/components/apps/tarot/tarot_app.gd
+++ b/components/apps/tarot/tarot_app.gd
@@ -5,8 +5,13 @@ class_name TarotApp
 @onready var cooldown_label: Label = %CooldownLabel
 @onready var draw_result: Control = %DrawResult
 @onready var draw_tab_button: Button = %DrawTabButton
+@onready var reading_tab_button: Button = %ReadingsTabButton
 @onready var collection_tab_button: Button = %CollectionTabButton
 @onready var draw_view: VBoxContainer = %DrawView
+@onready var readings_view: VBoxContainer = %ReadingsView
+@onready var reading_result: Control = %ReadingResult
+@onready var reading_button: Button = %ReadingButton
+@onready var reading_cost_label: Label = %ReadingCostLabel
 @onready var collection_view: ScrollContainer = %CollectionView
 @onready var collection_grid: GridContainer = %CollectionGrid
 @onready var card_collection_examiner: CardCollectionExaminer = %CardCollectionExaminer
@@ -15,13 +20,17 @@ var card_views: Dictionary = {}
 var _active_tab: StringName = &"Draw"
 
 func _ready() -> void:
-        draw_button.pressed.connect(_on_draw_button_pressed)
-        draw_tab_button.pressed.connect(_on_draw_tab_pressed)
-        collection_tab_button.pressed.connect(_on_collection_tab_pressed)
-        TarotManager.collection_changed.connect(_on_collection_changed)
-        TimeManager.minute_passed.connect(_on_minute_passed)
-        _build_collection_view()
-        _update_cooldown_label()
+       draw_button.pressed.connect(_on_draw_button_pressed)
+       reading_button.pressed.connect(_on_reading_button_pressed)
+       draw_tab_button.pressed.connect(_on_draw_tab_pressed)
+       reading_tab_button.pressed.connect(_on_readings_tab_pressed)
+       collection_tab_button.pressed.connect(_on_collection_tab_pressed)
+       TarotManager.collection_changed.connect(_on_collection_changed)
+       TimeManager.minute_passed.connect(_on_minute_passed)
+       UpgradeManager.upgrade_purchased.connect(_on_upgrade_purchased)
+       _build_collection_view()
+       _update_cooldown_label()
+       _update_reading_cost_label()
        _show_last_drawn_card()
        _activate_tab(&"Draw")
 
@@ -53,6 +62,13 @@ func _on_draw_button_pressed() -> void:
        _show_last_drawn_card()
        _update_cooldown_label()
 
+func _on_reading_button_pressed() -> void:
+       var count := 1 + UpgradeManager.get_level("tarot_extra_card")
+       var cards := TarotManager.draw_reading(count)
+       if cards.is_empty():
+               return
+       _show_reading_cards(cards)
+
 func _show_last_drawn_card() -> void:
        for child in draw_result.get_children():
                child.queue_free()
@@ -65,6 +81,17 @@ func _show_last_drawn_card() -> void:
        view.show_single_count = true
        draw_result.add_child(view)
 
+func _show_reading_cards(cards: Array) -> void:
+       for child in reading_result.get_children():
+               child.queue_free()
+       for c in cards:
+               var id: String = c.get("id", "")
+               var rarity: int = int(c.get("rarity", 1))
+               var count_for_rarity = TarotManager.get_card_rarity_count(id, rarity)
+               var view = TarotManager.instantiate_card_view(id, count_for_rarity, true, rarity)
+               view.show_single_count = true
+               reading_result.add_child(view)
+
 func _update_cooldown_label() -> void:
 	var remaining = TarotManager.time_until_next_draw()
 	if remaining <= 0:
@@ -74,26 +101,50 @@ func _update_cooldown_label() -> void:
 		var hours = remaining / 60
 		var minutes = remaining % 60
 		cooldown_label.text = "%02dh %02dm" % [hours, minutes]
-		draw_button.disabled = true
+               draw_button.disabled = true
+
+func _update_reading_cost_label() -> void:
+       var extra := UpgradeManager.get_level("tarot_extra_card")
+       var count := 1 + extra
+       var cost := TarotManager.reading_cost * count
+       reading_cost_label.text = "$" + str(cost) + " for %d card(s)" % count
 
 func _on_minute_passed(_total_minutes: int) -> void:
-	_update_cooldown_label()
+       _update_cooldown_label()
 
 func _activate_tab(tab_name: StringName) -> void:
-	if tab_name == &"Draw":
-		draw_tab_button.set_pressed(true)
-		collection_tab_button.set_pressed(false)
-		draw_view.visible = true
-		collection_view.visible = false
-	else:
-		draw_tab_button.set_pressed(false)
-		collection_tab_button.set_pressed(true)
-		draw_view.visible = false
-		collection_view.visible = true
-	_active_tab = tab_name
+       if tab_name == &"Draw":
+               draw_tab_button.set_pressed(true)
+               reading_tab_button.set_pressed(false)
+               collection_tab_button.set_pressed(false)
+               draw_view.visible = true
+               readings_view.visible = false
+               collection_view.visible = false
+       elif tab_name == &"Readings":
+               draw_tab_button.set_pressed(false)
+               reading_tab_button.set_pressed(true)
+               collection_tab_button.set_pressed(false)
+               draw_view.visible = false
+               readings_view.visible = true
+               collection_view.visible = false
+       else:
+               draw_tab_button.set_pressed(false)
+               reading_tab_button.set_pressed(false)
+               collection_tab_button.set_pressed(true)
+               draw_view.visible = false
+               readings_view.visible = false
+               collection_view.visible = true
+       _active_tab = tab_name
 
 func _on_draw_tab_pressed() -> void:
-	_activate_tab(&"Draw")
+       _activate_tab(&"Draw")
+
+func _on_readings_tab_pressed() -> void:
+       _activate_tab(&"Readings")
 
 func _on_collection_tab_pressed() -> void:
-	_activate_tab(&"Collection")
+       _activate_tab(&"Collection")
+
+func _on_upgrade_purchased(id: String, _new_level: int) -> void:
+       if id == "tarot_extra_card":
+               _update_reading_cost_label()

--- a/components/apps/tarot/tarot_upgrades.gd
+++ b/components/apps/tarot/tarot_upgrades.gd
@@ -1,0 +1,1 @@
+extends Pane

--- a/components/apps/tarot/tarot_upgrades.gd.uid
+++ b/components/apps/tarot/tarot_upgrades.gd.uid
@@ -1,0 +1,1 @@
+uid://e7y2k1vhw03d

--- a/components/apps/tarot/tarot_upgrades.tscn
+++ b/components/apps/tarot/tarot_upgrades.tscn
@@ -1,0 +1,21 @@
+[gd_scene load_steps=2 format=3 uid="uid://cbg1lx9h31ou3"]
+
+[ext_resource type="Script" uid="uid://e7y2k1vhw03d" path="res://components/apps/tarot/tarot_upgrades.gd" id="1"]
+[ext_resource type="PackedScene" uid="uid://c12jraubuv28g" path="res://data/upgrades/system_upgrade_ui.tscn" id="2"]
+
+[node name="TarotUpgrades" type="PanelContainer"]
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+script = ExtResource("1")
+window_title = "Tarot Upgrades"
+default_window_size = Vector2(480, 480)
+
+[node name="SystemUpgradeUI" parent="." instance=ExtResource("2")]
+system_name = "tarot"
+layout_mode = 2
+size_flags_vertical = 3

--- a/data/upgrades/tarot_extra_card.json
+++ b/data/upgrades/tarot_extra_card.json
@@ -1,0 +1,18 @@
+{
+  "id": "tarot_extra_card",
+  "name": "Deeper Reading",
+  "description": "Adds one additional card to each Tarot Reading.",
+  "effects": [],
+  "systems": [
+    "tarot"
+  ],
+  "dependencies": [],
+  "cost_per_level": {
+    "cash": 5
+  },
+  "scale_by_formula": true,
+  "cost_formula": {
+    "cash": "base_cost[\"cash\"] * pow(1.5, level-1)"
+  },
+  "repeatable": true
+}


### PR DESCRIPTION
## Summary
- Make the tarot app's daily draw free
- Add a paid Readings tab where players spend cash for multi-card draws
- Introduce tarot upgrades to increase cards per reading

## Testing
- `godot --headless -s tests/test_runner.gd` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b76dc29718832588d0f61493e3c334