### PR TITLE
Add right-click context menu for app shortcuts

### DIFF
--- a/components/desktop/app_shortcut.gd
+++ b/components/desktop/app_shortcut.gd
@@ -8,33 +8,50 @@ class_name AppShortcut
 
 @onready var icon_rect: TextureRect = %Icon
 @onready var title_label: Label = %Title
+@onready var context_menu: PopupMenu = %ContextMenu
 
 var is_dragging: bool = false
 var drag_offset: Vector2
 
 func _ready() -> void:
-	icon_rect.texture = icon
-	title_label.text = title
-	gui_input.connect(_on_gui_input)
+    icon_rect.texture = icon
+    title_label.text = title
+    gui_input.connect(_on_gui_input)
+    context_menu.add_item("Open", 0)
+    context_menu.add_item("Delete", 1)
+    context_menu.id_pressed.connect(_on_context_menu_id_pressed)
 
 func _on_gui_input(event: InputEvent) -> void:
-	if event is InputEventMouseButton:
-		var mb: InputEventMouseButton = event
-		if mb.button_index == MOUSE_BUTTON_LEFT:
-			if mb.double_click and mb.pressed:
-					var item := DesktopLayoutManager.get_item(item_id)
-					var data = item.get("data", {})
-					if data is Dictionary and data.size() > 0:
-							WindowManager.launch_app_by_name(app_name, item_id)
-					else:
-							WindowManager.launch_app_by_name(app_name)
-			elif mb.pressed:
-				is_dragging = true
-				drag_offset = mb.position
-			else:
-				if is_dragging:
-					is_dragging = false
-					DesktopLayoutManager.move_item(item_id, global_position)
-	elif event is InputEventMouseMotion:
-		if is_dragging:
-			global_position = get_global_mouse_position() - drag_offset
+    if event is InputEventMouseButton:
+        var mb: InputEventMouseButton = event
+        if mb.button_index == MOUSE_BUTTON_LEFT:
+            if mb.double_click and mb.pressed:
+                _open_app()
+            elif mb.pressed:
+                is_dragging = true
+                drag_offset = mb.position
+            else:
+                if is_dragging:
+                    is_dragging = false
+                    DesktopLayoutManager.move_item(item_id, global_position)
+        elif mb.button_index == MOUSE_BUTTON_RIGHT and mb.pressed:
+            context_menu.position = mb.global_position
+            context_menu.popup()
+    elif event is InputEventMouseMotion:
+        if is_dragging:
+            global_position = get_global_mouse_position() - drag_offset
+
+func _open_app() -> void:
+    var item := DesktopLayoutManager.get_item(item_id)
+    var data = item.get("data", {})
+    if data is Dictionary and data.size() > 0:
+        WindowManager.launch_app_by_name(app_name, item_id)
+    else:
+        WindowManager.launch_app_by_name(app_name)
+
+func _on_context_menu_id_pressed(id: int) -> void:
+    match id:
+        0:
+            _open_app()
+        1:
+            DesktopLayoutManager.delete_item(item_id)

--- a/components/desktop/app_shortcut.tscn
+++ b/components/desktop/app_shortcut.tscn
@@ -26,3 +26,6 @@ offset_top = 64.0
 offset_right = 64.0
 offset_bottom = 87.0
 horizontal_alignment = 1
+
+[node name="ContextMenu" type="PopupMenu" parent="."]
+unique_name_in_owner = true


### PR DESCRIPTION
## Summary
- allow app shortcuts to show a popup menu with Open and Delete options
- enable launching apps or removing shortcuts from the desktop

## Testing
- `godot4 --headless -s tests/test_runner.gd` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b854e2db64832596adaffef7f5b7d9