### PR TITLE
Refactor tarot RNG streams

### DIFF
--- a/autoloads/rng_manager.gd
+++ b/autoloads/rng_manager.gd
@@ -72,6 +72,12 @@ class TaskManagerRNG extends RNGStream:
 class NPCManagerRNG extends RNGStream:
 	pass
 
+class TarotCardRNG extends RNGStream:
+	pass
+
+class TarotRarityRNG extends RNGStream:
+	pass
+
 var global := GlobalRNG.new()
 var gpu := GPURNG.new()
 var rizz_battle_data := RizzBattleDataRNG.new()
@@ -89,6 +95,8 @@ var locked_in := LockedInRNG.new()
 var fumble_battle_logic := FumbleBattleLogicRNG.new()
 var task_manager := TaskManagerRNG.new()
 var npc_manager := NPCManagerRNG.new()
+var tarot_card := TarotCardRNG.new()
+var tarot_rarity := TarotRarityRNG.new()
 
 func _derive_seed(name: String) -> int:
 	return hash(str(seed) + ":" + name)
@@ -114,6 +122,8 @@ func init_seed(seed_value: int) -> void:
 	fumble_battle_logic.init_seed(_derive_seed("fumble_battle_logic"))
 	task_manager.init_seed(_derive_seed("task_manager"))
 	npc_manager.init_seed(_derive_seed("npc_manager"))
+	tarot_card.init_seed(_derive_seed("tarot_card"))
+	tarot_rarity.init_seed(_derive_seed("tarot_rarity"))
 	if OS.is_debug_build():
 		print("Global RNG Seed: ", seed)
 

--- a/autoloads/tarot_manager.gd
+++ b/autoloads/tarot_manager.gd
@@ -86,45 +86,47 @@ func _roll_rarity(rng: RandomNumberGenerator) -> int:
 	return 1
 
 func draw_card() -> Dictionary:
-	if not can_draw():
-					return {}
-	var rng := RNGManager.get_rng()
-	var rarity := _roll_rarity(rng)
-	var pool: Array = deck.cards_by_rarity.get(rarity, [])
-	if pool.is_empty():
-			return {}
-	var card: Dictionary = pool[rng.randi_range(0, pool.size() - 1)]
-	var id: String = card.get("id", "")
-	var rarities: Dictionary = collection.get(id, {})
-	rarities[rarity] = int(rarities.get(rarity, 0)) + 1
-	collection[id] = rarities
-	last_draw_minutes = TimeManager.get_now_minutes()
-	last_card_id = id
-	last_card_rarity = rarity
-	collection_changed.emit(id, get_card_count(id))
-	return card
+        if not can_draw():
+                                        return {}
+        var card_rng := RNGManager.tarot_card.get_rng()
+        var rarity_rng := RNGManager.tarot_rarity.get_rng()
+        var rarity := _roll_rarity(rarity_rng)
+        var pool: Array = deck.cards_by_rarity.get(rarity, [])
+        if pool.is_empty():
+                        return {}
+        var card: Dictionary = pool[card_rng.randi_range(0, pool.size() - 1)]
+        var id: String = card.get("id", "")
+        var rarities: Dictionary = collection.get(id, {})
+        rarities[rarity] = int(rarities.get(rarity, 0)) + 1
+        collection[id] = rarities
+        last_draw_minutes = TimeManager.get_now_minutes()
+        last_card_id = id
+        last_card_rarity = rarity
+        collection_changed.emit(id, get_card_count(id))
+        return card
 
 func draw_reading(count: int) -> Array:
-	var total_cost := reading_cost * count
-	if total_cost > 0.0 and not PortfolioManager.try_spend_cash(total_cost):
-			return []
-	var rng := RNGManager.get_rng()
-	var results: Array = []
-	for i in range(count):
-			var rarity := _roll_rarity(rng)
-			var pool: Array = deck.cards_by_rarity.get(rarity, [])
-			if pool.is_empty():
-					continue
-			var card: Dictionary = pool[rng.randi_range(0, pool.size() - 1)]
-			var id: String = card.get("id", "")
-			var rarities: Dictionary = collection.get(id, {})
-			rarities[rarity] = int(rarities.get(rarity, 0)) + 1
-			collection[id] = rarities
-			last_card_id = id
-			last_card_rarity = rarity
-			collection_changed.emit(id, get_card_count(id))
-			results.append({"id": id, "rarity": rarity})
-	return results
+        var total_cost := reading_cost * count
+        if total_cost > 0.0 and not PortfolioManager.try_spend_cash(total_cost):
+                        return []
+        var card_rng := RNGManager.tarot_card.get_rng()
+        var rarity_rng := RNGManager.tarot_rarity.get_rng()
+        var results: Array = []
+        for i in range(count):
+                        var rarity := _roll_rarity(rarity_rng)
+                        var pool: Array = deck.cards_by_rarity.get(rarity, [])
+                        if pool.is_empty():
+                                        continue
+                        var card: Dictionary = pool[card_rng.randi_range(0, pool.size() - 1)]
+                        var id: String = card.get("id", "")
+                        var rarities: Dictionary = collection.get(id, {})
+                        rarities[rarity] = int(rarities.get(rarity, 0)) + 1
+                        collection[id] = rarities
+                        last_card_id = id
+                        last_card_rarity = rarity
+                        collection_changed.emit(id, get_card_count(id))
+                        results.append({"id": id, "rarity": rarity})
+        return results
 
 func sell_card(card_id: String, rarity: int) -> void:
 		var rarities: Dictionary = collection.get(card_id, {})


### PR DESCRIPTION
## Summary
- add tarot-specific RNG streams for card choice and rarity
- draw tarot cards and rarities using independent deterministic streams

## Testing
- `godot --headless --path . --run tests/test_runner.tscn` *(fails: Could not find type "Stock"...)*

------
https://chatgpt.com/codex/tasks/task_e_68b78b4f9f6483258c2496d52e9f45be