### PR TITLE
Add installer pane for app installations

### DIFF
--- a/autoloads/window_manager.gd
+++ b/autoloads/window_manager.gd
@@ -39,8 +39,9 @@ var app_registry := {
 		"Wallet": preload("res://components/apps/wallet/wallet_ui.tscn"),
 		"Notepad": preload("res://components/apps/app_scenes/notepad.tscn"),
 		"Terminal": preload("res://components/apps/terminal/terminal.tscn"),
-		"SoftWares": preload("res://components/apps/app_scenes/soft_wares_app.tscn"),
-	"TarotApp": preload("res://components/apps/app_scenes/tarot_app.tscn"),
+                "SoftWares": preload("res://components/apps/app_scenes/soft_wares_app.tscn"),
+        "TarotApp": preload("res://components/apps/app_scenes/tarot_app.tscn"),
+        "Installer": preload("res://components/apps/app_scenes/installer.tscn"),
 
 }
 

--- a/components/apps/app_scenes/installer.tscn
+++ b/components/apps/app_scenes/installer.tscn
@@ -1,0 +1,42 @@
+[gd_scene load_steps=2 format=3 uid="uid://57160437ef3d"]
+
+[ext_resource type="Script" path="res://components/apps/installer/installer.gd" id="1"]
+
+[node name="Installer" type="PanelContainer"]
+script = ExtResource("1")
+window_title = "Installer"
+default_window_size = Vector2(300, 150)
+
+[node name="MarginContainer" type="MarginContainer" parent="."]
+layout_mode = 2
+theme_override_constants/margin_left = 10
+theme_override_constants/margin_top = 10
+theme_override_constants/margin_right = 10
+theme_override_constants/margin_bottom = 10
+
+[node name="VBox" type="VBoxContainer" parent="MarginContainer"]
+layout_mode = 2
+theme_override_constants/separation = 10
+
+[node name="HBox" type="HBoxContainer" parent="MarginContainer/VBox"]
+layout_mode = 2
+
+[node name="Label" type="Label" parent="MarginContainer/VBox/HBox"]
+layout_mode = 2
+text = "create desktop shortcut"
+
+[node name="ShortcutCheckBox" type="CheckBox" parent="MarginContainer/VBox/HBox"]
+unique_name_in_owner = true
+layout_mode = 2
+
+[node name="InstallButton" type="Button" parent="MarginContainer/VBox"]
+unique_name_in_owner = true
+layout_mode = 2
+text = "Install"
+
+[node name="ProgressBar" type="ProgressBar" parent="MarginContainer/VBox"]
+unique_name_in_owner = true
+layout_mode = 2
+max_value = 100.0
+value = 0.0
+show_percentage = true

--- a/components/apps/installer/installer.gd
+++ b/components/apps/installer/installer.gd
@@ -1,0 +1,51 @@
+extends Pane
+class_name Installer
+
+@onready var shortcut_checkbox: CheckBox = %ShortcutCheckBox
+@onready var progress_bar: ProgressBar = %ProgressBar
+@onready var install_button: Button = %InstallButton
+
+var app_id: String = ""
+var app_title: String = ""
+var app_icon: Texture2D = null
+var icon_path: String = ""
+
+func _ready() -> void:
+    window_can_close = false
+    progress_bar.value = 0
+    progress_bar.show_percentage = true
+    install_button.pressed.connect(_on_install_button_pressed)
+
+func setup_custom(data: Dictionary) -> void:
+    app_id = data.get("app_id", "")
+    app_title = data.get("app_title", "")
+    app_icon = data.get("app_icon", null)
+    if app_icon:
+        icon_path = app_icon.resource_path
+    if app_title != "":
+        window_title = "Installing " + app_title
+
+func _on_install_button_pressed() -> void:
+    install_button.disabled = true
+    progress_bar.value = 0
+    var tween := get_tree().create_tween()
+    tween.tween_property(progress_bar, "value", 99.0, 3.0)
+    tween.tween_interval(4.0)
+    tween.tween_property(progress_bar, "value", 100.0, 0.01)
+    tween.tween_callback(Callable(self, "_complete_install"))
+
+func _complete_install() -> void:
+    if app_id != "":
+        WindowManager.unlock_app(app_id)
+    var scene: PackedScene = WindowManager.app_registry.get(app_title)
+    if scene and not WindowManager.start_apps.has(app_title):
+        WindowManager.start_apps[app_title] = scene
+        if WindowManager.start_panel and WindowManager.start_panel.has_method("add_app_button"):
+            WindowManager.start_panel.add_app_button(app_title)
+    if shortcut_checkbox.button_pressed:
+        DesktopLayoutManager.create_app_shortcut(app_title, app_title, icon_path, Vector2.ZERO)
+    var window = get_parent().get_parent().get_parent()
+    if WindowManager:
+        WindowManager.close_window(window)
+    else:
+        window.queue_free()

--- a/components/apps/installer/installer.gd.uid
+++ b/components/apps/installer/installer.gd.uid
@@ -1,0 +1,1 @@
+uid://a3eebce104ca

--- a/components/apps/soft_wares/soft_ware_item.gd
+++ b/components/apps/soft_wares/soft_ware_item.gd
@@ -51,12 +51,16 @@ func _on_action_button_pressed() -> void:
 			WindowManager.launch_app(app_id)
 			return
 	var required_score: int = PortfolioManager.CREDIT_REQUIREMENTS.get(app_title, 0)
-	if PortfolioManager.attempt_spend(float(app_cost), required_score):
-			WindowManager.unlock_app(app_id)
-			_update_action_button()
-	else:
-			feedback_label.text = "Not enough funds!"
-			feedback_label.add_theme_color_override("font_color", Color.RED)
+       if PortfolioManager.attempt_spend(float(app_cost), required_score):
+                       var data = {
+                               "app_id": app_id,
+                               "app_title": app_title,
+                               "app_icon": app_icon,
+                       }
+                       WindowManager.launch_app_by_name("Installer", data)
+       else:
+                       feedback_label.text = "Not enough funds!"
+                       feedback_label.add_theme_color_override("font_color", Color.RED)
 
 func _on_upgrades_button_pressed() -> void:
 		if upgrade_scene:

--- a/components/start_panel_window.gd
+++ b/components/start_panel_window.gd
@@ -44,16 +44,45 @@ func _ready() -> void:
 			launch_app(app_name)
 		)
 
-		app_list_container.add_child(button)
-		preview.queue_free()
+               app_list_container.add_child(button)
+               preview.queue_free()
+
+func add_app_button(app_name: String) -> void:
+       if not WindowManager.start_apps.has(app_name):
+               return
+       var app_scene: PackedScene = WindowManager.start_apps[app_name]
+       var preview = app_scene.instantiate()
+       if not (preview is Pane):
+               push_error("App scene must extend Pane: " + str(app_scene))
+               return
+       var button := Button.new()
+       button.text = preview.window_title
+       button.focus_mode = Control.FOCUS_NONE
+       button.theme = preload("res://assets/themes/windows_95_theme.tres")
+       button.custom_minimum_size = Vector2(160, 40)
+       button.add_theme_font_size_override("font_size", 10)
+       if preview.window_icon:
+               var icon_texture := TextureRect.new()
+               icon_texture.texture = preview.window_icon
+               icon_texture.stretch_mode = TextureRect.STRETCH_KEEP_ASPECT_CENTERED
+               icon_texture.custom_minimum_size = Vector2(24, 24)
+               icon_texture.expand_mode = TextureRect.EXPAND_IGNORE_SIZE
+               button.add_child(icon_texture)
+               icon_texture.position = Vector2(8, 8)
+               button.icon = null
+       button.pressed.connect(func():
+               launch_app(app_name)
+       )
+       app_list_container.add_child(button)
+       preview.queue_free()
 
 
 func _input(event: InputEvent) -> void:
-	if listening_for_clicks and event is InputEventMouseButton and event.pressed:
-		# Check if the click is outside the StartPanel bounds
-		if not Rect2(Vector2.ZERO, size).has_point(get_local_mouse_position()):
-			hide()
-			listening_for_clicks = false
+        if listening_for_clicks and event is InputEventMouseButton and event.pressed:
+                # Check if the click is outside the StartPanel bounds
+                if not Rect2(Vector2.ZERO, size).has_point(get_local_mouse_position()):
+                        hide()
+                        listening_for_clicks = false
 
 func toggle_start_panel() -> void:
 	if visible:


### PR DESCRIPTION
## Summary
- Introduce non-closable Installer pane with desktop shortcut option and animated progress bar
- Launch installer after purchasing software and register installed apps in start menu
- Support dynamic start menu updates with add_app_button helper

## Testing
- `godot --headless tests/test_runner.tscn` *(fails: Missing assets and script errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b786ffa1d08325bad2ead0fbae48e0