### PR TITLE
Avoid cyclic reference when installer registers apps

### DIFF
--- a/autoloads/window_manager.gd
+++ b/autoloads/window_manager.gd
@@ -72,8 +72,15 @@ func is_app_unlocked(app_id: String) -> bool:
 		return app_unlock_state.get(app_id, true)
 
 func unlock_app(app_id: String) -> void:
-		app_unlock_state[app_id] = true
-		app_unlocked.emit(app_id)
+                app_unlock_state[app_id] = true
+                app_unlocked.emit(app_id)
+
+func register_start_app(app_name: String) -> void:
+                var scene: PackedScene = app_registry.get(app_name)
+                if scene and not start_apps.has(app_name):
+                                start_apps[app_name] = scene
+                                if start_panel and start_panel.has_method("add_app_button"):
+                                                start_panel.add_app_button(app_name)
 
 # --- Main window functions --- #
 

--- a/components/apps/installer/installer.gd
+++ b/components/apps/installer/installer.gd
@@ -37,11 +37,7 @@ func _on_install_button_pressed() -> void:
 func _complete_install() -> void:
     if app_id != "":
         WindowManager.unlock_app(app_id)
-    var scene: PackedScene = WindowManager.app_registry.get(app_title)
-    if scene and not WindowManager.start_apps.has(app_title):
-        WindowManager.start_apps[app_title] = scene
-        if WindowManager.start_panel and WindowManager.start_panel.has_method("add_app_button"):
-            WindowManager.start_panel.add_app_button(app_title)
+    WindowManager.register_start_app(app_title)
     if shortcut_checkbox.button_pressed:
         DesktopLayoutManager.create_app_shortcut(app_title, app_title, icon_path, Vector2.ZERO)
     var window = get_parent().get_parent().get_parent()


### PR DESCRIPTION
## Summary
- Add `WindowManager.register_start_app` helper to manage Start menu entries
- Use the new helper in `Installer` to avoid direct `app_registry` access and cyclic reference

## Testing
- `godot4 --headless -s tests/test_runner.gd` *(fails: command not found)*
- `godot --headless -s tests/test_runner.gd` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b78a45dcdc8325b0ee71b9982b9d5a