### PR TITLE
Avoid cyclic reference when registering installed apps

### DIFF
--- a/components/apps/installer/installer.gd
+++ b/components/apps/installer/installer.gd
@@ -35,13 +35,17 @@ func _on_install_button_pressed() -> void:
     tween.tween_callback(Callable(self, "_complete_install"))
 
 func _complete_install() -> void:
-    if app_id != "":
-        WindowManager.unlock_app(app_id)
-    WindowManager.register_start_app(app_title)
+    if app_id != "" and WindowManager and WindowManager.has_method("unlock_app"):
+        WindowManager.call("unlock_app", app_id)
+
+    if WindowManager and WindowManager.has_method("register_start_app"):
+        WindowManager.call("register_start_app", app_title)
+
     if shortcut_checkbox.button_pressed:
         DesktopLayoutManager.create_app_shortcut(app_title, app_title, icon_path, Vector2.ZERO)
+
     var window = get_parent().get_parent().get_parent()
-    if WindowManager:
-        WindowManager.close_window(window)
+    if WindowManager and WindowManager.has_method("close_window"):
+        WindowManager.call("close_window", window)
     else:
         window.queue_free()


### PR DESCRIPTION
## Summary
- Call WindowManager methods dynamically in Installer to avoid cyclic reference errors when the app is preloaded

## Testing
- Attempted to download Godot headless to run tests but received `Not Found` from download server

------
https://chatgpt.com/codex/tasks/task_e_68b78bf3e6588325a6143a4879ed96c4