### PR TITLE
fix: delay NPC roman numerals

### DIFF
--- a/components/npc/name_manager.gd
+++ b/components/npc/name_manager.gd
@@ -68,16 +68,31 @@ func get_random_first_name() -> String:
 	return first_names[idx].name
 
 func get_random_last_name() -> String:
-	if last_names.size() == 0:
-		return "LastName"
-	var idx: int = _rng.randi_range(0, last_names.size() - 1)
-	return last_names[idx]
+        if last_names.size() == 0:
+                return "LastName"
+        var idx: int = _rng.randi_range(0, last_names.size() - 1)
+        return last_names[idx]
 
 func get_npc_name_by_index(npc_index: int) -> Dictionary:
-	var total_combos: int = first_names.size() * middle_initials.size() * last_names.size()
-	var suffix_num: int = npc_index / total_combos
-	var base_index: int = npc_index % total_combos
-	var name_index: int = feistel_shuffle(base_index, total_combos, name_seed)
+        # Ensure name pools are initialised. When starting a fresh game
+        # `get_npc_name_by_index` may be invoked before this node's `_ready()`
+        # runs, leaving the arrays empty and causing division-by-zero below.
+        if first_names.is_empty():
+                _load_first_names()
+        if last_names.is_empty():
+                _load_last_names()
+        if middle_initials.is_empty():
+                for ascii in range(65, 91):
+                        middle_initials.append(String.chr(ascii))
+
+        var total_combos: int = first_names.size() * middle_initials.size() * last_names.size()
+        var suffix_num: int = 0
+        if total_combos > 0:
+                suffix_num = npc_index / total_combos
+        var base_index: int = 0
+        if total_combos > 0:
+                base_index = npc_index % total_combos
+        var name_index: int = feistel_shuffle(base_index, max(total_combos, 1), name_seed)
 
 	var first_count: int = first_names.size()
 	var middle_count: int = middle_initials.size()

--- a/tests/name_manager_roman_suffix_test.gd
+++ b/tests/name_manager_roman_suffix_test.gd
@@ -1,0 +1,14 @@
+extends SceneTree
+
+func _ready():
+    # Simulate uninitialised NameManager pools
+    NameManager.first_names.clear()
+    NameManager.last_names.clear()
+    NameManager.middle_initials.clear()
+    var data = NameManager.get_npc_name_by_index(0)
+    var full_name: String = data["full_name"]
+    var re := RegEx.new()
+    re.compile(" [IVXLCDM]+$")
+    assert(re.search(full_name) == null)
+    print("name_manager_roman_suffix_test passed")
+    quit()


### PR DESCRIPTION
## Summary
- lazily load NPC name pools and guard against division-by-zero so roman numeral suffixes only appear after base combinations are exhausted
- add regression test for roman numeral suffix handling

## Testing
- `godot --headless --path . -s tests/test_runner.gd` *(fails: Can't load tests script / missing resources)*


------
https://chatgpt.com/codex/tasks/task_e_68b7b218bf7c8325b95ba0c0244874ca