### PR TITLE
style: add panelized tab bars

### DIFF
--- a/components/apps/app_scenes/broke_rage.tscn
+++ b/components/apps/app_scenes/broke_rage.tscn
@@ -262,30 +262,42 @@ size_flags_horizontal = 3
 size_flags_vertical = 3
 theme_override_constants/separation = 8
 
-[node name="ChartsTopBar" type="HBoxContainer" parent="VBoxContainer/MarginContainer/Panel/MarginContainer/MainHBox/ContentArea/ChartsView"]
+[node name="PanelContainer" type="PanelContainer" parent="VBoxContainer/MarginContainer/Panel/MarginContainer/MainHBox/ContentArea/ChartsView"]
+layout_mode = 2
+mouse_filter = 1
+theme_override_styles/panel = SubResource("StyleBoxTexture_gnfo0")
+
+[node name="MarginContainer" type="MarginContainer" parent="VBoxContainer/MarginContainer/Panel/MarginContainer/MainHBox/ContentArea/ChartsView/PanelContainer"]
+layout_mode = 2
+theme_override_constants/margin_left = 10
+theme_override_constants/margin_top = 10
+theme_override_constants/margin_right = 10
+theme_override_constants/margin_bottom = 10
+
+[node name="ChartsTopBar" type="HBoxContainer" parent="VBoxContainer/MarginContainer/Panel/MarginContainer/MainHBox/ContentArea/ChartsView/PanelContainer/MarginContainer"]
 layout_mode = 2
 size_flags_horizontal = 3
 
-[node name="SummaryTabButtonCharts" type="Button" parent="VBoxContainer/MarginContainer/Panel/MarginContainer/MainHBox/ContentArea/ChartsView/ChartsTopBar"]
+[node name="SummaryTabButtonCharts" type="Button" parent="VBoxContainer/MarginContainer/Panel/MarginContainer/MainHBox/ContentArea/ChartsView/PanelContainer/MarginContainer/ChartsTopBar"]
 unique_name_in_owner = true
 layout_mode = 2
 focus_mode = 0
 toggle_mode = true
 text = "Summary"
 
-[node name="ChartsTabButtonCharts" type="Button" parent="VBoxContainer/MarginContainer/Panel/MarginContainer/MainHBox/ContentArea/ChartsView/ChartsTopBar"]
+[node name="ChartsTabButtonCharts" type="Button" parent="VBoxContainer/MarginContainer/Panel/MarginContainer/MainHBox/ContentArea/ChartsView/PanelContainer/MarginContainer/ChartsTopBar"]
 unique_name_in_owner = true
 layout_mode = 2
 focus_mode = 0
 toggle_mode = true
 text = "Charts"
 
-[node name="ChartsCashLabel" type="Label" parent="VBoxContainer/MarginContainer/Panel/MarginContainer/MainHBox/ContentArea/ChartsView/ChartsTopBar"]
+[node name="ChartsCashLabel" type="Label" parent="VBoxContainer/MarginContainer/Panel/MarginContainer/MainHBox/ContentArea/ChartsView/PanelContainer/MarginContainer/ChartsTopBar"]
 unique_name_in_owner = true
 layout_mode = 2
 text = "Cash: $"
 
-[node name="ChartsPortfolioLabel" type="Label" parent="VBoxContainer/MarginContainer/Panel/MarginContainer/MainHBox/ContentArea/ChartsView/ChartsTopBar"]
+[node name="ChartsPortfolioLabel" type="Label" parent="VBoxContainer/MarginContainer/Panel/MarginContainer/MainHBox/ContentArea/ChartsView/PanelContainer/MarginContainer/ChartsTopBar"]
 unique_name_in_owner = true
 layout_mode = 2
 text = "Stocks: $"
@@ -295,5 +307,5 @@ custom_minimum_size = Vector2(0, 18)
 layout_mode = 2
 
 [connection signal="pressed" from="VBoxContainer/MarginContainer/Panel/MarginContainer/MainHBox/ContentArea/SummaryView/MarginContainer/Summary/OwerViewButton" to="." method="_on_ower_view_button_pressed"]
-[connection signal="pressed" from="VBoxContainer/MarginContainer/Panel/MarginContainer/MainHBox/ContentArea/ChartsView/ChartsTopBar/SummaryTabButtonCharts" to="." method="_on_summary_tab_pressed"]
-[connection signal="pressed" from="VBoxContainer/MarginContainer/Panel/MarginContainer/MainHBox/ContentArea/ChartsView/ChartsTopBar/ChartsTabButtonCharts" to="." method="_on_charts_tab_pressed"]
+[connection signal="pressed" from="VBoxContainer/MarginContainer/Panel/MarginContainer/MainHBox/ContentArea/ChartsView/PanelContainer/MarginContainer/ChartsTopBar/SummaryTabButtonCharts" to="." method="_on_summary_tab_pressed"]
+[connection signal="pressed" from="VBoxContainer/MarginContainer/Panel/MarginContainer/MainHBox/ContentArea/ChartsView/PanelContainer/MarginContainer/ChartsTopBar/ChartsTabButtonCharts" to="." method="_on_charts_tab_pressed"]

--- a/components/apps/app_scenes/tarot_app.tscn
+++ b/components/apps/app_scenes/tarot_app.tscn
@@ -22,6 +22,18 @@ corner_radius_top_right = 8
 corner_radius_bottom_right = 8
 corner_radius_bottom_left = 8
 
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_tabbar"]
+bg_color = Color(0.385493, 0.385493, 0.385492, 0.109804)
+border_width_left = 2
+border_width_top = 2
+border_width_right = 2
+border_width_bottom = 2
+border_color = Color(0.8, 0.8, 0.8, 0.435294)
+corner_radius_top_left = 4
+corner_radius_top_right = 4
+corner_radius_bottom_right = 4
+corner_radius_bottom_left = 4
+
 [node name="TarotApp" type="MarginContainer"]
 anchors_preset = 15
 anchor_right = 1.0
@@ -59,28 +71,46 @@ theme_override_font_sizes/font_size = 36
 text = "Tarot"
 horizontal_alignment = 1
 
-[node name="TabButtons" type="VBoxContainer" parent="MarginContainer/VBox"]
+[node name="PanelContainer" type="PanelContainer" parent="MarginContainer/VBox"]
 layout_mode = 2
-size_flags_horizontal = 0
-theme_override_constants/separation = 4
+size_flags_vertical = 0
+mouse_filter = 1
+theme_override_styles/panel = SubResource("StyleBoxFlat_tabbar")
 
-[node name="DrawTabButton" type="Button" parent="MarginContainer/VBox/TabButtons"]
+[node name="MarginContainer" type="MarginContainer" parent="MarginContainer/VBox/PanelContainer"]
+layout_mode = 2
+theme_override_constants/margin_left = 10
+theme_override_constants/margin_top = 10
+theme_override_constants/margin_right = 10
+theme_override_constants/margin_bottom = 10
+
+[node name="TabBar" type="VBoxContainer" parent="MarginContainer/VBox/PanelContainer/MarginContainer"]
+layout_mode = 2
+
+[node name="DrawTabButton" type="Button" parent="MarginContainer/VBox/PanelContainer/MarginContainer/TabBar"]
 unique_name_in_owner = true
 layout_mode = 2
 focus_mode = 0
+toggle_mode = true
 text = "Daily Draw"
 
-[node name="ReadingsTabButton" type="Button" parent="MarginContainer/VBox/TabButtons"]
+[node name="ReadingsTabButton" type="Button" parent="MarginContainer/VBox/PanelContainer/MarginContainer/TabBar"]
 unique_name_in_owner = true
 layout_mode = 2
 focus_mode = 0
+toggle_mode = true
 text = "Readings"
 
-[node name="CollectionTabButton" type="Button" parent="MarginContainer/VBox/TabButtons"]
+[node name="CollectionTabButton" type="Button" parent="MarginContainer/VBox/PanelContainer/MarginContainer/TabBar"]
 unique_name_in_owner = true
 layout_mode = 2
 focus_mode = 0
+toggle_mode = true
 text = " Collection "
+
+[node name="Control" type="Control" parent="MarginContainer/VBox/PanelContainer/MarginContainer/TabBar"]
+custom_minimum_size = Vector2(0, 6)
+layout_mode = 2
 
 [node name="DrawView" type="VBoxContainer" parent="MarginContainer/VBox"]
 unique_name_in_owner = true


### PR DESCRIPTION
## Summary
- style TarotApp tabs with bordered panel and toggle buttons
- wrap BrokeRage charts tab bar in a panel for consistency

## Testing
- `godot -q --headless tests/test_runner.tscn` *(fails: command not found)*
- `apt-get install -y godot` *(fails: Unable to locate package godot)*
- `apt-get install -y godot4` *(fails: Unable to locate package godot4)*

------
https://chatgpt.com/codex/tasks/task_e_68b77731b33c83259fab4f87f10de36d