### PR TITLE
Refactor tarot readings to use EX currency

### DIFF
--- a/components/apps/tarot/tarot_app.gd
+++ b/components/apps/tarot/tarot_app.gd
@@ -27,6 +27,7 @@ func _ready() -> void:
 	collection_tab_button.pressed.connect(_on_collection_tab_pressed)
 	TarotManager.collection_changed.connect(_on_collection_changed)
 	TimeManager.minute_passed.connect(_on_minute_passed)
+        TimeManager.hour_passed.connect(_on_hour_passed)
 	UpgradeManager.upgrade_purchased.connect(_on_upgrade_purchased)
 	_build_collection_view()
 	_update_cooldown_label()
@@ -72,6 +73,7 @@ func _on_reading_button_pressed() -> void:
 	if cards.is_empty():
 			return
 	_show_reading_cards(cards)
+        _update_reading_cost_label()
 
 func _show_last_drawn_card() -> void:
 	for child in draw_result.get_children():
@@ -122,10 +124,13 @@ func _update_reading_cost_label() -> void:
 	var extra := UpgradeManager.get_level("tarot_extra_card")
 	var count := 1 + extra
 	var cost = TarotManager.reading_cost * count
-	reading_cost_label.text = "$" + str(cost) + " for %d card(s)" % count
+	reading_cost_label.text = "%d EX for %d card(s)" % [int(cost), count]
 
 func _on_minute_passed(_total_minutes: int) -> void:
 	_update_cooldown_label()
+
+func _on_hour_passed(_current_hour: int, _total_minutes: int) -> void:
+	_update_reading_cost_label()
 
 func _activate_tab(tab_name: StringName) -> void:
 	if tab_name == &"Draw":

--- a/tests/tarot_reading_cost_ex_test.gd
+++ b/tests/tarot_reading_cost_ex_test.gd
@@ -1,0 +1,12 @@
+extends SceneTree
+
+func _ready():
+    TarotManager.reset()
+    StatManager.set_base_stat("ex", 100.0)
+    var cards = TarotManager.draw_reading(1)
+    assert(not cards.is_empty())
+    assert(TarotManager.reading_cost == 2.0)
+    TarotManager._on_hour_passed(0, 0)
+    assert(TarotManager.reading_cost == 1.0)
+    print("tarot_reading_cost_ex_test passed")
+    quit()

--- a/tests/tarot_reading_cost_ex_test.gd.uid
+++ b/tests/tarot_reading_cost_ex_test.gd.uid
@@ -1,0 +1,1 @@
+uid://tarotreadingcostex


### PR DESCRIPTION
## Summary
- switch tarot readings from cash to EX cost
- add hourly decay and doubling logic for tarot reading cost
- update tarot app UI and tests for EX-based readings

## Testing
- `/tmp/godot/Godot_v4.2.1-stable_linux.x86_64 --headless --path . tests/test_runner.tscn` *(fails: Error opening file 'uid://gl0rjxkrh4wh')*


------
https://chatgpt.com/codex/tasks/task_e_68b7b9f402f08325b830615ef454366e