### PR TITLE
Add self-contained GDScript tests for key managers

### DIFF
--- a/tests/bill_manager_test.gd
+++ b/tests/bill_manager_test.gd
@@ -1,0 +1,106 @@
+extends Node
+
+func _init() -> void:
+    _ready()
+
+var bm_script: Script = preload("res://autoloads/bill_manager.gd")
+
+class DummyTimeManager:
+    func get_weekday_for_date(day: int, month: int, year: int) -> int:
+        return 6
+    func get_total_days_since_start(day: int, month: int, year: int) -> int:
+        return day - 2
+    func get_days_in_month(month: int, year: int) -> int:
+        return 31
+
+class DummyPortfolioManager:
+    var cash: float = 0.0
+    var credit_limit: float = 0.0
+    var credit_used: float = 0.0
+    var credit_interest_rate: float = 0.0
+    var credit_score: int = 700
+    var CREDIT_REQUIREMENTS: Dictionary = {"bills": 0}
+    func attempt_spend(amount: float, required_score: int = 0, silent: bool = false) -> bool:
+        if cash >= amount:
+            cash -= amount
+            return true
+        var available: float = credit_limit - credit_used
+        if available >= amount:
+            credit_used += amount
+            return true
+        return false
+    func pay_down_credit(amount: float) -> bool:
+        if cash >= amount:
+            cash -= amount
+            credit_used = max(credit_used - amount, 0.0)
+            return true
+        return false
+
+class DummyPopup:
+    var bill_name: String = ""
+    var amount: float = 0.0
+    var visible: bool = true
+    func close() -> void:
+        visible = false
+    func update_amount_display() -> void:
+        pass
+
+class TestBillManager extends bm_script:
+    var autopay_attempts: int = 0
+    func attempt_to_autopay(bill_name: String) -> bool:
+        autopay_attempts += 1
+        return true
+    func _get_yesterday() -> Dictionary:
+        return {"day": 1, "month": 1, "year": 2000}
+    func _format_date_key(date: Dictionary) -> String:
+        return "key"
+    func auto_resolve_bills_for_date(date_str: String) -> void:
+        pass
+    func get_due_bills_for_date(day: int, month: int, year: int) -> Array[String]:
+        return ["TestBill"]
+    func get_bill_amount(bill_name: String) -> float:
+        return 10.0
+    func mark_bill_paid(bill_name: String, date_key: String) -> void:
+        pass
+
+func _ready() -> void:
+    var tm: DummyTimeManager = DummyTimeManager.new()
+    Engine.register_singleton("TimeManager", tm)
+    var pm: DummyPortfolioManager = DummyPortfolioManager.new()
+    Engine.register_singleton("PortfolioManager", pm)
+
+    var bm1: Node = bm_script.new()
+    var sundays: Array[int] = [2, 9, 16, 23]
+    var expected: Array[String] = ["Rent", "Student Loan", "Credit Card", "Medical Insurance"]
+    var month: int = 1
+    var year: int = 2000
+    var i: int = 0
+    while i < sundays.size():
+        var bills: Array[String] = bm1.get_due_bills_for_date(sundays[i], month, year)
+        assert(expected[i] in bills)
+        i += 1
+
+    var bm2: TestBillManager = TestBillManager.new()
+    bm2.autopay_enabled = true
+    bm2._on_day_passed(1, 1, 2000)
+    assert(bm2.autopay_attempts == 1)
+    bm2.autopay_enabled = false
+    bm2._on_day_passed(1, 1, 2000)
+    assert(bm2.autopay_attempts == 1)
+
+    pm.cash = 0.0
+    pm.credit_limit = 100.0
+    pm.credit_used = 0.0
+    var bm3: Node = bm_script.new()
+    bm3.static_bill_amounts["TestBill"] = 40.0
+    var result: bool = bm3.attempt_to_autopay("TestBill")
+    assert(result)
+    assert(pm.credit_used == 40.0)
+
+    pm.credit_used = 90.0
+    bm3.static_bill_amounts["AnotherBill"] = 20.0
+    var result_fail: bool = bm3.attempt_to_autopay("AnotherBill")
+    assert(not result_fail)
+    assert(pm.credit_used == 90.0)
+
+    print("bill_manager_test passed")

--- a/tests/portfolio_manager_test.gd
+++ b/tests/portfolio_manager_test.gd
@@ -1,0 +1,65 @@
+extends Node
+
+func _init() -> void:
+    _ready()
+
+class DummyStatManager:
+    var stats: Dictionary = {}
+    func get_stat(name: String) -> float:
+        return stats.get(name, 0.0)
+    func set_base_stat(name: String, value: float) -> void:
+        stats[name] = value
+    func connect_to_stat(name: String, target: Object, method: String) -> void:
+        pass
+
+class DummyEvents:
+    func focus_wallet_card(category: String) -> void:
+        pass
+    func flash_wallet_value(category: String, amount: float) -> void:
+        pass
+
+class DummyWindowManager:
+    var launched_apps: Array = []
+    func launch_app_by_name(app_name: String) -> void:
+        launched_apps.append(app_name)
+
+func _ready() -> void:
+    var stat_manager: DummyStatManager = DummyStatManager.new()
+    Engine.register_singleton("StatManager", stat_manager)
+    var events: DummyEvents = DummyEvents.new()
+    Engine.register_singleton("Events", events)
+    var window_manager: DummyWindowManager = DummyWindowManager.new()
+    Engine.register_singleton("WindowManager", window_manager)
+
+    var pm_script: Script = load("res://autoloads/portfolio_manager.gd")
+    var pm: Node = pm_script.new()
+    pm.set_credit_limit(100.0)
+    pm.set_credit_used(0.0)
+    pm.set_credit_interest_rate(0.0)
+
+    pm.add_cash(100.0)
+    assert(stat_manager.get_stat("cash") == 100.0)
+    pm.add_cash(-50.0)
+    assert(stat_manager.get_stat("cash") == 100.0)
+
+    pm.spend_cash(30.0)
+    assert(stat_manager.get_stat("cash") == 70.0)
+    pm.spend_cash(-5.0)
+    assert(stat_manager.get_stat("cash") == 70.0)
+
+    var success: bool = pm.attempt_spend(50.0, 0, true)
+    assert(success)
+    assert(stat_manager.get_stat("cash") == 20.0)
+    assert(stat_manager.get_stat("credit_used") == 0.0)
+
+    success = pm.attempt_spend(30.0, 0, true)
+    assert(success)
+    assert(stat_manager.get_stat("cash") == 0.0)
+    assert(stat_manager.get_stat("credit_used") == 10.0)
+
+    success = pm.attempt_spend(200.0, 0, true)
+    assert(not success)
+    assert(stat_manager.get_stat("credit_used") == 10.0)
+    assert(window_manager.launched_apps.size() == 1)
+
+    print("portfolio_manager_test passed")

--- a/tests/window_manager_test.gd
+++ b/tests/window_manager_test.gd
@@ -1,0 +1,28 @@
+extends Node
+
+func _init() -> void:
+    _ready()
+
+var wm_script: Script = preload("res://autoloads/window_manager.gd")
+var pane_script: Script = preload("res://components/windows/pane.gd")
+
+class DummyPane extends pane_script:
+    pass
+
+class TestWindowManager extends wm_script:
+    func launch_pane(scene: PackedScene) -> void:
+        var pane: Node = scene.instantiate()
+        add_child(pane)
+
+func _ready() -> void:
+    var wm: TestWindowManager = TestWindowManager.new()
+    var ps: PackedScene = PackedScene.new()
+    var pane_instance: DummyPane = DummyPane.new()
+    ps.pack(pane_instance)
+    wm.app_registry["TestApp"] = ps
+    wm.launch_app_by_name("TestApp")
+    assert(wm.get_child_count() == 1)
+    assert(wm.get_child(0) is Pane)
+    wm.launch_app_by_name("MissingApp")
+    assert(wm.get_child_count() == 1)
+    print("window_manager_test passed")


### PR DESCRIPTION
## Summary
- add Node-based PortfolioManager test covering add_cash, spend_cash, attempt_spend, and credit usage
- add BillManager test for billing cycle, autopay toggle, and credit fallback
- add WindowManager test ensuring apps launched by name become children

## Testing
- `godot -s tests/test_runner.gd` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b7c54362f4832592e56cbc0692d191