### PR TITLE
Expose app details for Soft Wares

### DIFF
--- a/components/apps/soft_wares/soft_wares_app.gd
+++ b/components/apps/soft_wares/soft_wares_app.gd
@@ -27,12 +27,12 @@ func _populate_items() -> void:
 			pane.queue_free()
 			continue
 		used_icons[icon_path] = true
-		var item: SoftWareItem = SOFTWARE_ITEM_SCENE.instantiate() as SoftWareItem
-		item.app_icon = icon
-		item.app_title = pane.window_title
-		item.app_description = ""
-		item.app_cost = 5
-		item.app_id = app_name.to_lower()
-		item.upgrade_scene = pane.upgrade_pane
-		items_container.add_child(item)
-		pane.queue_free()
+                var item: SoftWareItem = SOFTWARE_ITEM_SCENE.instantiate() as SoftWareItem
+                item.app_icon = icon
+                item.app_title = pane.window_title
+                item.app_description = pane.app_description
+                item.app_cost = pane.app_cost
+                item.app_id = app_name.to_lower()
+                item.upgrade_scene = pane.upgrade_pane
+                items_container.add_child(item)
+                pane.queue_free()

--- a/components/windows/pane.gd
+++ b/components/windows/pane.gd
@@ -9,9 +9,11 @@ signal window_icon_changed(new_icon)
 		window_title = value
 		window_title_changed.emit(value)
 @export var window_icon: Texture :
-	set(value):
-		window_icon = value
-		window_icon_changed.emit(value)
+        set(value):
+                window_icon = value
+                window_icon_changed.emit(value)
+@export var app_description: String = ""
+@export var app_cost: int = 0
 @export var default_window_size: Vector2 = Vector2(400, 480)
 @export_enum("left", "center", "right") var default_position: String = "center"
 


### PR DESCRIPTION
## Summary
- export `app_description` and `app_cost` in `Pane`
- populate Soft Wares items using each app's description and cost

## Testing
- `godot3 --headless -s tests/test_runner.gd` *(fails: Can't open project at '/workspace/SigmaSim/project.godot', its `config_version` (5) is from a more recent and incompatible version of the engine)*

------
https://chatgpt.com/codex/tasks/task_e_68b85c30def48325b5cd9caf39ffec11