### PR TITLE
Randomize tarot card orientation

### DIFF
--- a/autoloads/rng_manager.gd
+++ b/autoloads/rng_manager.gd
@@ -76,7 +76,10 @@ class TarotCardRNG extends RNGStream:
 	pass
 
 class TarotRarityRNG extends RNGStream:
-	pass
+        pass
+
+class TarotOrientationRNG extends RNGStream:
+        pass
 
 var global := GlobalRNG.new()
 var gpu := GPURNG.new()
@@ -97,6 +100,7 @@ var task_manager := TaskManagerRNG.new()
 var npc_manager := NPCManagerRNG.new()
 var tarot_card := TarotCardRNG.new()
 var tarot_rarity := TarotRarityRNG.new()
+var tarot_orientation := TarotOrientationRNG.new()
 
 func _derive_seed(name: String) -> int:
 	return hash(str(seed) + ":" + name)
@@ -121,11 +125,12 @@ func init_seed(seed_value: int) -> void:
 	locked_in.init_seed(_derive_seed("locked_in"))
 	fumble_battle_logic.init_seed(_derive_seed("fumble_battle_logic"))
 	task_manager.init_seed(_derive_seed("task_manager"))
-	npc_manager.init_seed(_derive_seed("npc_manager"))
-	tarot_card.init_seed(_derive_seed("tarot_card"))
-	tarot_rarity.init_seed(_derive_seed("tarot_rarity"))
-	if OS.is_debug_build():
-		print("Global RNG Seed: ", seed)
+        npc_manager.init_seed(_derive_seed("npc_manager"))
+        tarot_card.init_seed(_derive_seed("tarot_card"))
+        tarot_rarity.init_seed(_derive_seed("tarot_rarity"))
+        tarot_orientation.init_seed(_derive_seed("tarot_orientation"))
+        if OS.is_debug_build():
+                print("Global RNG Seed: ", seed)
 
 func get_rng() -> RandomNumberGenerator:
 	return global.get_rng()

--- a/components/apps/tarot/tarot_app.gd
+++ b/components/apps/tarot/tarot_app.gd
@@ -74,34 +74,37 @@ func _on_reading_button_pressed() -> void:
 	_show_reading_cards(cards)
 
 func _show_last_drawn_card() -> void:
-	for child in draw_result.get_children():
-		child.queue_free()
+        for child in draw_result.get_children():
+                child.queue_free()
 	var id = TarotManager.last_card_id
 	var rarity = TarotManager.last_card_rarity
 	if id == "" or rarity <= 0:
 		return
 	var count_for_rarity = TarotManager.get_card_rarity_count(id, rarity)
-	var view = TarotManager.instantiate_card_view(id, count_for_rarity, true, rarity)
-	view.show_single_count = true
-	view.modulate.a = 0.0
-	draw_result.add_child(view)
-	create_tween().tween_property(view, "modulate:a", 1.0, 0.3)
+       var view = TarotManager.instantiate_card_view(id, count_for_rarity, true, rarity)
+       view.set_upside_down(RNGManager.tarot_orientation.get_rng().randf() < 0.5)
+       view.show_single_count = true
+       view.modulate.a = 0.0
+       draw_result.add_child(view)
+       create_tween().tween_property(view, "modulate:a", 1.0, 0.3)
 
 func _show_reading_cards(cards: Array) -> void:
-	for child in reading_result.get_children():
-		if child != reading_button and child != reading_cost_label and child != reading_button:
-			child.queue_free()
-	var index := 0
-	for c in cards:
-		var id: String = c.get("id", "")
-		var rarity: int = int(c.get("rarity", 1))
-		var count_for_rarity = TarotManager.get_card_rarity_count(id, rarity)
-		var view = TarotManager.instantiate_card_view(id, count_for_rarity, true, rarity)
-		view.show_single_count = true
-		view.modulate.a = 0.0
-		reading_result.add_child(view)
-		create_tween().tween_property(view, "modulate:a", 1.0, 0.3).set_delay(index * 0.2)
-		index += 1
+        for child in reading_result.get_children():
+                if child != reading_button and child != reading_cost_label and child != reading_button:
+                        child.queue_free()
+        var index := 0
+       var flip_rng := RNGManager.tarot_orientation.get_rng()
+       for c in cards:
+               var id: String = c.get("id", "")
+               var rarity: int = int(c.get("rarity", 1))
+               var count_for_rarity = TarotManager.get_card_rarity_count(id, rarity)
+               var view = TarotManager.instantiate_card_view(id, count_for_rarity, true, rarity)
+               view.set_upside_down(flip_rng.randf() < 0.5)
+               view.show_single_count = true
+               view.modulate.a = 0.0
+               reading_result.add_child(view)
+               create_tween().tween_property(view, "modulate:a", 1.0, 0.3).set_delay(index * 0.2)
+               index += 1
 
 
 func _update_cooldown_label() -> void:

--- a/components/apps/tarot/tarot_card_view.gd
+++ b/components/apps/tarot/tarot_card_view.gd
@@ -99,5 +99,11 @@ func _ready() -> void:
 				count_label.mouse_filter = Control.MOUSE_FILTER_PASS
 
 func _gui_input(event: InputEvent) -> void:
-		if event is InputEventMouseButton and event.pressed and event.button_index == MOUSE_BUTTON_LEFT:
-				card_pressed.emit(card_id)
+                if event is InputEventMouseButton and event.pressed and event.button_index == MOUSE_BUTTON_LEFT:
+                                card_pressed.emit(card_id)
+
+func set_upside_down(is_upside_down: bool) -> void:
+                if not is_node_ready():
+                                await ready
+                texture_rect.pivot_offset = texture_rect.size * 0.5
+                texture_rect.rotation_degrees = 180 if is_upside_down else 0


### PR DESCRIPTION
## Summary
- Add dedicated RNG stream for tarot card orientation
- Allow TarotCardView to flip textures upside down
- Randomly flip cards 50% in daily draw and reading results

## Testing
- `godot3-server -s tests/test_runner.gd` *(fails: project uses config_version 5)*

------
https://chatgpt.com/codex/tasks/task_e_68b79c1aa3388325a742dafcbcae34a9