### PR TITLE
Introduce earlybird email and generate starter friend NPC

### DIFF
--- a/autoloads/player_manager.gd
+++ b/autoloads/player_manager.gd
@@ -56,14 +56,15 @@ var default_user_data: Dictionary = {
 	"portrait_config": {},
 	"background_path": "",
 	"education_level": "",
-	"starting_student_debt": 0.0,
-	"starting_credit_limit": 0.0,
-	"bio": "",
+        "starting_student_debt": 0.0,
+        "starting_credit_limit": 0.0,
+        "bio": "",
+        "friend1_npc_index": -1,
 
-	# Core Stats
-	"alpha": 0.0,
-	"beta": 0.0,
-	"delta": 0.0,
+        # Core Stats
+        "alpha": 0.0,
+        "beta": 0.0,
+        "delta": 0.0,
 	"gamma": 0.0,
 	"omega": 0.0,
 	"sigma": 0.0,
@@ -182,23 +183,32 @@ func reset():
 
 
 func ensure_default_stats() -> void:
-	for key in default_user_data.keys():
-		if not user_data.has(key):
-			user_data[key] = default_user_data[key]
-		elif key == "background_shaders":
+        for key in default_user_data.keys():
+                if not user_data.has(key):
+                        user_data[key] = default_user_data[key]
+                elif key == "background_shaders":
 			for shader in default_user_data["background_shaders"].keys():
 				if not user_data[key].has(shader):
 					user_data[key][shader] = default_user_data["background_shaders"][shader].duplicate(true)
 				else:
 					for param in default_user_data["background_shaders"][shader].keys():
-						if not user_data[key][shader].has(param):
-							user_data[key][shader][param] = default_user_data["background_shaders"][shader][param]
+                                                if not user_data[key][shader].has(param):
+                                                        user_data[key][shader][param] = default_user_data["background_shaders"][shader][param]
+        ensure_friend1()
 
+func generate_friend1() -> void:
+        var idx = RNGManager.npc_manager.get_rng().randi()
+        user_data["friend1_npc_index"] = idx
+        NPCManager.get_npc_by_index(idx)
+
+func ensure_friend1() -> void:
+        if int(user_data.get("friend1_npc_index", -1)) == -1:
+                generate_friend1()
 
 func djb2(s: String) -> int:
-		var hash := 5381
-		for i in s.length():
-				hash = ((hash << 5) + hash) + s.unicode_at(i)
+                var hash := 5381
+                for i in s.length():
+                                hash = ((hash << 5) + hash) + s.unicode_at(i)
 		return hash & 0xFFFFFFFF
 
 

--- a/components/apps/sigma_mail/sigma_mail.gd
+++ b/components/apps/sigma_mail/sigma_mail.gd
@@ -14,28 +14,31 @@ var current_page: int = 0
 var emails_per_page: int = 12
 
 func _ready() -> void:
-		_generate_dummy_emails()
-		limit_option.add_item("12", 12)
-		limit_option.add_item("24", 24)
-		limit_option.add_item("48", 48)
-		limit_option.select(0)
-		search_bar.text_changed.connect(_on_search_changed)
-		limit_option.item_selected.connect(_on_limit_selected)
-		prev_button.pressed.connect(_on_prev_page)
-		next_button.pressed.connect(_on_next_page)
-		_apply_filter()
+        _generate_initial_email()
+        limit_option.add_item("12", 12)
+        limit_option.add_item("24", 24)
+        limit_option.add_item("48", 48)
+        limit_option.select(0)
+        search_bar.text_changed.connect(_on_search_changed)
+        limit_option.item_selected.connect(_on_limit_selected)
+        prev_button.pressed.connect(_on_prev_page)
+        next_button.pressed.connect(_on_next_page)
+        _apply_filter()
 
-func _generate_dummy_emails() -> void:
-	emails.clear()
-	var dummy: EmailResource = ResourceLoader.load("res://resources/emails/dummy_email.tres") as EmailResource
-	if dummy != null:
-		emails.append(dummy)
-	for i in range(1, 50):
-		var e := EmailResource.new()
-		e.from = "user%d@example.com" % i
-		e.subject = "Subject %d" % i
-		e.body = "Body %d" % i
-		emails.append(e)
+func _generate_initial_email() -> void:
+        emails.clear()
+        var template: EmailResource = ResourceLoader.load("res://resources/emails/earlybird_email.tres") as EmailResource
+        if template != null:
+                var email: EmailResource = template.duplicate()
+                var idx := int(PlayerManager.get_var("friend1_npc_index", -1))
+                var first := "Friend"
+                if idx != -1:
+                        var npc = NPCManager.get_npc_by_index(idx)
+                        if npc != null:
+                                first = npc.first_name
+                email.from = first
+                email.body = email.body.format({"friend1_first_name": first})
+                emails.append(email)
 
 func _on_search_changed(_new_text: String) -> void:
 		_apply_filter()

--- a/resources/emails/dummy_email.tres
+++ b/resources/emails/dummy_email.tres
@@ -1,3 +1,0 @@
-[gd_resource type="Resource" format=3 uid="uid://c34ro8lj36jup"]
-
-[resource]

--- a/resources/emails/earlybird_email.tres
+++ b/resources/emails/earlybird_email.tres
@@ -1,0 +1,6 @@
+[gd_resource type="EmailResource" format=3]
+
+[resource]
+from = ""
+subject = "earlybird is literally cracked 🐦💸"
+body = "dude. i cannot stop playing earlybird. it’s like the most addicting thing ever… one run turns into ten, ten turns into a hundred, and suddenly i’m sweating like i’m the worm hahahaha\nand here’s the kicker: i legit made almost $3 just from playing. three bucks from gaming! yeah, it costs $5, but you can just put that on your credit card. pretty soon it’ll be puuuure profit baby!!\nanyways, use my referral code to get $1 back after you buy it. i bet you can’t beat my high score—188!\nyour boy,\n{friend1_first_name}"


### PR DESCRIPTION
## Summary
- Generate a random `friend1` NPC when a new profile is created
- Deliver a single introductory "earlybird" email from that NPC instead of test emails
- Look up the friend's name from the NPC data rather than storing a separate field

## Testing
- `godot3 --headless --run tests/test_runner.gd` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b78212d1288325b5b553917b6596be