### PR TITLE
Reset RNG streams when clearing game state

### DIFF
--- a/autoloads/rng_manager.gd
+++ b/autoloads/rng_manager.gd
@@ -129,11 +129,18 @@ var streams := {
 	"npc_manager": npc_manager,
 	"tarot_card": tarot_card,
 	"tarot_rarity": tarot_rarity,
-	"tarot_orientation": tarot_orientation,
+        "tarot_orientation": tarot_orientation,
 }
 
+func reset() -> void:
+        seed = 0
+        for name in streams.keys():
+                var stream_class = streams[name].get_script()
+                streams[name] = stream_class.new()
+                set(name, streams[name])
+
 func _derive_seed(name: String) -> int:
-	return hash(str(seed) + ":" + name)
+        return hash(str(seed) + ":" + name)
 
 func init_seed(seed_value: int) -> void:
 	print("RNGManager.init_seed:", seed_value)

--- a/autoloads/save_manager.gd
+++ b/autoloads/save_manager.gd
@@ -297,8 +297,9 @@ func load_from_slot(slot_id: int) -> void:
 
 
 func reset_game_state() -> void:
-	# Reset all relevant managers to blank state
-	PlayerManager.reset()
+        # Reset all relevant managers to blank state
+        RNGManager.reset()
+        PlayerManager.reset()
 	StatManager.reset()
 	PortfolioManager.reset()
 	WindowManager.reset()
@@ -315,7 +316,8 @@ func reset_game_state() -> void:
 	TarotManager.reset()
 
 func reset_managers():
-	PlayerManager.reset()
+        RNGManager.reset()
+        PlayerManager.reset()
 	StatManager.reset()
 	PortfolioManager.reset()
 	WindowManager.reset()


### PR DESCRIPTION
## Summary
- implement `RNGManager.reset` to recreate all RNG streams and clear master seed
- invoke `RNGManager.reset` at the start of `SaveManager.reset_game_state` and `reset_managers`

## Testing
- `godot3-server --path . -s tests/test_runner.gd` *(fails: project requires newer Godot engine)*

------
https://chatgpt.com/codex/tasks/task_e_68b7b013be748325bc5e2abfc829cec3