### PR TITLE
feat: add tooltip popup to education selection

### DIFF
--- a/components/ui/profile_creation/education_selection_screen.gd
+++ b/components/ui/profile_creation/education_selection_screen.gd
@@ -9,6 +9,11 @@ signal step_valid(valid: bool)
 @onready var masters_button: Button = %MastersButton
 @onready var doctorate_button: Button = %DoctorateButton
 
+@onready var tooltip_popup: PanelContainer = %TooltipPopup
+@onready var tooltip_label: Label = %TooltipLabel
+
+var tooltip_tween: Tween = null
+
 var selected_level: String = ""
 var selected_student_debt: float = 0.0
 var selected_credit_limit: float = 0.0
@@ -45,11 +50,11 @@ func _on_option_pressed(button: Button) -> void:
 			btn.set_pressed_no_signal(false)
 
 	# Update selection state
-	match button:
-		none_button:
-			selected_level = "None"
-			selected_student_debt = 0.0
-			selected_credit_limit = 0.0
+        match button:
+                none_button:
+                        selected_level = "None"
+                        selected_student_debt = 0.0
+                        selected_credit_limit = 0.0
 		high_school_button:
 			selected_level = "High School / GED"
 			selected_student_debt = 0.0
@@ -66,13 +71,39 @@ func _on_option_pressed(button: Button) -> void:
 			selected_level = "Master's Degree"
 			selected_student_debt = 250000.0
 			selected_credit_limit = 25000.0
-		doctorate_button:
-			selected_level = "Doctorate"
-			selected_student_debt = 1200000.0
-			selected_credit_limit = 100000.0
+                doctorate_button:
+                        selected_level = "Doctorate"
+                        selected_student_debt = 1200000.0
+                        selected_credit_limit = 100000.0
 
-	emit_signal("step_valid", true)
+        show_tooltip_from_button(button)
 
+        emit_signal("step_valid", true)
+
+
+
+func show_tooltip_from_button(button: Button) -> void:
+        var tooltip_text = button.tooltip_text
+        if tooltip_text == "":
+                return
+
+        tooltip_label.text = tooltip_text
+        tooltip_popup.visible = true
+        tooltip_popup.modulate.a = 1.0
+
+        await get_tree().process_frame
+
+        var button_global_rect = button.get_global_rect()
+        var button_right_center = button_global_rect.position + Vector2(button_global_rect.size.x, button_global_rect.size.y / 2)
+        var local_pos = tooltip_popup.get_parent().get_global_transform_with_canvas().affine_inverse() * button_right_center
+        var tooltip_size = tooltip_popup.size
+        tooltip_popup.position = local_pos + Vector2(10, -tooltip_size.y / 2)
+
+        if tooltip_tween and tooltip_tween.is_valid():
+                tooltip_tween.kill()
+
+        tooltip_tween = get_tree().create_tween()
+        tooltip_tween.tween_property(tooltip_popup, "position:y", tooltip_popup.position.y - 30, 0.4)
 
 
 func save_data() -> void:

--- a/components/ui/profile_creation/education_selection_screen.tscn
+++ b/components/ui/profile_creation/education_selection_screen.tscn
@@ -101,3 +101,29 @@ tooltip_text = "$1,200,000 student debt
 $100,000 credit limit"
 focus_mode = 0
 text = "Doctorate"
+
+[node name="TooltipPopup" type="PanelContainer" parent="."]
+unique_name_in_owner = true
+visible = false
+custom_minimum_size = Vector2(220, 40)
+layout_mode = 1
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="MarginContainer" type="MarginContainer" parent="TooltipPopup"]
+layout_mode = 2
+theme_override_constants/margin_left = 10
+theme_override_constants/margin_top = 10
+theme_override_constants/margin_right = 10
+theme_override_constants/margin_bottom = 10
+
+[node name="TooltipLabel" type="Label" parent="TooltipPopup/MarginContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+autowrap_mode = 3
+


### PR DESCRIPTION
## Summary
- display tooltip popup when choosing education level
- position tooltip to the right of the selected option

## Testing
- `godot3-server -s tests/test_runner.gd` *(fails: project requires Godot 4)*
- `wget https://downloads.tuxfamily.org/godotengine/4.2.1/Godot_v4.2.1-stable_linux_headless.64.zip -O /tmp/godot_headless.zip` *(fails: 503 Service Unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68b76e53f3848325afaf74c2e527d644