### PR TITLE
fix: restore tarot tab button input

### DIFF
--- a/components/apps/app_scenes/tarot_app.tscn
+++ b/components/apps/app_scenes/tarot_app.tscn
@@ -74,7 +74,7 @@ horizontal_alignment = 1
 [node name="PanelContainer" type="PanelContainer" parent="MarginContainer/VBox"]
 layout_mode = 2
 size_flags_vertical = 0
-mouse_filter = 1
+mouse_filter = 0
 theme_override_styles/panel = SubResource("StyleBoxFlat_tabbar")
 
 [node name="MarginContainer" type="MarginContainer" parent="MarginContainer/VBox/PanelContainer"]


### PR DESCRIPTION
## Summary
- ensure Tarot app tab buttons receive mouse input by stopping parent panel from passing events

## Testing
- `godot --headless --script tests/test_runner.gd` *(fails: command not found)*
- `apt-get install -y godot` *(fails: unable to locate package godot)*

------
https://chatgpt.com/codex/tasks/task_e_68b77a2e6eb483259bbd946b4f10519c