### PR TITLE
Show highest rarity in tarot collection

### DIFF
--- a/autoloads/tarot_manager.gd
+++ b/autoloads/tarot_manager.gd
@@ -59,8 +59,17 @@ func get_card_count(id: String) -> int:
 		return total
 
 func get_card_rarity_count(id: String, rarity: int) -> int:
-		var rarities: Dictionary = collection.get(id, {})
-		return int(rarities.get(rarity, 0))
+        var rarities: Dictionary = collection.get(id, {})
+        return int(rarities.get(rarity, 0))
+
+func get_highest_owned_rarity(id: String) -> int:
+        var rarities: Dictionary = collection.get(id, {})
+        var highest := 1
+        for r in rarities.keys():
+                var r_int := int(r)
+                if r_int > highest and int(rarities[r]) > 0:
+                        highest = r_int
+        return highest
 
 func get_all_cards_ordered() -> Array:
 	return deck.get_all_cards_ordered()

--- a/components/apps/tarot/tarot_app.gd
+++ b/components/apps/tarot/tarot_app.gd
@@ -36,24 +36,27 @@ func _ready() -> void:
 
 
 func _build_collection_view() -> void:
-	for child in collection_grid.get_children():
-		child.queue_free()
-	card_views.clear()
-	for card in TarotManager.get_all_cards_ordered():
-		var id: String = card.get("id", "")
-		var count: int = TarotManager.get_card_count(id)
-		var view: TarotCardView = TarotManager.instantiate_card_view(id, count)
-		collection_grid.add_child(view)
-		view.set_rarity_label_visible(false)
-		view.texture_rect.custom_minimum_size = Vector2(32, 56)
-		view.card_pressed.connect(card_collection_examiner.show_card)
+        for child in collection_grid.get_children():
+                child.queue_free()
+        card_views.clear()
+        for card in TarotManager.get_all_cards_ordered():
+                var id: String = card.get("id", "")
+                var count: int = TarotManager.get_card_count(id)
+                var rarity := TarotManager.get_highest_owned_rarity(id)
+                var view: TarotCardView = TarotManager.instantiate_card_view(id, count, false, rarity)
+                collection_grid.add_child(view)
+                view.set_rarity_label_visible(false)
+                view.texture_rect.custom_minimum_size = Vector2(32, 56)
+                view.card_pressed.connect(card_collection_examiner.show_card)
 
-		card_views[id] = view
+                card_views[id] = view
 
 func _on_collection_changed(card_id: String, count: int) -> void:
-	var view = card_views.get(card_id)
-	if view:
-		view.update_count(count)
+        var view = card_views.get(card_id)
+        if view:
+                var rarity := TarotManager.get_highest_owned_rarity(card_id)
+                view.update_rarity(rarity)
+                view.update_count(count)
 
 func _on_draw_button_pressed() -> void:
 	var card = TarotManager.draw_card()

--- a/components/apps/tarot/tarot_card_view.gd
+++ b/components/apps/tarot/tarot_card_view.gd
@@ -57,14 +57,26 @@ func setup(data: Dictionary, owned: int) -> void:
 		sell_button.pressed.connect(_on_sell_pressed)
 
 func update_count(new_count: int) -> void:
-				count = new_count
-				count_label.visible = count > 0 and (count > 1 or show_single_count)
-				count_label.text = "x%d" % count
-				sell_button.visible = count > 0
-				texture_rect.modulate = Color(1,1,1,1) if count > 0 else Color(0.5,0.5,0.5,1)
-				if count > 0:
-								sell_button.disabled = false
-								sell_button.text = "Sell for $%d" % int(sell_price)
+        count = new_count
+        count_label.visible = count > 0 and (count > 1 or show_single_count)
+        count_label.text = "x%d" % count
+        sell_button.visible = count > 0
+        texture_rect.modulate = Color(1,1,1,1) if count > 0 else Color(0.5,0.5,0.5,1)
+        if count > 0:
+                        sell_button.disabled = false
+                        sell_button.text = "Sell for $%d" % int(sell_price)
+
+func update_rarity(new_rarity: int) -> void:
+        rarity = new_rarity
+        rarity_label.text = RARITY_NAMES.get(rarity, "")
+        if rarity == 5:
+                        rarity_label.material = RAINBOW_MATERIAL
+                        rarity_label.add_theme_color_override("font_color", Color.WHITE)
+        else:
+                        rarity_label.material = null
+                        rarity_label.add_theme_color_override("font_color", RARITY_COLORS.get(rarity, Color.WHITE))
+        sell_price = TarotManager.get_sell_price(rarity)
+        sell_button.text = "Sell for $%d" % int(sell_price)
 
 func set_rarity_label_visible(is_visible: bool) -> void:
 				if not is_node_ready():


### PR DESCRIPTION
## Summary
- Display each tarot card in the collection using the highest owned rarity
- Update card views to refresh rarity and sell price when inventory changes
- Add helper to obtain highest rarity per card

## Testing
- `/usr/local/bin/godot --headless -s res://tests/test_runner.gd` *(fails: Can't load the script as it doesn't inherit from SceneTree or MainLoop)*

------
https://chatgpt.com/codex/tasks/task_e_68b7966a61fc8325a019bf0a9fd728e4