### PR TITLE
Avoid premature roman numeral NPC names

### DIFF
--- a/autoloads/player_manager.gd
+++ b/autoloads/player_manager.gd
@@ -197,9 +197,12 @@ func ensure_default_stats() -> void:
 	ensure_friend1()
 
 func generate_friend1() -> void:
-		var idx = RNGManager.npc_manager.get_rng().randi()
-		user_data["friend1_npc_index"] = idx
-		NPCManager.get_npc_by_index(idx)
+        var total: int = NameManager.get_unique_name_count()
+        var idx: int = 0
+        if total > 0:
+                idx = RNGManager.npc_manager.get_rng().randi_range(0, total - 1)
+        user_data["friend1_npc_index"] = idx
+        NPCManager.get_npc_by_index(idx)
 
 func ensure_friend1() -> void:
 		if int(user_data.get("friend1_npc_index", -1)) == -1:

--- a/components/npc/name_manager.gd
+++ b/components/npc/name_manager.gd
@@ -73,6 +73,20 @@ func get_random_last_name() -> String:
         var idx: int = _rng.randi_range(0, last_names.size() - 1)
         return last_names[idx]
 
+func get_unique_name_count() -> int:
+        # Ensure the name pools are initialised before calculating the
+        # total number of unique combinations. When a new profile is
+        # created, this function may be called before the node's `_ready()`
+        # executes, so we lazily load the data as needed.
+        if first_names.is_empty():
+                _load_first_names()
+        if last_names.is_empty():
+                _load_last_names()
+        if middle_initials.is_empty():
+                for ascii in range(65, 91):
+                        middle_initials.append(String.chr(ascii))
+        return first_names.size() * middle_initials.size() * last_names.size()
+
 func get_npc_name_by_index(npc_index: int) -> Dictionary:
         # Ensure name pools are initialised. When starting a fresh game
         # `get_npc_name_by_index` may be invoked before this node's `_ready()`

--- a/tests/friend1_name_no_suffix_test.gd
+++ b/tests/friend1_name_no_suffix_test.gd
@@ -1,0 +1,15 @@
+extends SceneTree
+
+func _ready():
+        RNGManager.init_seed(0)
+        PlayerManager.reset()
+        PlayerManager.generate_friend1()
+        var idx = PlayerManager.user_data["friend1_npc_index"]
+        var total = NameManager.get_unique_name_count()
+        assert(idx < total)
+        var full_name: String = NameManager.get_npc_name_by_index(idx)["full_name"]
+        var re := RegEx.new()
+        re.compile(" [IVXLCDM]+$")
+        assert(re.search(full_name) == null)
+        print("friend1_name_no_suffix_test passed")
+        quit()


### PR DESCRIPTION
## Summary
- Restrict friend NPC index to the range of unique name combinations to avoid early Roman numeral suffixes
- Provide NameManager helper to calculate total unique name combinations
- Test that friend1 is generated within range and without Roman numeral suffix

## Testing
- `godot --headless --quiet -s tests/test_runner.gd` *(fails: command not found)*
- `apt-get install -y godot` *(fails: Unable to locate package godot)*

------
https://chatgpt.com/codex/tasks/task_e_68b7b4504db4832584a015c669c80a9e