### PR TITLE
Restrict terminal access to desktop environment

### DIFF
--- a/autoload/terminal_manager.gd
+++ b/autoload/terminal_manager.gd
@@ -4,20 +4,22 @@ extends Node
 const TOGGLE_ACTION := "toggle_terminal"
 
 func _ready() -> void:
-	_ensure_toggle_action()
+        _ensure_toggle_action()
 
 func _input(event: InputEvent) -> void:
-	if event.is_action_pressed(TOGGLE_ACTION):
-		toggle()
-		get_viewport().set_input_as_handled()
+        if GameManager.in_game and event.is_action_pressed(TOGGLE_ACTION):
+                toggle()
+                get_viewport().set_input_as_handled()
 
 func open() -> void:
-	var existing := WindowManager.find_window_by_app("Terminal")
-	if existing:
-		WindowManager.focus_window(existing)
-		if existing.pane is Terminal:
-			(existing.pane as Terminal).open()
-		return
+        if not GameManager.in_game:
+                return
+        var existing := WindowManager.find_window_by_app("Terminal")
+        if existing:
+                WindowManager.focus_window(existing)
+                if existing.pane is Terminal:
+                        (existing.pane as Terminal).open()
+                return
 
 	WindowManager.launch_app_by_name("Terminal")
 	existing = WindowManager.find_window_by_app("Terminal")
@@ -30,11 +32,13 @@ func close() -> void:
 		WindowManager.close_window(existing)
 
 func toggle() -> void:
-	var existing := WindowManager.find_window_by_app("Terminal")
-	if existing:
-		WindowManager.close_window(existing)
-	else:
-		open()
+        if not GameManager.in_game:
+                return
+        var existing := WindowManager.find_window_by_app("Terminal")
+        if existing:
+                WindowManager.close_window(existing)
+        else:
+                open()
 
 func _ensure_toggle_action() -> void:
 	if not InputMap.has_action(TOGGLE_ACTION):


### PR DESCRIPTION
## Summary
- Gate terminal toggle behind GameManager.in_game to block use on login screen
- Add guard clauses preventing opening or toggling Terminal when not in desktop environment

## Testing
- `godot -s tests/test_runner.gd` *(fails: Can't load script, missing resources)*

------
https://chatgpt.com/codex/tasks/task_e_68b796403098832588fe810167c51df5