### PR TITLE
feat: add persistent app ownership and storefront listings

### DIFF
--- a/autoloads/player_manager.gd
+++ b/autoloads/player_manager.gd
@@ -103,14 +103,15 @@ var default_user_data: Dictionary = {
 		# Daterbase Headhunters
 		"hh_open_fumble_cost": 10,
 
-		# Flags and progression
-			   "unlocked_perks": [],
-			   "seen_dialogue_ids": [],
-			   "global_rng_seed": 0,
-			   "using_random_seed": false,
-		# Background shader settings
-		"background_shaders": DEFAULT_BACKGROUND_SHADERS.duplicate(true),
-		}
+                # Flags and progression
+                           "unlocked_perks": [],
+                           "seen_dialogue_ids": [],
+                           "owned_apps": ["SoftWares", "OwerView", "SigmaMail"],
+                           "global_rng_seed": 0,
+                           "using_random_seed": false,
+                # Background shader settings
+                "background_shaders": DEFAULT_BACKGROUND_SHADERS.duplicate(true),
+                }
 
 var user_data: Dictionary = default_user_data.duplicate(true)
 

--- a/components/apps/installer/installer.gd
+++ b/components/apps/installer/installer.gd
@@ -47,9 +47,8 @@ func _on_install_button_pressed() -> void:
 	tween.tween_callback(Callable(self, "_complete_install"))
 
 func _complete_install() -> void:
-	if app_id != "":
-		WindowManager.unlock_app(app_id)
-	WindowManager.register_start_app(app_title)
+        if app_id != "":
+                WindowManager.unlock_app(app_id)
 	if shortcut_checkbox.button_pressed:
 		DesktopLayoutManager.create_app_shortcut(app_title, app_title, icon_path, Vector2.ZERO)
 	var window = get_parent().get_parent().get_parent()

--- a/components/apps/soft_wares/soft_wares_app.gd
+++ b/components/apps/soft_wares/soft_wares_app.gd
@@ -3,77 +3,35 @@ class_name SoftWaresApp
 
 const SOFTWARE_ITEM_SCENE: PackedScene = preload("res://components/apps/soft_wares/soft_ware_item.tscn")
 
-var soft_wares_registry: Dictionary = {
-				"minerr": {
-								"title": "Minerr",
-								"description": "Mine and trade cryptocurrencies.",
-								"icon": preload("res://assets/cursors/pickaxe.png"),
-								"cost": 5
-				},
-				"brokerage": {
-								"title": "BrokeRage",
-								"description": "Buy and sell stocks in a chaotic market.",
-								"icon": preload("res://assets/logos/brokerage.png"),
-								"cost": 5
-				},
-				"fumble": {
-								"title": "Fumble",
-								"description": "Date, swipe, and battle for love.",
-								"icon": preload("res://assets/logos/fumble.png"),
-								"cost": 5
-				},
-				"earlybird": {
-								"title": "EarlyBird",
-								"description": "Rise early and get that worm.",
-								"icon": preload("res://assets/early_bird/worm1.png"),
-								"cost": 5
-				}
-}
-
 @onready var items_container: VBoxContainer = %ItemsContainer
 
 func _ready() -> void:
 	_populate_items()
 
 func _populate_items() -> void:
-				var used_icons: Dictionary = {}
-				for app_id in soft_wares_registry.keys():
-								var data: Dictionary = soft_wares_registry[app_id]
-								var icon: Texture2D = data["icon"]
-								var icon_path: String = icon.resource_path
-								if used_icons.has(icon_path):
-												continue
-								used_icons[icon_path] = true
-								var item: SoftWareItem = SOFTWARE_ITEM_SCENE.instantiate() as SoftWareItem
-								item.app_icon = icon
-								item.app_title = data["title"]
-								item.app_description = data["description"]
-								item.app_cost = int(data["cost"])
-								item.app_id = app_id
-								item.upgrade_scene = _get_upgrade_scene(app_id)
-								items_container.add_child(item)
+                                var used_icons: Dictionary = {}
+                                var exclude := ["SoftWares", "OwerView", "SigmaMail", "Installer"]
+                                for app_name in WindowManager.app_registry.keys():
+                                                if app_name in exclude:
+                                                                continue
+                                                var scene: PackedScene = WindowManager.app_registry[app_name]
+                                                var pane = scene.instantiate()
+                                                if not (pane is Pane):
+                                                                pane.queue_free()
+                                                                continue
+                                                var icon: Texture2D = pane.window_icon
+                                                var icon_path: String = icon.resource_path if icon else ""
+                                                if used_icons.has(icon_path):
+                                                                pane.queue_free()
+                                                                continue
+                                                used_icons[icon_path] = true
+                                                var item: SoftWareItem = SOFTWARE_ITEM_SCENE.instantiate() as SoftWareItem
+                                                item.app_icon = icon
+                                                item.app_title = pane.window_title
+                                                item.app_description = ""
+                                                item.app_cost = 5
+                                                item.app_id = app_name.to_lower()
+                                                item.upgrade_scene = pane.upgrade_pane
+                                                items_container.add_child(item)
+                                                pane.queue_free()
 
-func _get_upgrade_scene(app_id: String) -> PackedScene:
-
-	var mapping: Dictionary = {
-			"minerr": "Minerr",
-			"brokerage": "BrokeRage",
-			"fumble": "Fumble",
-			"earlybird": "EarlyBird"
-	}
-	var app_name: String = mapping.get(app_id, app_id)
-	var scene: PackedScene = null
-
-	var wm := get_tree().root.get_node("WindowManager")
-	if wm:
-			var registry = wm.get("app_registry")
-			if registry is Dictionary:
-					scene = registry.get(app_name)
-
-	if scene:
-			var pane := scene.instantiate() as Pane
-			if pane:
-					var upgrade_scene: PackedScene = pane.upgrade_pane
-					pane.queue_free()
-					return upgrade_scene
-	return null

--- a/components/start_panel_window.gd
+++ b/components/start_panel_window.gd
@@ -45,7 +45,7 @@ func _ready() -> void:
 			)
 
 		app_list_container.add_child(button)
-		preview.queue_free()
+                preview.queue_free()
 
 func add_app_button(app_name: String) -> void:
 	if not WindowManager.start_apps.has(app_name):
@@ -73,8 +73,14 @@ func add_app_button(app_name: String) -> void:
 	button.pressed.connect(func():
 			launch_app(app_name)
 	)
-	app_list_container.add_child(button)
-	preview.queue_free()
+        app_list_container.add_child(button)
+        preview.queue_free()
+
+func rebuild() -> void:
+        for child in app_list_container.get_children():
+                child.queue_free()
+        for app_name in WindowManager.start_apps.keys():
+                add_app_button(app_name)
 
 
 func _input(event: InputEvent) -> void:


### PR DESCRIPTION
## Summary
- persist owned apps in player data and restore start menu
- dynamically list all apps for sale in Soft Wares and handle purchases
- add rebuildable Start menu for newly installed apps

## Testing
- `godot3 --headless -s tests/test_runner.gd` *(fails: project requires newer Godot)*

------
https://chatgpt.com/codex/tasks/task_e_68b854a3fb088325ad02f54fa733a719