### PR TITLE
Refactor SoftWareItem to use PanelContainer

### DIFF
--- a/components/apps/soft_wares/soft_ware_item.gd
+++ b/components/apps/soft_wares/soft_ware_item.gd
@@ -1,4 +1,4 @@
-extends HBoxContainer
+extends PanelContainer
 class_name SoftWareItem
 
 @export var app_icon: Texture2D

--- a/components/apps/soft_wares/soft_ware_item.tscn
+++ b/components/apps/soft_wares/soft_ware_item.tscn
@@ -2,20 +2,24 @@
 
 [ext_resource type="Script" uid="uid://dfkb3gxulmxys" path="res://components/apps/soft_wares/soft_ware_item.gd" id="1"]
 
-[node name="SoftWareItem" type="HBoxContainer"]
+[node name="SoftWareItem" type="PanelContainer"]
 custom_minimum_size = Vector2(450, 0)
 size_flags_horizontal = 3
-theme_override_constants/separation = 10
 script = ExtResource("1")
 
-[node name="Icon" type="TextureRect" parent="."]
+[node name="Content" type="HBoxContainer" parent="."]
+layout_mode = 2
+size_flags_horizontal = 3
+theme_override_constants/separation = 10
+
+[node name="Icon" type="TextureRect" parent="Content"]
 unique_name_in_owner = true
 custom_minimum_size = Vector2(64, 64)
 layout_mode = 2
 expand_mode = 1
 stretch_mode = 1
 
-[node name="InfoContainer" type="VBoxContainer" parent="."]
+[node name="InfoContainer" type="VBoxContainer" parent="Content"]
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 3
@@ -37,7 +41,7 @@ autowrap_mode = 3
 unique_name_in_owner = true
 layout_mode = 2
 
-[node name="ButtonsContainer" type="VBoxContainer" parent="."]
+[node name="ButtonsContainer" type="VBoxContainer" parent="Content"]
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 0


### PR DESCRIPTION
## Summary
- Refactor SoftWareItem to extend PanelContainer instead of HBoxContainer
- Wrap existing UI in a Content HBoxContainer for layout

## Testing
- `godot3 --headless -s tests/test_runner.gd` *(fails: project requires newer engine)*

------
https://chatgpt.com/codex/tasks/task_e_68b84d386d7c8325bb616c54daaa7cb7