### PR TITLE
Fix oversized app shortcut context menu

### DIFF
--- a/components/desktop/app_shortcut.gd
+++ b/components/desktop/app_shortcut.gd
@@ -36,6 +36,7 @@ func _on_gui_input(event: InputEvent) -> void:
 					DesktopLayoutManager.move_item(item_id, global_position)
 		elif mb.button_index == MOUSE_BUTTON_RIGHT and mb.pressed:
 			context_menu.position = mb.global_position
+			context_menu.reset_size()
 			context_menu.popup()
 	elif event is InputEventMouseMotion:
 		if is_dragging:


### PR DESCRIPTION
## Summary
- ensure app shortcut context menu resets to correct size before opening

## Testing
- `godot --headless -s tests/test_runner.gd` *(fails: Can't load the script tests/test_runner.gd as it doesn't inherit from SceneTree or MainLoop)*

------
https://chatgpt.com/codex/tasks/task_e_68b85c61bb0483259388ce3bd7fd0109