### PR TITLE
Disable button focus globally

### DIFF
--- a/components/apps/app_scenes/grinderr.tscn
+++ b/components/apps/app_scenes/grinderr.tscn
@@ -85,6 +85,7 @@ theme_override_font_sizes/font_size = 36
 text = "Grinderr"
 
 [node name="HireButton" type="Button" parent="MarginContainer/VBoxContainer"]
+focus_mode = 0
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 8

--- a/components/apps/app_scenes/installer.tscn
+++ b/components/apps/app_scenes/installer.tscn
@@ -42,6 +42,7 @@ unique_name_in_owner = true
 layout_mode = 2
 
 [node name="InstallButton" type="Button" parent="MarginContainer/VBox"]
+focus_mode = 0
 unique_name_in_owner = true
 layout_mode = 2
 text = "Install"

--- a/components/apps/app_scenes/minerr.tscn
+++ b/components/apps/app_scenes/minerr.tscn
@@ -112,11 +112,13 @@ unique_name_in_owner = true
 layout_mode = 2
 
 [node name="SortPropertyOption" type="OptionButton" parent="MarginContainer/VBoxContainer/MineView/HBoxContainer/LeftColumnVBox/SortHBoxContainer"]
+focus_mode = 0
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 3
 
 [node name="SortDirectionButton" type="Button" parent="MarginContainer/VBoxContainer/MineView/HBoxContainer/LeftColumnVBox/SortHBoxContainer"]
+focus_mode = 0
 unique_name_in_owner = true
 layout_mode = 2
 text = " "

--- a/components/apps/app_scenes/settings.tscn
+++ b/components/apps/app_scenes/settings.tscn
@@ -143,6 +143,7 @@ layout_mode = 2
 size_flags_horizontal = 3
 
 [node name="CheckButton" type="CheckButton" parent="Panel/MarginContainer/TabContainer/General/HBoxContainer/VBoxContainer/VBoxContainer2"]
+focus_mode = 0
 visible = false
 layout_mode = 2
 size_flags_horizontal = 4
@@ -157,6 +158,7 @@ focus_mode = 0
 text = "Siggy?"
 
 [node name="CreateAppsFolderButton" type="Button" parent="Panel/MarginContainer/TabContainer/General/HBoxContainer/VBoxContainer/VBoxContainer2"]
+focus_mode = 0
 unique_name_in_owner = true
 layout_mode = 2
 text = "(WIP)"
@@ -227,6 +229,7 @@ layout_mode = 2
 text = "Low"
 
 [node name="BlueWarpColorLowPicker" type="ColorPickerButton" parent="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/BlueWarpContainer/MarginContainer/VBoxContainer/ColorRowLow"]
+focus_mode = 0
 unique_name_in_owner = true
 custom_minimum_size = Vector2(32, 0)
 layout_mode = 2
@@ -239,6 +242,7 @@ layout_mode = 2
 text = "Mid"
 
 [node name="BlueWarpColorMidPicker" type="ColorPickerButton" parent="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/BlueWarpContainer/MarginContainer/VBoxContainer/ColorRowMid"]
+focus_mode = 0
 unique_name_in_owner = true
 custom_minimum_size = Vector2(32, 0)
 layout_mode = 2
@@ -251,6 +255,7 @@ layout_mode = 2
 text = "High"
 
 [node name="BlueWarpColorHighPicker" type="ColorPickerButton" parent="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/BlueWarpContainer/MarginContainer/VBoxContainer/ColorRowHigh"]
+focus_mode = 0
 unique_name_in_owner = true
 custom_minimum_size = Vector2(32, 0)
 layout_mode = 2
@@ -263,6 +268,7 @@ layout_mode = 2
 text = "Flat"
 
 [node name="BlueWarpFlatColorPicker" type="ColorPickerButton" parent="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/BlueWarpContainer/MarginContainer/VBoxContainer/ColorRowFlat"]
+focus_mode = 0
 unique_name_in_owner = true
 custom_minimum_size = Vector2(32, 0)
 layout_mode = 2
@@ -351,6 +357,7 @@ step = 0.001
 value = 0.03
 
 [node name="BlueWarpResetButton" type="Button" parent="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/BlueWarpContainer/MarginContainer/VBoxContainer"]
+focus_mode = 0
 layout_mode = 2
 text = "Reset"
 
@@ -383,11 +390,13 @@ text = "   Waves"
 layout_mode = 2
 
 [node name="BottomColorPicker" type="ColorPickerButton" parent="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/WavesContainer/MarginContainer/VBoxContainer/HBoxContainer"]
+focus_mode = 0
 unique_name_in_owner = true
 custom_minimum_size = Vector2(16, 16)
 layout_mode = 2
 
 [node name="TopColorPicker" type="ColorPickerButton" parent="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/WavesContainer/MarginContainer/VBoxContainer/HBoxContainer"]
+focus_mode = 0
 unique_name_in_owner = true
 custom_minimum_size = Vector2(16, 16)
 layout_mode = 2
@@ -455,6 +464,7 @@ min_value = 2.0
 value = 6.0
 
 [node name="WavesResetButton" type="Button" parent="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/WavesContainer/MarginContainer/VBoxContainer"]
+focus_mode = 0
 layout_mode = 2
 text = "Reset"
 
@@ -487,11 +497,13 @@ text = "   Electric"
 layout_mode = 2
 
 [node name="ElectricBGColorPicker" type="ColorPickerButton" parent="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/ElectricContainer/MarginContainer/VBoxContainer/HBoxContainer"]
+focus_mode = 0
 unique_name_in_owner = true
 custom_minimum_size = Vector2(16, 16)
 layout_mode = 2
 
 [node name="ElectricLineColorPicker" type="ColorPickerButton" parent="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/ElectricContainer/MarginContainer/VBoxContainer/HBoxContainer"]
+focus_mode = 0
 unique_name_in_owner = true
 custom_minimum_size = Vector2(16, 16)
 layout_mode = 2
@@ -575,6 +587,7 @@ step = 0.01
 value = 15.43
 
 [node name="ElectricResetButton" type="Button" parent="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer/ElectricContainer/MarginContainer/VBoxContainer"]
+focus_mode = 0
 layout_mode = 2
 text = "Reset"
 
@@ -614,6 +627,7 @@ layout_mode = 2
 text = "Color"
 
 [node name="ComicDots1ColorPicker" type="ColorPickerButton" parent="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer2/ComicDotsContainer/MarginContainer/HBoxContainer4/VBoxContainer/HBoxContainer"]
+focus_mode = 0
 unique_name_in_owner = true
 custom_minimum_size = Vector2(16, 16)
 layout_mode = 2
@@ -649,6 +663,7 @@ step = 0.01
 value = 0.1
 
 [node name="ComicDots1ResetButton" type="Button" parent="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer2/ComicDotsContainer/MarginContainer/HBoxContainer4/VBoxContainer"]
+focus_mode = 0
 unique_name_in_owner = true
 layout_mode = 2
 text = "Reset"
@@ -671,6 +686,7 @@ layout_mode = 2
 text = "Color"
 
 [node name="ComicDots2ColorPicker" type="ColorPickerButton" parent="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer2/ComicDotsContainer/MarginContainer/HBoxContainer4/VBoxContainer2/HBoxContainer"]
+focus_mode = 0
 unique_name_in_owner = true
 custom_minimum_size = Vector2(16, 16)
 layout_mode = 2
@@ -706,6 +722,7 @@ step = 0.01
 value = 0.1
 
 [node name="ComicDots2ResetButton" type="Button" parent="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer2/ComicDotsContainer/MarginContainer/HBoxContainer4/VBoxContainer2"]
+focus_mode = 0
 unique_name_in_owner = true
 layout_mode = 2
 text = "Reset"
@@ -746,11 +763,13 @@ text = "   Flat"
 layout_mode = 2
 
 [node name="FlatColorPicker" type="ColorPickerButton" parent="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer2/FlatColorContainer/MarginContainer/VBoxContainer/HBoxContainer"]
+focus_mode = 0
 unique_name_in_owner = true
 custom_minimum_size = Vector2(16, 16)
 layout_mode = 2
 
 [node name="FlatColorResetButton" type="Button" parent="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer2/FlatColorContainer/MarginContainer/VBoxContainer"]
+focus_mode = 0
 layout_mode = 2
 text = "Reset"
 
@@ -784,6 +803,7 @@ theme_override_styles/normal = SubResource("StyleBoxFlat_dij2h")
 text = "   Image"
 
 [node name="BackgroundSelectImageButton" type="Button" parent="Panel/MarginContainer/TabContainer/Backgrounds/MarginContainer/VBoxContainer/HBoxContainer2/BackgroundContainer/MarginContainer/VBoxContainer"]
+focus_mode = 0
 unique_name_in_owner = true
 layout_mode = 2
 text = "Select Image"

--- a/components/apps/app_scenes/sigma_mail.tscn
+++ b/components/apps/app_scenes/sigma_mail.tscn
@@ -76,6 +76,7 @@ size_flags_horizontal = 3
 placeholder_text = "Search"
 
 [node name="LimitOption" type="OptionButton" parent="HBoxContainer/Panel/MarginContainer/VBox/Controls"]
+focus_mode = 0
 unique_name_in_owner = true
 layout_mode = 2
 
@@ -94,6 +95,7 @@ layout_mode = 2
 size_flags_horizontal = 3
 
 [node name="PrevButton" type="Button" parent="HBoxContainer/Panel/MarginContainer/VBox/Pagination"]
+focus_mode = 0
 unique_name_in_owner = true
 layout_mode = 2
 text = "Prev"
@@ -104,6 +106,7 @@ layout_mode = 2
 text = "Page 1/1"
 
 [node name="NextButton" type="Button" parent="HBoxContainer/Panel/MarginContainer/VBox/Pagination"]
+focus_mode = 0
 unique_name_in_owner = true
 layout_mode = 2
 text = "Next"

--- a/components/apps/daterbase/daterbase.tscn
+++ b/components/apps/daterbase/daterbase.tscn
@@ -198,6 +198,7 @@ size_flags_vertical = 3
 placeholder_text = "Enter a SELECT query, like \"SELECT * FROM npc\""
 
 [node name="RunQueryButton" type="Button" parent="MarginContainer/VBox/MainHBox/ContentArea/SQLView/QueryHBox"]
+focus_mode = 0
 unique_name_in_owner = true
 layout_mode = 2
 text = " Run "
@@ -234,6 +235,7 @@ size_flags_horizontal = 3
 placeholder_text = "Enter full name"
 
 [node name="HHCreateButton" type="Button" parent="MarginContainer/VBox/MainHBox/ContentArea/HeadhuntersView/HHInputHBox"]
+focus_mode = 0
 unique_name_in_owner = true
 layout_mode = 2
 text = "Find"
@@ -260,6 +262,7 @@ size_flags_horizontal = 3
 size_flags_vertical = 3
 
 [node name="HHOpenFumbleButton" type="Button" parent="MarginContainer/VBox/MainHBox/ContentArea/HeadhuntersView"]
+focus_mode = 0
 unique_name_in_owner = true
 layout_mode = 2
 text = "Open in Fumble"

--- a/components/apps/fumble/chat_battle_button.tscn
+++ b/components/apps/fumble/chat_battle_button.tscn
@@ -6,6 +6,7 @@
 bg_color = Color(0.6, 0.6, 0.6, 0.0941176)
 
 [node name="ChatBattleButton" type="Button"]
+focus_mode = 0
 custom_minimum_size = Vector2(0, 36)
 theme_override_colors/font_outline_color = Color(0, 0, 0, 1)
 theme_override_constants/outline_size = 2

--- a/components/apps/fumble/chats_tab.tscn
+++ b/components/apps/fumble/chats_tab.tscn
@@ -63,6 +63,7 @@ size_flags_horizontal = 3
 size_flags_vertical = 3
 
 [node name="MatchesSort" type="OptionButton" parent="MarginContainer/PanelContainer/MarginContainer/VBoxContainer/MarginContainer/MatchesHBox"]
+focus_mode = 0
 unique_name_in_owner = true
 layout_mode = 2
 
@@ -100,6 +101,7 @@ size_flags_horizontal = 3
 size_flags_vertical = 3
 
 [node name="ChatBattlesSort" type="OptionButton" parent="MarginContainer/PanelContainer/MarginContainer/VBoxContainer/ChatBattlesVBox"]
+focus_mode = 0
 unique_name_in_owner = true
 layout_mode = 2
 

--- a/components/apps/fumble/fumble.tscn
+++ b/components/apps/fumble/fumble.tscn
@@ -284,6 +284,7 @@ size_flags_horizontal = 6
 text = "X"
 
 [node name="CheckButton" type="CheckButton" parent="MarginContainer/VBoxContainer/SelfTab/MarginContainer/ScrollContainer/VBoxContainer2/VBoxContainer/FumbleSearchCriteriaContainer/HBoxContainer99"]
+focus_mode = 0
 visible = false
 layout_mode = 2
 size_flags_horizontal = 0
@@ -488,6 +489,7 @@ theme_override_font_sizes/font_size = 20
 text = "+ 1.0 🔥to your dime status. "
 
 [node name="Button" type="Button" parent="MarginContainer/VBoxContainer/SelfTab/MarginContainer/ScrollContainer/VBoxContainer2/FumbleShopContainer/MarginContainer/ScrollContainer/VBoxContainer/TurkishHairSurgery/MarginContainer/VBoxContainer"]
+focus_mode = 0
 layout_mode = 2
 size_flags_horizontal = 4
 size_flags_vertical = 8
@@ -620,6 +622,7 @@ layout_mode = 2
 size_flags_horizontal = 6
 
 [node name="SelfButton" type="Button" parent="MarginContainer/VBoxContainer/MenuTabContainer/HBoxContainer"]
+focus_mode = 0
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 4
@@ -630,6 +633,7 @@ text = " You "
 flat = true
 
 [node name="SwipesButton" type="Button" parent="MarginContainer/VBoxContainer/MenuTabContainer/HBoxContainer"]
+focus_mode = 0
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 4
@@ -640,6 +644,7 @@ text = " Swipe "
 flat = true
 
 [node name="ChatsButton" type="Button" parent="MarginContainer/VBoxContainer/MenuTabContainer/HBoxContainer"]
+focus_mode = 0
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 4

--- a/components/apps/fumble/fumble_battle/battle_ui.tscn
+++ b/components/apps/fumble/fumble_battle/battle_ui.tscn
@@ -701,6 +701,7 @@ none_label_color = null
 label_color = null
 
 [node name="CloseFumbleProfileButton" type="Button" parent="ProfileCenterContainer/FumbleProfile"]
+focus_mode = 0
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 8

--- a/components/apps/fumble/fumble_match_profile.tscn
+++ b/components/apps/fumble/fumble_match_profile.tscn
@@ -76,6 +76,7 @@ size_flags_vertical = 3
 mouse_filter = 2
 
 [node name="CloseFumbleProfileButton" type="Button" parent="MarginContainer/VBoxContainer/MarginContainer"]
+focus_mode = 0
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 0
@@ -92,6 +93,7 @@ size_flags_vertical = 8
 mouse_filter = 2
 
 [node name="BlockButton" type="Button" parent="MarginContainer/VBoxContainer/MarginContainer/HBoxContainer"]
+focus_mode = 0
 visible = false
 custom_minimum_size = Vector2(0, 32)
 layout_mode = 2
@@ -100,6 +102,7 @@ size_flags_vertical = 8
 text = " CHAT "
 
 [node name="ChatButton" type="Button" parent="MarginContainer/VBoxContainer/MarginContainer/HBoxContainer"]
+focus_mode = 0
 unique_name_in_owner = true
 material = SubResource("ShaderMaterial_545u1")
 custom_minimum_size = Vector2(0, 32)

--- a/components/apps/fumble/fumble_special_offers.tscn
+++ b/components/apps/fumble/fumble_special_offers.tscn
@@ -87,6 +87,7 @@ theme_override_colors/font_color = Color(0, 0, 0, 1)
 text = "Confidence Boost: $10"
 
 [node name="Button" type="Button" parent="MarginContainer/VBoxContainer/VBoxContainer/SpecialOfferUI/MarginContainer"]
+focus_mode = 0
 layout_mode = 2
 size_flags_horizontal = 8
 size_flags_vertical = 10

--- a/components/apps/fumble/match_button.tscn
+++ b/components/apps/fumble/match_button.tscn
@@ -5,6 +5,7 @@
 [ext_resource type="PackedScene" uid="uid://drm1apbdsjj5g" path="res://components/portrait/portrait_view.tscn" id="3_dvkw6"]
 
 [node name="MatchButton" type="Button"]
+focus_mode = 0
 custom_minimum_size = Vector2(128, 128)
 icon = ExtResource("1_jare7")
 icon_alignment = 1

--- a/components/apps/lifestylist/lifestyle_row.tscn
+++ b/components/apps/lifestylist/lifestyle_row.tscn
@@ -18,6 +18,7 @@ layout_mode = 2
 text = "Category"
 
 [node name="Dropdown" type="OptionButton" parent="."]
+focus_mode = 0
 unique_name_in_owner = true
 layout_mode = 2
 theme_override_font_sizes/font_size = 14

--- a/components/apps/ower_view/debt_card_ui.tscn
+++ b/components/apps/ower_view/debt_card_ui.tscn
@@ -82,6 +82,7 @@ size_flags_horizontal = 3
 text = "$0.00"
 
 [node name="PayButton" type="Button" parent="MarginContainer/VBox"]
+focus_mode = 0
 unique_name_in_owner = true
 layout_mode = 2
 text = "Pay Off Debt"
@@ -105,6 +106,7 @@ horizontal_alignment = 2
 vertical_alignment = 1
 
 [node name="BorrowButton" type="Button" parent="MarginContainer/VBox/BorrowHBox"]
+focus_mode = 0
 unique_name_in_owner = true
 layout_mode = 2
 text = "Borrow"

--- a/components/apps/sigma_mail/email_view.gd
+++ b/components/apps/sigma_mail/email_view.gd
@@ -19,11 +19,11 @@ func setup(email_res: EmailResource) -> void:
 	for child in button_container.get_children():
 		child.queue_free()
 	for action in email.buttons:
-                var btn := Button.new()
-                btn.text = action.get("text", "Action")
-                btn.focus_mode = Control.FOCUS_NONE
-                btn.pressed.connect(func(): _on_email_action(action))
-                button_container.add_child(btn)
+		var btn := Button.new()
+		btn.text = action.get("text", "Action")
+		btn.focus_mode = Control.FOCUS_NONE
+		btn.pressed.connect(func(): _on_email_action(action))
+		button_container.add_child(btn)
 
 func _on_email_action(action: Dictionary) -> void:
 	for stat in action.get("stat_changes", {}).keys():

--- a/components/apps/sigma_mail/email_view.gd
+++ b/components/apps/sigma_mail/email_view.gd
@@ -19,10 +19,11 @@ func setup(email_res: EmailResource) -> void:
 	for child in button_container.get_children():
 		child.queue_free()
 	for action in email.buttons:
-		var btn := Button.new()
-		btn.text = action.get("text", "Action")
-		btn.pressed.connect(func(): _on_email_action(action))
-		button_container.add_child(btn)
+                var btn := Button.new()
+                btn.text = action.get("text", "Action")
+                btn.focus_mode = Control.FOCUS_NONE
+                btn.pressed.connect(func(): _on_email_action(action))
+                button_container.add_child(btn)
 
 func _on_email_action(action: Dictionary) -> void:
 	for stat in action.get("stat_changes", {}).keys():

--- a/components/apps/sigma_mail/sigma_mail.gd
+++ b/components/apps/sigma_mail/sigma_mail.gd
@@ -77,14 +77,14 @@ func _render_emails() -> void:
 		var box := VBoxContainer.new()
 		inbox.add_child(box)
 
-                var btn := Button.new()
-                btn.flat = true
-                btn.alignment = HORIZONTAL_ALIGNMENT_LEFT
-                btn.add_theme_font_size_override("14", 14)
-                btn.text = "From: %s  Subject: %s" % [email.from, email.subject]
-                btn.focus_mode = Control.FOCUS_NONE
-                btn.pressed.connect(func(): _open_email(email))
-                box.add_child(btn)
+		var btn := Button.new()
+		btn.flat = true
+		btn.alignment = HORIZONTAL_ALIGNMENT_LEFT
+		btn.add_theme_font_size_override("14", 14)
+		btn.text = "From: %s  Subject: %s" % [email.from, email.subject]
+		btn.focus_mode = Control.FOCUS_NONE
+		btn.pressed.connect(func(): _open_email(email))
+		box.add_child(btn)
 
 	var total_pages = max(1, int(ceil(filtered_emails.size() / float(emails_per_page))))
 	page_label.text = "Page %d/%d" % [current_page + 1, total_pages]

--- a/components/apps/sigma_mail/sigma_mail.gd
+++ b/components/apps/sigma_mail/sigma_mail.gd
@@ -77,13 +77,14 @@ func _render_emails() -> void:
 		var box := VBoxContainer.new()
 		inbox.add_child(box)
 
-		var btn := Button.new()
-		btn.flat = true
-		btn.alignment = HORIZONTAL_ALIGNMENT_LEFT
-		btn.add_theme_font_size_override("14", 14)
-		btn.text = "From: %s  Subject: %s" % [email.from, email.subject]
-		btn.pressed.connect(func(): _open_email(email))
-		box.add_child(btn)
+                var btn := Button.new()
+                btn.flat = true
+                btn.alignment = HORIZONTAL_ALIGNMENT_LEFT
+                btn.add_theme_font_size_override("14", 14)
+                btn.text = "From: %s  Subject: %s" % [email.from, email.subject]
+                btn.focus_mode = Control.FOCUS_NONE
+                btn.pressed.connect(func(): _open_email(email))
+                box.add_child(btn)
 
 	var total_pages = max(1, int(ceil(filtered_emails.size() / float(emails_per_page))))
 	page_label.text = "Page %d/%d" % [current_page + 1, total_pages]

--- a/components/apps/tarot/card_collection_examiner.tscn
+++ b/components/apps/tarot/card_collection_examiner.tscn
@@ -35,6 +35,7 @@ unique_name_in_owner = true
 layout_mode = 2
 
 [node name="CloseButton" type="Button" parent="Panel/MarginContainer/VBox"]
+focus_mode = 0
 unique_name_in_owner = true
 layout_mode = 2
 text = "Close"

--- a/components/apps/terminal/terminal.tscn
+++ b/components/apps/terminal/terminal.tscn
@@ -51,6 +51,7 @@ size_flags_horizontal = 3
 placeholder_text = "Ayudame"
 
 [node name="EnterButton" type="Button" parent="PanelContainer/MarginContainer/VBoxContainer/HBoxContainer"]
+focus_mode = 0
 unique_name_in_owner = true
 layout_mode = 2
 text = "Enter"

--- a/components/apps/wallet/wallet_cards/credit_card.gd
+++ b/components/apps/wallet/wallet_cards/credit_card.gd
@@ -53,10 +53,11 @@ func _build() -> void:
 	controls.add_theme_constant_override("separation", 8)
 	controls.size_flags_horizontal = Control.SIZE_EXPAND_FILL
 
-	_autopay_check = CheckBox.new()
-	_autopay_check.text = "Autopay"
-	_autopay_check.button_pressed = _autopay
-	_autopay_check.toggled.connect(_on_autopay_toggled)
+        _autopay_check = CheckBox.new()
+        _autopay_check.text = "Autopay"
+        _autopay_check.button_pressed = _autopay
+        _autopay_check.focus_mode = Control.FOCUS_NONE
+        _autopay_check.toggled.connect(_on_autopay_toggled)
 	controls.add_child(_autopay_check)
 
 	_pay_slider = HSlider.new()
@@ -71,9 +72,10 @@ func _build() -> void:
 	_pay_label.text = "$" + String.num(_pay_slider.value, 2)
 	controls.add_child(_pay_label)
 
-	_pay_button = Button.new()
-	_pay_button.text = "Pay"
-	_pay_button.pressed.connect(_on_pay_pressed)
+        _pay_button = Button.new()
+        _pay_button.text = "Pay"
+        _pay_button.focus_mode = Control.FOCUS_NONE
+        _pay_button.pressed.connect(_on_pay_pressed)
 	controls.add_child(_pay_button)
 
 	_content.add_child(controls)

--- a/components/apps/wallet/wallet_cards/credit_card.gd
+++ b/components/apps/wallet/wallet_cards/credit_card.gd
@@ -53,11 +53,11 @@ func _build() -> void:
 	controls.add_theme_constant_override("separation", 8)
 	controls.size_flags_horizontal = Control.SIZE_EXPAND_FILL
 
-        _autopay_check = CheckBox.new()
-        _autopay_check.text = "Autopay"
-        _autopay_check.button_pressed = _autopay
-        _autopay_check.focus_mode = Control.FOCUS_NONE
-        _autopay_check.toggled.connect(_on_autopay_toggled)
+	_autopay_check = CheckBox.new()
+	_autopay_check.text = "Autopay"
+	_autopay_check.button_pressed = _autopay
+	_autopay_check.focus_mode = Control.FOCUS_NONE
+	_autopay_check.toggled.connect(_on_autopay_toggled)
 	controls.add_child(_autopay_check)
 
 	_pay_slider = HSlider.new()
@@ -72,10 +72,10 @@ func _build() -> void:
 	_pay_label.text = "$" + String.num(_pay_slider.value, 2)
 	controls.add_child(_pay_label)
 
-        _pay_button = Button.new()
-        _pay_button.text = "Pay"
-        _pay_button.focus_mode = Control.FOCUS_NONE
-        _pay_button.pressed.connect(_on_pay_pressed)
+	_pay_button = Button.new()
+	_pay_button.text = "Pay"
+	_pay_button.focus_mode = Control.FOCUS_NONE
+	_pay_button.pressed.connect(_on_pay_pressed)
 	controls.add_child(_pay_button)
 
 	_content.add_child(controls)

--- a/components/apps/wallet/wallet_cards/student_loan_card.gd
+++ b/components/apps/wallet/wallet_cards/student_loan_card.gd
@@ -36,11 +36,11 @@ func _build() -> void:
 	controls.size_flags_horizontal = Control.SIZE_EXPAND_FILL
 
 
-        _autopay_check = CheckBox.new()
-        _autopay_check.text = "Autopay"
-        _autopay_check.button_pressed = _autopay
-        _autopay_check.focus_mode = Control.FOCUS_NONE
-        _autopay_check.toggled.connect(_on_autopay_toggled)
+	_autopay_check = CheckBox.new()
+	_autopay_check.text = "Autopay"
+	_autopay_check.button_pressed = _autopay
+	_autopay_check.focus_mode = Control.FOCUS_NONE
+	_autopay_check.toggled.connect(_on_autopay_toggled)
 	controls.add_child(_autopay_check)
 
 	_pay_slider = HSlider.new()
@@ -55,10 +55,10 @@ func _build() -> void:
 	_pay_label.text = "$" + String.num(_pay_slider.value, 2)
 	controls.add_child(_pay_label)
 
-        _pay_button = Button.new()
-        _pay_button.text = "Pay Early"
-        _pay_button.focus_mode = Control.FOCUS_NONE
-        _pay_button.pressed.connect(_on_pay_pressed)
+	_pay_button = Button.new()
+	_pay_button.text = "Pay Early"
+	_pay_button.focus_mode = Control.FOCUS_NONE
+	_pay_button.pressed.connect(_on_pay_pressed)
 	controls.add_child(_pay_button)
 
 	if _content != null:

--- a/components/apps/wallet/wallet_cards/student_loan_card.gd
+++ b/components/apps/wallet/wallet_cards/student_loan_card.gd
@@ -36,10 +36,11 @@ func _build() -> void:
 	controls.size_flags_horizontal = Control.SIZE_EXPAND_FILL
 
 
-	_autopay_check = CheckBox.new()
-	_autopay_check.text = "Autopay"
-	_autopay_check.button_pressed = _autopay
-	_autopay_check.toggled.connect(_on_autopay_toggled)
+        _autopay_check = CheckBox.new()
+        _autopay_check.text = "Autopay"
+        _autopay_check.button_pressed = _autopay
+        _autopay_check.focus_mode = Control.FOCUS_NONE
+        _autopay_check.toggled.connect(_on_autopay_toggled)
 	controls.add_child(_autopay_check)
 
 	_pay_slider = HSlider.new()
@@ -54,9 +55,10 @@ func _build() -> void:
 	_pay_label.text = "$" + String.num(_pay_slider.value, 2)
 	controls.add_child(_pay_label)
 
-	_pay_button = Button.new()
-	_pay_button.text = "Pay Early"
-	_pay_button.pressed.connect(_on_pay_pressed)
+        _pay_button = Button.new()
+        _pay_button.text = "Pay Early"
+        _pay_button.focus_mode = Control.FOCUS_NONE
+        _pay_button.pressed.connect(_on_pay_pressed)
 	controls.add_child(_pay_button)
 
 	if _content != null:

--- a/components/desktop_env.tscn
+++ b/components/desktop_env.tscn
@@ -264,6 +264,7 @@ theme_override_colors/font_color = Color(0, 0, 0, 1)
 text = "you're not supposed to see this"
 
 [node name="Button" type="Button" parent="ColorRect/VBoxContainer"]
+focus_mode = 0
 layout_mode = 2
 theme_override_font_sizes/font_size = 12
 text = "& you wouldn't believe me if i told you what's under it"

--- a/components/desktop_window.tscn
+++ b/components/desktop_window.tscn
@@ -45,6 +45,7 @@ layout_mode = 2
 size_flags_horizontal = 3
 
 [node name="MinimizeButton" type="Button" parent="VBoxContainer/MarginContainer/Header"]
+focus_mode = 0
 layout_mode = 2
 size_flags_vertical = 4
 size_flags_stretch_ratio = 0.0
@@ -52,6 +53,7 @@ theme_override_constants/icon_max_width = 16
 text = "_"
 
 [node name="MaximizeButton" type="Button" parent="VBoxContainer/MarginContainer/Header"]
+focus_mode = 0
 layout_mode = 2
 size_flags_horizontal = 6
 size_flags_vertical = 4
@@ -60,6 +62,7 @@ theme_override_constants/icon_max_width = 16
 text = "□"
 
 [node name="CloseButton" type="Button" parent="VBoxContainer/MarginContainer/Header"]
+focus_mode = 0
 layout_mode = 2
 size_flags_vertical = 4
 size_flags_stretch_ratio = 0.0

--- a/components/popups/calendar_popup_ui.tscn
+++ b/components/popups/calendar_popup_ui.tscn
@@ -124,6 +124,7 @@ layout_mode = 2
 size_flags_horizontal = 8
 
 [node name="LifeStylistButton" type="Button" parent="MarginContainer/VBoxContainer/HBoxContainer2"]
+focus_mode = 0
 unique_name_in_owner = true
 layout_mode = 2
 theme_override_font_sizes/font_size = 12

--- a/components/popups/crypto_popup_ui.tscn
+++ b/components/popups/crypto_popup_ui.tscn
@@ -187,5 +187,6 @@ theme_override_styles/normal = SubResource("StyleBoxTexture_xqhjc")
 text = " SELL "
 
 [node name="QuantityOption" type="OptionButton" parent="MarginContainer/VBoxContainer/HBoxContainer/InfoVBox/ButtonBox"]
+focus_mode = 0
 unique_name_in_owner = true
 layout_mode = 2

--- a/components/popups/ex_factor_view.tscn
+++ b/components/popups/ex_factor_view.tscn
@@ -112,6 +112,7 @@ layout_mode = 2
 layout_mode = 2
 
 [node name="NextStageButton" type="Button" parent="MarginContainer/VBox"]
+focus_mode = 0
 unique_name_in_owner = true
 visible = false
 layout_mode = 2
@@ -302,12 +303,14 @@ size_flags_vertical = 8
 theme_override_constants/separation = 8
 
 [node name="BreakupConfirmYesButton" type="Button" parent="BreakupConfirm/Panel/MarginContainer/VBox/Buttons"]
+focus_mode = 0
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 3
 text = "Yes"
 
 [node name="BreakupConfirmNoButton" type="Button" parent="BreakupConfirm/Panel/MarginContainer/VBox/Buttons"]
+focus_mode = 0
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 3
@@ -349,12 +352,14 @@ layout_mode = 2
 layout_mode = 2
 
 [node name="NextStageConfirmPrimaryButton" type="Button" parent="NextStageConfirm/Panel/MarginContainer/VBox/VBoxContainer"]
+focus_mode = 0
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 3
 text = "Transition"
 
 [node name="NextStageConfirmAltButton" type="Button" parent="NextStageConfirm/Panel/MarginContainer/VBox/VBoxContainer"]
+focus_mode = 0
 unique_name_in_owner = true
 visible = false
 layout_mode = 2
@@ -362,6 +367,7 @@ size_flags_horizontal = 3
 text = "Alt"
 
 [node name="NextStageConfirmNoButton" type="Button" parent="NextStageConfirm/Panel/MarginContainer/VBox/VBoxContainer"]
+focus_mode = 0
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 3

--- a/components/popups/gig_popup.gd
+++ b/components/popups/gig_popup.gd
@@ -136,9 +136,9 @@ func _refresh_workers():
 		var row = HBoxContainer.new()
 		var name = Label.new()
 		name.text = worker.name
-                var remove_button = Button.new()
-                remove_button.text = "Unassign"
-                remove_button.focus_mode = Control.FOCUS_NONE
+		var remove_button = Button.new()
+		remove_button.text = "Unassign"
+		remove_button.focus_mode = Control.FOCUS_NONE
 		remove_button.pressed.connect(func():
 			gig.assigned_workers.erase(worker)
 			WorkerManager.unassign_worker(worker)

--- a/components/popups/gig_popup.gd
+++ b/components/popups/gig_popup.gd
@@ -136,8 +136,9 @@ func _refresh_workers():
 		var row = HBoxContainer.new()
 		var name = Label.new()
 		name.text = worker.name
-		var remove_button = Button.new()
-		remove_button.text = "Unassign"
+                var remove_button = Button.new()
+                remove_button.text = "Unassign"
+                remove_button.focus_mode = Control.FOCUS_NONE
 		remove_button.pressed.connect(func():
 			gig.assigned_workers.erase(worker)
 			WorkerManager.unassign_worker(worker)

--- a/components/popups/stock_popup_ui.tscn
+++ b/components/popups/stock_popup_ui.tscn
@@ -177,5 +177,6 @@ theme_override_styles/normal = SubResource("StyleBoxTexture_67og2")
 text = " SELL "
 
 [node name="QuantityOption" type="OptionButton" parent="MarginContainer/VBoxContainer/HBoxContainer/InfoVBox/ButtonBox"]
+focus_mode = 0
 unique_name_in_owner = true
 layout_mode = 2

--- a/components/portrait/portrait_creator.gd
+++ b/components/portrait/portrait_creator.gd
@@ -43,8 +43,9 @@ func _setup_layers() -> void:
 		var label := Label.new()
 		label.text = "Hair2" if layer == "hair_back" else layer.capitalize()
 		col.add_child(label)
-		var index_btn := OptionButton.new()
-		index_btn.name = "Index"
+                var index_btn := OptionButton.new()
+                index_btn.name = "Index"
+                index_btn.focus_mode = Control.FOCUS_NONE
 		var tex_arr: Array = info.get("textures", [])
 		if layer != "face":
 			index_btn.add_item("0", 0)
@@ -52,14 +53,16 @@ func _setup_layers() -> void:
 			index_btn.add_item(str(i + 1), i + 1)
 		index_btn.item_selected.connect(_on_index_changed.bind(layer))
 		col.add_child(index_btn)
-		var color_btn := ColorPickerButton.new()
-		color_btn.name = "Color"
+                var color_btn := ColorPickerButton.new()
+                color_btn.name = "Color"
+                color_btn.focus_mode = Control.FOCUS_NONE
 		color_btn.custom_minimum_size = Vector2(15, 15)
 		color_btn.color_changed.connect(_on_color_changed.bind(layer))
 		col.add_child(color_btn)
 		if layer == "hair" or layer == "hair_back":
-			var sync_chk := CheckBox.new()
-			sync_chk.name = "Sync"
+                        var sync_chk := CheckBox.new()
+                        sync_chk.name = "Sync"
+                        sync_chk.focus_mode = Control.FOCUS_NONE
 			sync_chk.text = "Sync"
 			sync_chk.add_theme_font_size_override("font_size", 14)
 			sync_chk.button_pressed = hair_color_sync

--- a/components/portrait/portrait_creator.gd
+++ b/components/portrait/portrait_creator.gd
@@ -43,9 +43,9 @@ func _setup_layers() -> void:
 		var label := Label.new()
 		label.text = "Hair2" if layer == "hair_back" else layer.capitalize()
 		col.add_child(label)
-                var index_btn := OptionButton.new()
-                index_btn.name = "Index"
-                index_btn.focus_mode = Control.FOCUS_NONE
+		var index_btn := OptionButton.new()
+		index_btn.name = "Index"
+		index_btn.focus_mode = Control.FOCUS_NONE
 		var tex_arr: Array = info.get("textures", [])
 		if layer != "face":
 			index_btn.add_item("0", 0)
@@ -53,16 +53,16 @@ func _setup_layers() -> void:
 			index_btn.add_item(str(i + 1), i + 1)
 		index_btn.item_selected.connect(_on_index_changed.bind(layer))
 		col.add_child(index_btn)
-                var color_btn := ColorPickerButton.new()
-                color_btn.name = "Color"
-                color_btn.focus_mode = Control.FOCUS_NONE
+		var color_btn := ColorPickerButton.new()
+		color_btn.name = "Color"
+		color_btn.focus_mode = Control.FOCUS_NONE
 		color_btn.custom_minimum_size = Vector2(15, 15)
 		color_btn.color_changed.connect(_on_color_changed.bind(layer))
 		col.add_child(color_btn)
 		if layer == "hair" or layer == "hair_back":
-                        var sync_chk := CheckBox.new()
-                        sync_chk.name = "Sync"
-                        sync_chk.focus_mode = Control.FOCUS_NONE
+			var sync_chk := CheckBox.new()
+			sync_chk.name = "Sync"
+			sync_chk.focus_mode = Control.FOCUS_NONE
 			sync_chk.text = "Sync"
 			sync_chk.add_theme_font_size_override("font_size", 14)
 			sync_chk.button_pressed = hair_color_sync

--- a/components/siggy/siggy.tscn
+++ b/components/siggy/siggy.tscn
@@ -25,6 +25,7 @@ scale = Vector2(0.5, 0.5)
 texture = ExtResource("1_qdwsr")
 
 [node name="TalkButton" type="Button" parent="."]
+focus_mode = 0
 custom_minimum_size = Vector2(20, 20)
 layout_mode = 0
 offset_left = 59.0

--- a/components/ui/hire_popup.tscn
+++ b/components/ui/hire_popup.tscn
@@ -82,6 +82,7 @@ layout_mode = 2
 size_flags_horizontal = 3
 
 [node name="WorkForceButton" type="Button" parent="MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer"]
+focus_mode = 0
 custom_minimum_size = Vector2(150, 0)
 layout_mode = 2
 size_flags_horizontal = 10
@@ -89,6 +90,7 @@ text = "WorkForce"
 icon = ExtResource("2_dvjtp")
 
 [node name="GrinderrButton" type="Button" parent="MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer"]
+focus_mode = 0
 custom_minimum_size = Vector2(150, 0)
 layout_mode = 2
 size_flags_horizontal = 8

--- a/components/ui/log_in_ui.tscn
+++ b/components/ui/log_in_ui.tscn
@@ -302,6 +302,7 @@ theme_override_constants/margin_bottom = 50
 layout_mode = 2
 
 [node name="SettingsButton" type="Button" parent="AOLLogoHolder/MarginContainer/HBoxContainer"]
+focus_mode = 0
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 8

--- a/components/ui/login_settings_panel_container.tscn
+++ b/components/ui/login_settings_panel_container.tscn
@@ -23,21 +23,25 @@ text = "Manage Profiles"
 horizontal_alignment = 1
 
 [node name="ProfileSelector" type="OptionButton" parent="VBoxContainer"]
+focus_mode = 0
 unique_name_in_owner = true
 layout_mode = 2
 
 [node name="DeleteButton" type="Button" parent="VBoxContainer"]
+focus_mode = 0
 unique_name_in_owner = true
 layout_mode = 2
 text = " Delete Selected Profile "
 
 [node name="ResetButton" type="Button" parent="VBoxContainer"]
+focus_mode = 0
 unique_name_in_owner = true
 visible = false
 layout_mode = 2
 text = "Reset Selected Profile"
 
 [node name="CloseButton" type="Button" parent="VBoxContainer"]
+focus_mode = 0
 unique_name_in_owner = true
 layout_mode = 2
 text = "Close Settings"

--- a/components/ui/profile_creation/portrait_creation_screen.tscn
+++ b/components/ui/profile_creation/portrait_creation_screen.tscn
@@ -81,6 +81,7 @@ size_flags_vertical = 0
 size_flags_stretch_ratio = 0.25
 
 [node name="Generate" type="Button" parent="PortraitCreator/MarginContainer/VBox/NameRow/VBoxContainer2"]
+focus_mode = 0
 unique_name_in_owner = true
 layout_mode = 2
 theme_override_font_sizes/font_size = 14

--- a/components/ui/profile_creation/sexuality_entry_screen.tscn
+++ b/components/ui/profile_creation/sexuality_entry_screen.tscn
@@ -136,6 +136,7 @@ layout_mode = 2
 mouse_filter = 2
 
 [node name="QuestionButton" type="Button" parent="MarginContainer/VBoxContainer/HBoxContainer3"]
+focus_mode = 0
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 4

--- a/components/ui/task_card.tscn
+++ b/components/ui/task_card.tscn
@@ -56,6 +56,7 @@ unique_name_in_owner = true
 layout_mode = 2
 
 [node name="Button" type="Button" parent="."]
+focus_mode = 0
 unique_name_in_owner = true
 layout_mode = 2
 flat = true

--- a/components/ui/worker_card/worker_card.tscn
+++ b/components/ui/worker_card/worker_card.tscn
@@ -184,6 +184,7 @@ theme_override_font_sizes/font_size = 12
 text = "Cost"
 
 [node name="ActionButton" type="Button" parent="MarginContainer/WorkerCard"]
+focus_mode = 0
 unique_name_in_owner = true
 custom_minimum_size = Vector2(80, 20)
 layout_mode = 2

--- a/components/ui/worker_card/worker_card_redux.tscn
+++ b/components/ui/worker_card/worker_card_redux.tscn
@@ -93,6 +93,7 @@ theme_override_font_sizes/font_size = 12
 text = "Cost"
 
 [node name="ActionButton" type="Button" parent="MarginContainer/WorkerCard"]
+focus_mode = 0
 unique_name_in_owner = true
 custom_minimum_size = Vector2(80, 20)
 layout_mode = 2

--- a/components/upgrade_scenes/deprecated/upgrade_tree_ui.tscn
+++ b/components/upgrade_scenes/deprecated/upgrade_tree_ui.tscn
@@ -111,6 +111,7 @@ layout_mode = 2
 mouse_filter = 2
 
 [node name="BuyButton" type="Button" parent="MarginContainer/UpgradeTooltip/HBoxContainer/MarginContainer/VBoxContainer"]
+focus_mode = 0
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_vertical = 3
@@ -128,6 +129,7 @@ theme_override_constants/margin_top = 4
 theme_override_constants/margin_right = 4
 
 [node name="CloseButton" type="Button" parent="MarginContainer/UpgradeTooltip/HBoxContainer/MarginContainer2"]
+focus_mode = 0
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 8

--- a/data/upgrades/system_upgrade_ui.tscn
+++ b/data/upgrades/system_upgrade_ui.tscn
@@ -36,6 +36,7 @@ size_flags_horizontal = 3
 size_flags_vertical = 3
 
 [node name="SortOptionButton" type="OptionButton" parent="MarginContainer/ScrollContainer/VBoxContainer"]
+focus_mode = 0
 unique_name_in_owner = true
 layout_mode = 2
 

--- a/tools/upgrade_editor/upgrade_node_editor.tscn
+++ b/tools/upgrade_editor/upgrade_node_editor.tscn
@@ -99,6 +99,7 @@ grow_horizontal = 2
 grow_vertical = 0
 
 [node name="DeleteButton" type="Button" parent="HBoxContainer"]
+focus_mode = 0
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 4
@@ -107,6 +108,7 @@ theme_override_font_sizes/font_size = 10
 text = "X"
 
 [node name="ClearDepsButton" type="Button" parent="HBoxContainer"]
+focus_mode = 0
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 4

--- a/tools/upgrade_editor/upgrade_tree_editor.tscn
+++ b/tools/upgrade_editor/upgrade_tree_editor.tscn
@@ -50,6 +50,7 @@ grow_horizontal = 0
 mouse_filter = 2
 
 [node name="AddNodeButton" type="Button" parent="Toolbar"]
+focus_mode = 0
 unique_name_in_owner = true
 layout_mode = 2
 text = "Add Node"
@@ -60,33 +61,39 @@ layout_mode = 2
 text = "UNSAVED"
 
 [node name="SaveButton" type="Button" parent="Toolbar"]
+focus_mode = 0
 unique_name_in_owner = true
 layout_mode = 2
 text = "Save"
 
 [node name="SaveAsButton" type="Button" parent="Toolbar"]
+focus_mode = 0
 unique_name_in_owner = true
 layout_mode = 2
 text = "Save As"
 
 [node name="LoadButton" type="Button" parent="Toolbar"]
+focus_mode = 0
 unique_name_in_owner = true
 visible = false
 layout_mode = 2
 text = "Load"
 
 [node name="ClearAllButton" type="Button" parent="Toolbar"]
+focus_mode = 0
 unique_name_in_owner = true
 layout_mode = 2
 text = "New"
 
 [node name="LoadButtonFake" type="Button" parent="Toolbar"]
+focus_mode = 0
 unique_name_in_owner = true
 layout_mode = 2
 mouse_filter = 1
 text = "          "
 
 [node name="LoadMenuButton" type="MenuButton" parent="Toolbar/LoadButtonFake"]
+focus_mode = 0
 unique_name_in_owner = true
 layout_mode = 1
 anchors_preset = 15
@@ -115,11 +122,13 @@ layout_mode = 2
 size_flags_horizontal = 3
 
 [node name="UpgradeFolderButton" type="Button" parent="Toolbar"]
+focus_mode = 0
 unique_name_in_owner = true
 layout_mode = 2
 text = "Upgrade Folder"
 
 [node name="AttachUpgradeButton" type="MenuButton" parent="Toolbar"]
+focus_mode = 0
 unique_name_in_owner = true
 layout_mode = 2
 text = "Attach Upgrade"
@@ -142,6 +151,7 @@ unique_name_in_owner = true
 layout_mode = 2
 
 [node name="ConfirmButton" type="Button" parent="SaveAsDialog/VBoxContainer"]
+focus_mode = 0
 unique_name_in_owner = true
 layout_mode = 2
 text = "confirm"

--- a/trash/workforce.tscn
+++ b/trash/workforce.tscn
@@ -239,6 +239,7 @@ size_flags_horizontal = 4
 columns = 3
 
 [node name="Button" type="Button" parent="MarginContainer/HBoxContainer/TabBar/Inc/MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer/Handbook/PanelContainer/MarginContainer/VBoxContainer/GridContainer"]
+focus_mode = 0
 custom_minimum_size = Vector2(150, 0)
 layout_mode = 2
 theme_override_font_sizes/font_size = 10
@@ -247,6 +248,7 @@ More Words About the Upgrade"
 autowrap_mode = 3
 
 [node name="Button2" type="Button" parent="MarginContainer/HBoxContainer/TabBar/Inc/MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer/Handbook/PanelContainer/MarginContainer/VBoxContainer/GridContainer"]
+focus_mode = 0
 custom_minimum_size = Vector2(150, 0)
 layout_mode = 2
 theme_override_font_sizes/font_size = 10
@@ -255,6 +257,7 @@ More Words About the Upgrade"
 autowrap_mode = 3
 
 [node name="Button3" type="Button" parent="MarginContainer/HBoxContainer/TabBar/Inc/MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer/Handbook/PanelContainer/MarginContainer/VBoxContainer/GridContainer"]
+focus_mode = 0
 custom_minimum_size = Vector2(150, 0)
 layout_mode = 2
 theme_override_font_sizes/font_size = 10
@@ -263,6 +266,7 @@ More Words About the Upgrade"
 autowrap_mode = 3
 
 [node name="Button4" type="Button" parent="MarginContainer/HBoxContainer/TabBar/Inc/MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer/Handbook/PanelContainer/MarginContainer/VBoxContainer/GridContainer"]
+focus_mode = 0
 custom_minimum_size = Vector2(150, 0)
 layout_mode = 2
 theme_override_font_sizes/font_size = 10
@@ -271,6 +275,7 @@ More Words About the Upgrade"
 autowrap_mode = 3
 
 [node name="Button5" type="Button" parent="MarginContainer/HBoxContainer/TabBar/Inc/MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer/Handbook/PanelContainer/MarginContainer/VBoxContainer/GridContainer"]
+focus_mode = 0
 custom_minimum_size = Vector2(150, 0)
 layout_mode = 2
 theme_override_font_sizes/font_size = 10
@@ -329,10 +334,12 @@ layout_mode = 2
 text = "Name McNameface"
 
 [node name="Button" type="Button" parent="MarginContainer/HBoxContainer/TabBar/Inc/MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer3/Resumes/PanelContainer/MarginContainer/VBoxContainer/PanelContainer/VBoxContainer/HBoxContainer"]
+focus_mode = 0
 layout_mode = 2
 text = " 👁 "
 
 [node name="Button2" type="Button" parent="MarginContainer/HBoxContainer/TabBar/Inc/MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer3/Resumes/PanelContainer/MarginContainer/VBoxContainer/PanelContainer/VBoxContainer/HBoxContainer"]
+focus_mode = 0
 layout_mode = 2
 text = " Hire "
 
@@ -344,10 +351,12 @@ layout_mode = 2
 text = "Name McNameface"
 
 [node name="Button" type="Button" parent="MarginContainer/HBoxContainer/TabBar/Inc/MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer3/Resumes/PanelContainer/MarginContainer/VBoxContainer/PanelContainer/VBoxContainer/HBoxContainer2"]
+focus_mode = 0
 layout_mode = 2
 text = " 👁 "
 
 [node name="Button2" type="Button" parent="MarginContainer/HBoxContainer/TabBar/Inc/MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer3/Resumes/PanelContainer/MarginContainer/VBoxContainer/PanelContainer/VBoxContainer/HBoxContainer2"]
+focus_mode = 0
 layout_mode = 2
 text = " Hire "
 
@@ -359,10 +368,12 @@ layout_mode = 2
 text = "Name McNameface"
 
 [node name="Button" type="Button" parent="MarginContainer/HBoxContainer/TabBar/Inc/MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer3/Resumes/PanelContainer/MarginContainer/VBoxContainer/PanelContainer/VBoxContainer/HBoxContainer3"]
+focus_mode = 0
 layout_mode = 2
 text = " 👁 "
 
 [node name="Button2" type="Button" parent="MarginContainer/HBoxContainer/TabBar/Inc/MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer3/Resumes/PanelContainer/MarginContainer/VBoxContainer/PanelContainer/VBoxContainer/HBoxContainer3"]
+focus_mode = 0
 layout_mode = 2
 text = " Hire "
 
@@ -374,10 +385,12 @@ layout_mode = 2
 text = "Name McNameface"
 
 [node name="Button" type="Button" parent="MarginContainer/HBoxContainer/TabBar/Inc/MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer3/Resumes/PanelContainer/MarginContainer/VBoxContainer/PanelContainer/VBoxContainer/HBoxContainer4"]
+focus_mode = 0
 layout_mode = 2
 text = " 👁 "
 
 [node name="Button2" type="Button" parent="MarginContainer/HBoxContainer/TabBar/Inc/MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer3/Resumes/PanelContainer/MarginContainer/VBoxContainer/PanelContainer/VBoxContainer/HBoxContainer4"]
+focus_mode = 0
 layout_mode = 2
 text = " Hire "
 
@@ -389,10 +402,12 @@ layout_mode = 2
 text = "Name McNameface"
 
 [node name="Button" type="Button" parent="MarginContainer/HBoxContainer/TabBar/Inc/MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer3/Resumes/PanelContainer/MarginContainer/VBoxContainer/PanelContainer/VBoxContainer/HBoxContainer5"]
+focus_mode = 0
 layout_mode = 2
 text = " 👁 "
 
 [node name="Button2" type="Button" parent="MarginContainer/HBoxContainer/TabBar/Inc/MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer3/Resumes/PanelContainer/MarginContainer/VBoxContainer/PanelContainer/VBoxContainer/HBoxContainer5"]
+focus_mode = 0
 layout_mode = 2
 text = " Hire "
 
@@ -404,10 +419,12 @@ layout_mode = 2
 text = "Name McNameface"
 
 [node name="Button" type="Button" parent="MarginContainer/HBoxContainer/TabBar/Inc/MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer3/Resumes/PanelContainer/MarginContainer/VBoxContainer/PanelContainer/VBoxContainer/HBoxContainer6"]
+focus_mode = 0
 layout_mode = 2
 text = " 👁 "
 
 [node name="Button2" type="Button" parent="MarginContainer/HBoxContainer/TabBar/Inc/MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer3/Resumes/PanelContainer/MarginContainer/VBoxContainer/PanelContainer/VBoxContainer/HBoxContainer6"]
+focus_mode = 0
 layout_mode = 2
 text = " Hire "
 
@@ -419,10 +436,12 @@ layout_mode = 2
 text = "Name McNameface"
 
 [node name="Button" type="Button" parent="MarginContainer/HBoxContainer/TabBar/Inc/MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer3/Resumes/PanelContainer/MarginContainer/VBoxContainer/PanelContainer/VBoxContainer/HBoxContainer7"]
+focus_mode = 0
 layout_mode = 2
 text = " 👁 "
 
 [node name="Button2" type="Button" parent="MarginContainer/HBoxContainer/TabBar/Inc/MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer3/Resumes/PanelContainer/MarginContainer/VBoxContainer/PanelContainer/VBoxContainer/HBoxContainer7"]
+focus_mode = 0
 layout_mode = 2
 text = " Hire "
 
@@ -434,10 +453,12 @@ layout_mode = 2
 text = "Name McNameface"
 
 [node name="Button" type="Button" parent="MarginContainer/HBoxContainer/TabBar/Inc/MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer3/Resumes/PanelContainer/MarginContainer/VBoxContainer/PanelContainer/VBoxContainer/HBoxContainer8"]
+focus_mode = 0
 layout_mode = 2
 text = " 👁 "
 
 [node name="Button2" type="Button" parent="MarginContainer/HBoxContainer/TabBar/Inc/MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer3/Resumes/PanelContainer/MarginContainer/VBoxContainer/PanelContainer/VBoxContainer/HBoxContainer8"]
+focus_mode = 0
 layout_mode = 2
 text = " Hire "
 
@@ -636,6 +657,7 @@ size_flags_horizontal = 4
 columns = 3
 
 [node name="Button" type="Button" parent="MarginContainer/HBoxContainer/TabBar/Board/MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer/Handbook/PanelContainer/MarginContainer/VBoxContainer/GridContainer"]
+focus_mode = 0
 custom_minimum_size = Vector2(150, 0)
 layout_mode = 2
 theme_override_font_sizes/font_size = 10
@@ -644,6 +666,7 @@ More Words About the Upgrade"
 autowrap_mode = 3
 
 [node name="Button2" type="Button" parent="MarginContainer/HBoxContainer/TabBar/Board/MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer/Handbook/PanelContainer/MarginContainer/VBoxContainer/GridContainer"]
+focus_mode = 0
 custom_minimum_size = Vector2(150, 0)
 layout_mode = 2
 theme_override_font_sizes/font_size = 10
@@ -652,6 +675,7 @@ More Words About the Upgrade"
 autowrap_mode = 3
 
 [node name="Button3" type="Button" parent="MarginContainer/HBoxContainer/TabBar/Board/MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer/Handbook/PanelContainer/MarginContainer/VBoxContainer/GridContainer"]
+focus_mode = 0
 custom_minimum_size = Vector2(150, 0)
 layout_mode = 2
 theme_override_font_sizes/font_size = 10
@@ -660,6 +684,7 @@ More Words About the Upgrade"
 autowrap_mode = 3
 
 [node name="Button4" type="Button" parent="MarginContainer/HBoxContainer/TabBar/Board/MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer/Handbook/PanelContainer/MarginContainer/VBoxContainer/GridContainer"]
+focus_mode = 0
 custom_minimum_size = Vector2(150, 0)
 layout_mode = 2
 theme_override_font_sizes/font_size = 10
@@ -668,6 +693,7 @@ More Words About the Upgrade"
 autowrap_mode = 3
 
 [node name="Button5" type="Button" parent="MarginContainer/HBoxContainer/TabBar/Board/MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer/Handbook/PanelContainer/MarginContainer/VBoxContainer/GridContainer"]
+focus_mode = 0
 custom_minimum_size = Vector2(150, 0)
 layout_mode = 2
 theme_override_font_sizes/font_size = 10
@@ -726,10 +752,12 @@ layout_mode = 2
 text = "Name McNameface"
 
 [node name="Button" type="Button" parent="MarginContainer/HBoxContainer/TabBar/Board/MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer3/Resumes/PanelContainer/MarginContainer/VBoxContainer/PanelContainer/VBoxContainer/HBoxContainer"]
+focus_mode = 0
 layout_mode = 2
 text = " 👁 "
 
 [node name="Button2" type="Button" parent="MarginContainer/HBoxContainer/TabBar/Board/MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer3/Resumes/PanelContainer/MarginContainer/VBoxContainer/PanelContainer/VBoxContainer/HBoxContainer"]
+focus_mode = 0
 layout_mode = 2
 text = " Hire "
 
@@ -741,10 +769,12 @@ layout_mode = 2
 text = "Name McNameface"
 
 [node name="Button" type="Button" parent="MarginContainer/HBoxContainer/TabBar/Board/MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer3/Resumes/PanelContainer/MarginContainer/VBoxContainer/PanelContainer/VBoxContainer/HBoxContainer2"]
+focus_mode = 0
 layout_mode = 2
 text = " 👁 "
 
 [node name="Button2" type="Button" parent="MarginContainer/HBoxContainer/TabBar/Board/MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer3/Resumes/PanelContainer/MarginContainer/VBoxContainer/PanelContainer/VBoxContainer/HBoxContainer2"]
+focus_mode = 0
 layout_mode = 2
 text = " Hire "
 
@@ -756,10 +786,12 @@ layout_mode = 2
 text = "Name McNameface"
 
 [node name="Button" type="Button" parent="MarginContainer/HBoxContainer/TabBar/Board/MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer3/Resumes/PanelContainer/MarginContainer/VBoxContainer/PanelContainer/VBoxContainer/HBoxContainer3"]
+focus_mode = 0
 layout_mode = 2
 text = " 👁 "
 
 [node name="Button2" type="Button" parent="MarginContainer/HBoxContainer/TabBar/Board/MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer3/Resumes/PanelContainer/MarginContainer/VBoxContainer/PanelContainer/VBoxContainer/HBoxContainer3"]
+focus_mode = 0
 layout_mode = 2
 text = " Hire "
 
@@ -771,10 +803,12 @@ layout_mode = 2
 text = "Name McNameface"
 
 [node name="Button" type="Button" parent="MarginContainer/HBoxContainer/TabBar/Board/MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer3/Resumes/PanelContainer/MarginContainer/VBoxContainer/PanelContainer/VBoxContainer/HBoxContainer4"]
+focus_mode = 0
 layout_mode = 2
 text = " 👁 "
 
 [node name="Button2" type="Button" parent="MarginContainer/HBoxContainer/TabBar/Board/MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer3/Resumes/PanelContainer/MarginContainer/VBoxContainer/PanelContainer/VBoxContainer/HBoxContainer4"]
+focus_mode = 0
 layout_mode = 2
 text = " Hire "
 
@@ -786,10 +820,12 @@ layout_mode = 2
 text = "Name McNameface"
 
 [node name="Button" type="Button" parent="MarginContainer/HBoxContainer/TabBar/Board/MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer3/Resumes/PanelContainer/MarginContainer/VBoxContainer/PanelContainer/VBoxContainer/HBoxContainer5"]
+focus_mode = 0
 layout_mode = 2
 text = " 👁 "
 
 [node name="Button2" type="Button" parent="MarginContainer/HBoxContainer/TabBar/Board/MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer3/Resumes/PanelContainer/MarginContainer/VBoxContainer/PanelContainer/VBoxContainer/HBoxContainer5"]
+focus_mode = 0
 layout_mode = 2
 text = " Hire "
 
@@ -801,10 +837,12 @@ layout_mode = 2
 text = "Name McNameface"
 
 [node name="Button" type="Button" parent="MarginContainer/HBoxContainer/TabBar/Board/MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer3/Resumes/PanelContainer/MarginContainer/VBoxContainer/PanelContainer/VBoxContainer/HBoxContainer6"]
+focus_mode = 0
 layout_mode = 2
 text = " 👁 "
 
 [node name="Button2" type="Button" parent="MarginContainer/HBoxContainer/TabBar/Board/MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer3/Resumes/PanelContainer/MarginContainer/VBoxContainer/PanelContainer/VBoxContainer/HBoxContainer6"]
+focus_mode = 0
 layout_mode = 2
 text = " Hire "
 
@@ -816,10 +854,12 @@ layout_mode = 2
 text = "Name McNameface"
 
 [node name="Button" type="Button" parent="MarginContainer/HBoxContainer/TabBar/Board/MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer3/Resumes/PanelContainer/MarginContainer/VBoxContainer/PanelContainer/VBoxContainer/HBoxContainer7"]
+focus_mode = 0
 layout_mode = 2
 text = " 👁 "
 
 [node name="Button2" type="Button" parent="MarginContainer/HBoxContainer/TabBar/Board/MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer3/Resumes/PanelContainer/MarginContainer/VBoxContainer/PanelContainer/VBoxContainer/HBoxContainer7"]
+focus_mode = 0
 layout_mode = 2
 text = " Hire "
 
@@ -831,10 +871,12 @@ layout_mode = 2
 text = "Name McNameface"
 
 [node name="Button" type="Button" parent="MarginContainer/HBoxContainer/TabBar/Board/MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer3/Resumes/PanelContainer/MarginContainer/VBoxContainer/PanelContainer/VBoxContainer/HBoxContainer8"]
+focus_mode = 0
 layout_mode = 2
 text = " 👁 "
 
 [node name="Button2" type="Button" parent="MarginContainer/HBoxContainer/TabBar/Board/MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer3/Resumes/PanelContainer/MarginContainer/VBoxContainer/PanelContainer/VBoxContainer/HBoxContainer8"]
+focus_mode = 0
 layout_mode = 2
 text = " Hire "
 
@@ -1033,6 +1075,7 @@ size_flags_horizontal = 4
 columns = 3
 
 [node name="Button" type="Button" parent="MarginContainer/HBoxContainer/TabBar/C-Suite/MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer/Handbook/PanelContainer/MarginContainer/VBoxContainer/GridContainer"]
+focus_mode = 0
 custom_minimum_size = Vector2(150, 0)
 layout_mode = 2
 theme_override_font_sizes/font_size = 10
@@ -1041,6 +1084,7 @@ More Words About the Upgrade"
 autowrap_mode = 3
 
 [node name="Button2" type="Button" parent="MarginContainer/HBoxContainer/TabBar/C-Suite/MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer/Handbook/PanelContainer/MarginContainer/VBoxContainer/GridContainer"]
+focus_mode = 0
 custom_minimum_size = Vector2(150, 0)
 layout_mode = 2
 theme_override_font_sizes/font_size = 10
@@ -1049,6 +1093,7 @@ More Words About the Upgrade"
 autowrap_mode = 3
 
 [node name="Button3" type="Button" parent="MarginContainer/HBoxContainer/TabBar/C-Suite/MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer/Handbook/PanelContainer/MarginContainer/VBoxContainer/GridContainer"]
+focus_mode = 0
 custom_minimum_size = Vector2(150, 0)
 layout_mode = 2
 theme_override_font_sizes/font_size = 10
@@ -1057,6 +1102,7 @@ More Words About the Upgrade"
 autowrap_mode = 3
 
 [node name="Button4" type="Button" parent="MarginContainer/HBoxContainer/TabBar/C-Suite/MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer/Handbook/PanelContainer/MarginContainer/VBoxContainer/GridContainer"]
+focus_mode = 0
 custom_minimum_size = Vector2(150, 0)
 layout_mode = 2
 theme_override_font_sizes/font_size = 10
@@ -1065,6 +1111,7 @@ More Words About the Upgrade"
 autowrap_mode = 3
 
 [node name="Button5" type="Button" parent="MarginContainer/HBoxContainer/TabBar/C-Suite/MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer/Handbook/PanelContainer/MarginContainer/VBoxContainer/GridContainer"]
+focus_mode = 0
 custom_minimum_size = Vector2(150, 0)
 layout_mode = 2
 theme_override_font_sizes/font_size = 10
@@ -1123,10 +1170,12 @@ layout_mode = 2
 text = "Name McNameface"
 
 [node name="Button" type="Button" parent="MarginContainer/HBoxContainer/TabBar/C-Suite/MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer3/Resumes/PanelContainer/MarginContainer/VBoxContainer/PanelContainer/VBoxContainer/HBoxContainer"]
+focus_mode = 0
 layout_mode = 2
 text = " 👁 "
 
 [node name="Button2" type="Button" parent="MarginContainer/HBoxContainer/TabBar/C-Suite/MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer3/Resumes/PanelContainer/MarginContainer/VBoxContainer/PanelContainer/VBoxContainer/HBoxContainer"]
+focus_mode = 0
 layout_mode = 2
 text = " Hire "
 
@@ -1138,10 +1187,12 @@ layout_mode = 2
 text = "Name McNameface"
 
 [node name="Button" type="Button" parent="MarginContainer/HBoxContainer/TabBar/C-Suite/MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer3/Resumes/PanelContainer/MarginContainer/VBoxContainer/PanelContainer/VBoxContainer/HBoxContainer2"]
+focus_mode = 0
 layout_mode = 2
 text = " 👁 "
 
 [node name="Button2" type="Button" parent="MarginContainer/HBoxContainer/TabBar/C-Suite/MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer3/Resumes/PanelContainer/MarginContainer/VBoxContainer/PanelContainer/VBoxContainer/HBoxContainer2"]
+focus_mode = 0
 layout_mode = 2
 text = " Hire "
 
@@ -1153,10 +1204,12 @@ layout_mode = 2
 text = "Name McNameface"
 
 [node name="Button" type="Button" parent="MarginContainer/HBoxContainer/TabBar/C-Suite/MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer3/Resumes/PanelContainer/MarginContainer/VBoxContainer/PanelContainer/VBoxContainer/HBoxContainer3"]
+focus_mode = 0
 layout_mode = 2
 text = " 👁 "
 
 [node name="Button2" type="Button" parent="MarginContainer/HBoxContainer/TabBar/C-Suite/MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer3/Resumes/PanelContainer/MarginContainer/VBoxContainer/PanelContainer/VBoxContainer/HBoxContainer3"]
+focus_mode = 0
 layout_mode = 2
 text = " Hire "
 
@@ -1168,10 +1221,12 @@ layout_mode = 2
 text = "Name McNameface"
 
 [node name="Button" type="Button" parent="MarginContainer/HBoxContainer/TabBar/C-Suite/MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer3/Resumes/PanelContainer/MarginContainer/VBoxContainer/PanelContainer/VBoxContainer/HBoxContainer4"]
+focus_mode = 0
 layout_mode = 2
 text = " 👁 "
 
 [node name="Button2" type="Button" parent="MarginContainer/HBoxContainer/TabBar/C-Suite/MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer3/Resumes/PanelContainer/MarginContainer/VBoxContainer/PanelContainer/VBoxContainer/HBoxContainer4"]
+focus_mode = 0
 layout_mode = 2
 text = " Hire "
 
@@ -1183,10 +1238,12 @@ layout_mode = 2
 text = "Name McNameface"
 
 [node name="Button" type="Button" parent="MarginContainer/HBoxContainer/TabBar/C-Suite/MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer3/Resumes/PanelContainer/MarginContainer/VBoxContainer/PanelContainer/VBoxContainer/HBoxContainer5"]
+focus_mode = 0
 layout_mode = 2
 text = " 👁 "
 
 [node name="Button2" type="Button" parent="MarginContainer/HBoxContainer/TabBar/C-Suite/MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer3/Resumes/PanelContainer/MarginContainer/VBoxContainer/PanelContainer/VBoxContainer/HBoxContainer5"]
+focus_mode = 0
 layout_mode = 2
 text = " Hire "
 
@@ -1198,10 +1255,12 @@ layout_mode = 2
 text = "Name McNameface"
 
 [node name="Button" type="Button" parent="MarginContainer/HBoxContainer/TabBar/C-Suite/MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer3/Resumes/PanelContainer/MarginContainer/VBoxContainer/PanelContainer/VBoxContainer/HBoxContainer6"]
+focus_mode = 0
 layout_mode = 2
 text = " 👁 "
 
 [node name="Button2" type="Button" parent="MarginContainer/HBoxContainer/TabBar/C-Suite/MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer3/Resumes/PanelContainer/MarginContainer/VBoxContainer/PanelContainer/VBoxContainer/HBoxContainer6"]
+focus_mode = 0
 layout_mode = 2
 text = " Hire "
 
@@ -1213,10 +1272,12 @@ layout_mode = 2
 text = "Name McNameface"
 
 [node name="Button" type="Button" parent="MarginContainer/HBoxContainer/TabBar/C-Suite/MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer3/Resumes/PanelContainer/MarginContainer/VBoxContainer/PanelContainer/VBoxContainer/HBoxContainer7"]
+focus_mode = 0
 layout_mode = 2
 text = " 👁 "
 
 [node name="Button2" type="Button" parent="MarginContainer/HBoxContainer/TabBar/C-Suite/MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer3/Resumes/PanelContainer/MarginContainer/VBoxContainer/PanelContainer/VBoxContainer/HBoxContainer7"]
+focus_mode = 0
 layout_mode = 2
 text = " Hire "
 
@@ -1228,10 +1289,12 @@ layout_mode = 2
 text = "Name McNameface"
 
 [node name="Button" type="Button" parent="MarginContainer/HBoxContainer/TabBar/C-Suite/MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer3/Resumes/PanelContainer/MarginContainer/VBoxContainer/PanelContainer/VBoxContainer/HBoxContainer8"]
+focus_mode = 0
 layout_mode = 2
 text = " 👁 "
 
 [node name="Button2" type="Button" parent="MarginContainer/HBoxContainer/TabBar/C-Suite/MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer3/Resumes/PanelContainer/MarginContainer/VBoxContainer/PanelContainer/VBoxContainer/HBoxContainer8"]
+focus_mode = 0
 layout_mode = 2
 text = " Hire "
 
@@ -1430,6 +1493,7 @@ size_flags_horizontal = 4
 columns = 3
 
 [node name="Button" type="Button" parent="MarginContainer/HBoxContainer/TabBar/MGMT/MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer/Handbook/PanelContainer/MarginContainer/VBoxContainer/GridContainer"]
+focus_mode = 0
 custom_minimum_size = Vector2(150, 0)
 layout_mode = 2
 theme_override_font_sizes/font_size = 10
@@ -1438,6 +1502,7 @@ More Words About the Upgrade"
 autowrap_mode = 3
 
 [node name="Button2" type="Button" parent="MarginContainer/HBoxContainer/TabBar/MGMT/MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer/Handbook/PanelContainer/MarginContainer/VBoxContainer/GridContainer"]
+focus_mode = 0
 custom_minimum_size = Vector2(150, 0)
 layout_mode = 2
 theme_override_font_sizes/font_size = 10
@@ -1446,6 +1511,7 @@ More Words About the Upgrade"
 autowrap_mode = 3
 
 [node name="Button3" type="Button" parent="MarginContainer/HBoxContainer/TabBar/MGMT/MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer/Handbook/PanelContainer/MarginContainer/VBoxContainer/GridContainer"]
+focus_mode = 0
 custom_minimum_size = Vector2(150, 0)
 layout_mode = 2
 theme_override_font_sizes/font_size = 10
@@ -1454,6 +1520,7 @@ More Words About the Upgrade"
 autowrap_mode = 3
 
 [node name="Button4" type="Button" parent="MarginContainer/HBoxContainer/TabBar/MGMT/MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer/Handbook/PanelContainer/MarginContainer/VBoxContainer/GridContainer"]
+focus_mode = 0
 custom_minimum_size = Vector2(150, 0)
 layout_mode = 2
 theme_override_font_sizes/font_size = 10
@@ -1462,6 +1529,7 @@ More Words About the Upgrade"
 autowrap_mode = 3
 
 [node name="Button5" type="Button" parent="MarginContainer/HBoxContainer/TabBar/MGMT/MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer/Handbook/PanelContainer/MarginContainer/VBoxContainer/GridContainer"]
+focus_mode = 0
 custom_minimum_size = Vector2(150, 0)
 layout_mode = 2
 theme_override_font_sizes/font_size = 10
@@ -1520,10 +1588,12 @@ layout_mode = 2
 text = "Name McNameface"
 
 [node name="Button" type="Button" parent="MarginContainer/HBoxContainer/TabBar/MGMT/MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer3/Resumes/PanelContainer/MarginContainer/VBoxContainer/PanelContainer/VBoxContainer/HBoxContainer"]
+focus_mode = 0
 layout_mode = 2
 text = " 👁 "
 
 [node name="Button2" type="Button" parent="MarginContainer/HBoxContainer/TabBar/MGMT/MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer3/Resumes/PanelContainer/MarginContainer/VBoxContainer/PanelContainer/VBoxContainer/HBoxContainer"]
+focus_mode = 0
 layout_mode = 2
 text = " Hire "
 
@@ -1535,10 +1605,12 @@ layout_mode = 2
 text = "Name McNameface"
 
 [node name="Button" type="Button" parent="MarginContainer/HBoxContainer/TabBar/MGMT/MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer3/Resumes/PanelContainer/MarginContainer/VBoxContainer/PanelContainer/VBoxContainer/HBoxContainer2"]
+focus_mode = 0
 layout_mode = 2
 text = " 👁 "
 
 [node name="Button2" type="Button" parent="MarginContainer/HBoxContainer/TabBar/MGMT/MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer3/Resumes/PanelContainer/MarginContainer/VBoxContainer/PanelContainer/VBoxContainer/HBoxContainer2"]
+focus_mode = 0
 layout_mode = 2
 text = " Hire "
 
@@ -1550,10 +1622,12 @@ layout_mode = 2
 text = "Name McNameface"
 
 [node name="Button" type="Button" parent="MarginContainer/HBoxContainer/TabBar/MGMT/MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer3/Resumes/PanelContainer/MarginContainer/VBoxContainer/PanelContainer/VBoxContainer/HBoxContainer3"]
+focus_mode = 0
 layout_mode = 2
 text = " 👁 "
 
 [node name="Button2" type="Button" parent="MarginContainer/HBoxContainer/TabBar/MGMT/MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer3/Resumes/PanelContainer/MarginContainer/VBoxContainer/PanelContainer/VBoxContainer/HBoxContainer3"]
+focus_mode = 0
 layout_mode = 2
 text = " Hire "
 
@@ -1565,10 +1639,12 @@ layout_mode = 2
 text = "Name McNameface"
 
 [node name="Button" type="Button" parent="MarginContainer/HBoxContainer/TabBar/MGMT/MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer3/Resumes/PanelContainer/MarginContainer/VBoxContainer/PanelContainer/VBoxContainer/HBoxContainer4"]
+focus_mode = 0
 layout_mode = 2
 text = " 👁 "
 
 [node name="Button2" type="Button" parent="MarginContainer/HBoxContainer/TabBar/MGMT/MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer3/Resumes/PanelContainer/MarginContainer/VBoxContainer/PanelContainer/VBoxContainer/HBoxContainer4"]
+focus_mode = 0
 layout_mode = 2
 text = " Hire "
 
@@ -1580,10 +1656,12 @@ layout_mode = 2
 text = "Name McNameface"
 
 [node name="Button" type="Button" parent="MarginContainer/HBoxContainer/TabBar/MGMT/MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer3/Resumes/PanelContainer/MarginContainer/VBoxContainer/PanelContainer/VBoxContainer/HBoxContainer5"]
+focus_mode = 0
 layout_mode = 2
 text = " 👁 "
 
 [node name="Button2" type="Button" parent="MarginContainer/HBoxContainer/TabBar/MGMT/MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer3/Resumes/PanelContainer/MarginContainer/VBoxContainer/PanelContainer/VBoxContainer/HBoxContainer5"]
+focus_mode = 0
 layout_mode = 2
 text = " Hire "
 
@@ -1595,10 +1673,12 @@ layout_mode = 2
 text = "Name McNameface"
 
 [node name="Button" type="Button" parent="MarginContainer/HBoxContainer/TabBar/MGMT/MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer3/Resumes/PanelContainer/MarginContainer/VBoxContainer/PanelContainer/VBoxContainer/HBoxContainer6"]
+focus_mode = 0
 layout_mode = 2
 text = " 👁 "
 
 [node name="Button2" type="Button" parent="MarginContainer/HBoxContainer/TabBar/MGMT/MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer3/Resumes/PanelContainer/MarginContainer/VBoxContainer/PanelContainer/VBoxContainer/HBoxContainer6"]
+focus_mode = 0
 layout_mode = 2
 text = " Hire "
 
@@ -1610,10 +1690,12 @@ layout_mode = 2
 text = "Name McNameface"
 
 [node name="Button" type="Button" parent="MarginContainer/HBoxContainer/TabBar/MGMT/MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer3/Resumes/PanelContainer/MarginContainer/VBoxContainer/PanelContainer/VBoxContainer/HBoxContainer7"]
+focus_mode = 0
 layout_mode = 2
 text = " 👁 "
 
 [node name="Button2" type="Button" parent="MarginContainer/HBoxContainer/TabBar/MGMT/MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer3/Resumes/PanelContainer/MarginContainer/VBoxContainer/PanelContainer/VBoxContainer/HBoxContainer7"]
+focus_mode = 0
 layout_mode = 2
 text = " Hire "
 
@@ -1625,10 +1707,12 @@ layout_mode = 2
 text = "Name McNameface"
 
 [node name="Button" type="Button" parent="MarginContainer/HBoxContainer/TabBar/MGMT/MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer3/Resumes/PanelContainer/MarginContainer/VBoxContainer/PanelContainer/VBoxContainer/HBoxContainer8"]
+focus_mode = 0
 layout_mode = 2
 text = " 👁 "
 
 [node name="Button2" type="Button" parent="MarginContainer/HBoxContainer/TabBar/MGMT/MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer3/Resumes/PanelContainer/MarginContainer/VBoxContainer/PanelContainer/VBoxContainer/HBoxContainer8"]
+focus_mode = 0
 layout_mode = 2
 text = " Hire "
 
@@ -1828,6 +1912,7 @@ size_flags_horizontal = 4
 columns = 3
 
 [node name="Button" type="Button" parent="MarginContainer/HBoxContainer/TabBar/HR/MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer/Handbook/PanelContainer/MarginContainer/VBoxContainer/GridContainer"]
+focus_mode = 0
 custom_minimum_size = Vector2(150, 0)
 layout_mode = 2
 theme_override_font_sizes/font_size = 10
@@ -1836,6 +1921,7 @@ More Words About the Upgrade"
 autowrap_mode = 3
 
 [node name="Button2" type="Button" parent="MarginContainer/HBoxContainer/TabBar/HR/MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer/Handbook/PanelContainer/MarginContainer/VBoxContainer/GridContainer"]
+focus_mode = 0
 custom_minimum_size = Vector2(150, 0)
 layout_mode = 2
 theme_override_font_sizes/font_size = 10
@@ -1844,6 +1930,7 @@ More Words About the Upgrade"
 autowrap_mode = 3
 
 [node name="Button3" type="Button" parent="MarginContainer/HBoxContainer/TabBar/HR/MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer/Handbook/PanelContainer/MarginContainer/VBoxContainer/GridContainer"]
+focus_mode = 0
 custom_minimum_size = Vector2(150, 0)
 layout_mode = 2
 theme_override_font_sizes/font_size = 10
@@ -1852,6 +1939,7 @@ More Words About the Upgrade"
 autowrap_mode = 3
 
 [node name="Button4" type="Button" parent="MarginContainer/HBoxContainer/TabBar/HR/MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer/Handbook/PanelContainer/MarginContainer/VBoxContainer/GridContainer"]
+focus_mode = 0
 custom_minimum_size = Vector2(150, 0)
 layout_mode = 2
 theme_override_font_sizes/font_size = 10
@@ -1860,6 +1948,7 @@ More Words About the Upgrade"
 autowrap_mode = 3
 
 [node name="Button5" type="Button" parent="MarginContainer/HBoxContainer/TabBar/HR/MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer/Handbook/PanelContainer/MarginContainer/VBoxContainer/GridContainer"]
+focus_mode = 0
 custom_minimum_size = Vector2(150, 0)
 layout_mode = 2
 theme_override_font_sizes/font_size = 10
@@ -1920,10 +2009,12 @@ layout_mode = 2
 text = "Name McNameface"
 
 [node name="Button" type="Button" parent="MarginContainer/HBoxContainer/TabBar/HR/MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer3/Resumes/PanelContainer/MarginContainer/VBoxContainer/PanelContainer/ResumesList/HBoxContainer"]
+focus_mode = 0
 layout_mode = 2
 text = " 👁 "
 
 [node name="Button2" type="Button" parent="MarginContainer/HBoxContainer/TabBar/HR/MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer3/Resumes/PanelContainer/MarginContainer/VBoxContainer/PanelContainer/ResumesList/HBoxContainer"]
+focus_mode = 0
 layout_mode = 2
 text = " Hire "
 
@@ -2123,6 +2214,7 @@ size_flags_horizontal = 4
 columns = 3
 
 [node name="Button" type="Button" parent="MarginContainer/HBoxContainer/TabBar/Production/MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer/Handbook/PanelContainer/MarginContainer/VBoxContainer/GridContainer"]
+focus_mode = 0
 custom_minimum_size = Vector2(150, 0)
 layout_mode = 2
 theme_override_font_sizes/font_size = 10
@@ -2131,6 +2223,7 @@ More Words About the Upgrade"
 autowrap_mode = 3
 
 [node name="Button2" type="Button" parent="MarginContainer/HBoxContainer/TabBar/Production/MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer/Handbook/PanelContainer/MarginContainer/VBoxContainer/GridContainer"]
+focus_mode = 0
 custom_minimum_size = Vector2(150, 0)
 layout_mode = 2
 theme_override_font_sizes/font_size = 10
@@ -2139,6 +2232,7 @@ More Words About the Upgrade"
 autowrap_mode = 3
 
 [node name="Button3" type="Button" parent="MarginContainer/HBoxContainer/TabBar/Production/MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer/Handbook/PanelContainer/MarginContainer/VBoxContainer/GridContainer"]
+focus_mode = 0
 custom_minimum_size = Vector2(150, 0)
 layout_mode = 2
 theme_override_font_sizes/font_size = 10
@@ -2147,6 +2241,7 @@ More Words About the Upgrade"
 autowrap_mode = 3
 
 [node name="Button4" type="Button" parent="MarginContainer/HBoxContainer/TabBar/Production/MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer/Handbook/PanelContainer/MarginContainer/VBoxContainer/GridContainer"]
+focus_mode = 0
 custom_minimum_size = Vector2(150, 0)
 layout_mode = 2
 theme_override_font_sizes/font_size = 10
@@ -2155,6 +2250,7 @@ More Words About the Upgrade"
 autowrap_mode = 3
 
 [node name="Button5" type="Button" parent="MarginContainer/HBoxContainer/TabBar/Production/MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer/Handbook/PanelContainer/MarginContainer/VBoxContainer/GridContainer"]
+focus_mode = 0
 custom_minimum_size = Vector2(150, 0)
 layout_mode = 2
 theme_override_font_sizes/font_size = 10
@@ -2213,10 +2309,12 @@ layout_mode = 2
 text = "Name McNameface"
 
 [node name="Button" type="Button" parent="MarginContainer/HBoxContainer/TabBar/Production/MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer3/Resumes/PanelContainer/MarginContainer/VBoxContainer/PanelContainer/VBoxContainer/HBoxContainer"]
+focus_mode = 0
 layout_mode = 2
 text = " 👁 "
 
 [node name="Button2" type="Button" parent="MarginContainer/HBoxContainer/TabBar/Production/MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer3/Resumes/PanelContainer/MarginContainer/VBoxContainer/PanelContainer/VBoxContainer/HBoxContainer"]
+focus_mode = 0
 layout_mode = 2
 text = " Hire "
 
@@ -2228,10 +2326,12 @@ layout_mode = 2
 text = "Name McNameface"
 
 [node name="Button" type="Button" parent="MarginContainer/HBoxContainer/TabBar/Production/MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer3/Resumes/PanelContainer/MarginContainer/VBoxContainer/PanelContainer/VBoxContainer/HBoxContainer2"]
+focus_mode = 0
 layout_mode = 2
 text = " 👁 "
 
 [node name="Button2" type="Button" parent="MarginContainer/HBoxContainer/TabBar/Production/MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer3/Resumes/PanelContainer/MarginContainer/VBoxContainer/PanelContainer/VBoxContainer/HBoxContainer2"]
+focus_mode = 0
 layout_mode = 2
 text = " Hire "
 
@@ -2243,10 +2343,12 @@ layout_mode = 2
 text = "Name McNameface"
 
 [node name="Button" type="Button" parent="MarginContainer/HBoxContainer/TabBar/Production/MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer3/Resumes/PanelContainer/MarginContainer/VBoxContainer/PanelContainer/VBoxContainer/HBoxContainer3"]
+focus_mode = 0
 layout_mode = 2
 text = " 👁 "
 
 [node name="Button2" type="Button" parent="MarginContainer/HBoxContainer/TabBar/Production/MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer3/Resumes/PanelContainer/MarginContainer/VBoxContainer/PanelContainer/VBoxContainer/HBoxContainer3"]
+focus_mode = 0
 layout_mode = 2
 text = " Hire "
 
@@ -2258,10 +2360,12 @@ layout_mode = 2
 text = "Name McNameface"
 
 [node name="Button" type="Button" parent="MarginContainer/HBoxContainer/TabBar/Production/MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer3/Resumes/PanelContainer/MarginContainer/VBoxContainer/PanelContainer/VBoxContainer/HBoxContainer4"]
+focus_mode = 0
 layout_mode = 2
 text = " 👁 "
 
 [node name="Button2" type="Button" parent="MarginContainer/HBoxContainer/TabBar/Production/MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer3/Resumes/PanelContainer/MarginContainer/VBoxContainer/PanelContainer/VBoxContainer/HBoxContainer4"]
+focus_mode = 0
 layout_mode = 2
 text = " Hire "
 
@@ -2273,10 +2377,12 @@ layout_mode = 2
 text = "Name McNameface"
 
 [node name="Button" type="Button" parent="MarginContainer/HBoxContainer/TabBar/Production/MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer3/Resumes/PanelContainer/MarginContainer/VBoxContainer/PanelContainer/VBoxContainer/HBoxContainer5"]
+focus_mode = 0
 layout_mode = 2
 text = " 👁 "
 
 [node name="Button2" type="Button" parent="MarginContainer/HBoxContainer/TabBar/Production/MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer3/Resumes/PanelContainer/MarginContainer/VBoxContainer/PanelContainer/VBoxContainer/HBoxContainer5"]
+focus_mode = 0
 layout_mode = 2
 text = " Hire "
 
@@ -2288,10 +2394,12 @@ layout_mode = 2
 text = "Name McNameface"
 
 [node name="Button" type="Button" parent="MarginContainer/HBoxContainer/TabBar/Production/MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer3/Resumes/PanelContainer/MarginContainer/VBoxContainer/PanelContainer/VBoxContainer/HBoxContainer6"]
+focus_mode = 0
 layout_mode = 2
 text = " 👁 "
 
 [node name="Button2" type="Button" parent="MarginContainer/HBoxContainer/TabBar/Production/MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer3/Resumes/PanelContainer/MarginContainer/VBoxContainer/PanelContainer/VBoxContainer/HBoxContainer6"]
+focus_mode = 0
 layout_mode = 2
 text = " Hire "
 
@@ -2303,10 +2411,12 @@ layout_mode = 2
 text = "Name McNameface"
 
 [node name="Button" type="Button" parent="MarginContainer/HBoxContainer/TabBar/Production/MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer3/Resumes/PanelContainer/MarginContainer/VBoxContainer/PanelContainer/VBoxContainer/HBoxContainer7"]
+focus_mode = 0
 layout_mode = 2
 text = " 👁 "
 
 [node name="Button2" type="Button" parent="MarginContainer/HBoxContainer/TabBar/Production/MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer3/Resumes/PanelContainer/MarginContainer/VBoxContainer/PanelContainer/VBoxContainer/HBoxContainer7"]
+focus_mode = 0
 layout_mode = 2
 text = " Hire "
 
@@ -2318,10 +2428,12 @@ layout_mode = 2
 text = "Name McNameface"
 
 [node name="Button" type="Button" parent="MarginContainer/HBoxContainer/TabBar/Production/MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer3/Resumes/PanelContainer/MarginContainer/VBoxContainer/PanelContainer/VBoxContainer/HBoxContainer8"]
+focus_mode = 0
 layout_mode = 2
 text = " 👁 "
 
 [node name="Button2" type="Button" parent="MarginContainer/HBoxContainer/TabBar/Production/MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer3/Resumes/PanelContainer/MarginContainer/VBoxContainer/PanelContainer/VBoxContainer/HBoxContainer8"]
+focus_mode = 0
 layout_mode = 2
 text = " Hire "
 
@@ -2520,6 +2632,7 @@ size_flags_horizontal = 4
 columns = 3
 
 [node name="Button" type="Button" parent="MarginContainer/HBoxContainer/TabBar/R&D/MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer/Handbook/PanelContainer/MarginContainer/VBoxContainer/GridContainer"]
+focus_mode = 0
 custom_minimum_size = Vector2(150, 0)
 layout_mode = 2
 theme_override_font_sizes/font_size = 10
@@ -2528,6 +2641,7 @@ More Words About the Upgrade"
 autowrap_mode = 3
 
 [node name="Button2" type="Button" parent="MarginContainer/HBoxContainer/TabBar/R&D/MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer/Handbook/PanelContainer/MarginContainer/VBoxContainer/GridContainer"]
+focus_mode = 0
 custom_minimum_size = Vector2(150, 0)
 layout_mode = 2
 theme_override_font_sizes/font_size = 10
@@ -2536,6 +2650,7 @@ More Words About the Upgrade"
 autowrap_mode = 3
 
 [node name="Button3" type="Button" parent="MarginContainer/HBoxContainer/TabBar/R&D/MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer/Handbook/PanelContainer/MarginContainer/VBoxContainer/GridContainer"]
+focus_mode = 0
 custom_minimum_size = Vector2(150, 0)
 layout_mode = 2
 theme_override_font_sizes/font_size = 10
@@ -2544,6 +2659,7 @@ More Words About the Upgrade"
 autowrap_mode = 3
 
 [node name="Button4" type="Button" parent="MarginContainer/HBoxContainer/TabBar/R&D/MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer/Handbook/PanelContainer/MarginContainer/VBoxContainer/GridContainer"]
+focus_mode = 0
 custom_minimum_size = Vector2(150, 0)
 layout_mode = 2
 theme_override_font_sizes/font_size = 10
@@ -2552,6 +2668,7 @@ More Words About the Upgrade"
 autowrap_mode = 3
 
 [node name="Button5" type="Button" parent="MarginContainer/HBoxContainer/TabBar/R&D/MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer/Handbook/PanelContainer/MarginContainer/VBoxContainer/GridContainer"]
+focus_mode = 0
 custom_minimum_size = Vector2(150, 0)
 layout_mode = 2
 theme_override_font_sizes/font_size = 10
@@ -2610,10 +2727,12 @@ layout_mode = 2
 text = "Name McNameface"
 
 [node name="Button" type="Button" parent="MarginContainer/HBoxContainer/TabBar/R&D/MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer3/Resumes/PanelContainer/MarginContainer/VBoxContainer/PanelContainer/VBoxContainer/HBoxContainer"]
+focus_mode = 0
 layout_mode = 2
 text = " 👁 "
 
 [node name="Button2" type="Button" parent="MarginContainer/HBoxContainer/TabBar/R&D/MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer3/Resumes/PanelContainer/MarginContainer/VBoxContainer/PanelContainer/VBoxContainer/HBoxContainer"]
+focus_mode = 0
 layout_mode = 2
 text = " Hire "
 
@@ -2625,10 +2744,12 @@ layout_mode = 2
 text = "Name McNameface"
 
 [node name="Button" type="Button" parent="MarginContainer/HBoxContainer/TabBar/R&D/MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer3/Resumes/PanelContainer/MarginContainer/VBoxContainer/PanelContainer/VBoxContainer/HBoxContainer2"]
+focus_mode = 0
 layout_mode = 2
 text = " 👁 "
 
 [node name="Button2" type="Button" parent="MarginContainer/HBoxContainer/TabBar/R&D/MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer3/Resumes/PanelContainer/MarginContainer/VBoxContainer/PanelContainer/VBoxContainer/HBoxContainer2"]
+focus_mode = 0
 layout_mode = 2
 text = " Hire "
 
@@ -2640,10 +2761,12 @@ layout_mode = 2
 text = "Name McNameface"
 
 [node name="Button" type="Button" parent="MarginContainer/HBoxContainer/TabBar/R&D/MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer3/Resumes/PanelContainer/MarginContainer/VBoxContainer/PanelContainer/VBoxContainer/HBoxContainer3"]
+focus_mode = 0
 layout_mode = 2
 text = " 👁 "
 
 [node name="Button2" type="Button" parent="MarginContainer/HBoxContainer/TabBar/R&D/MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer3/Resumes/PanelContainer/MarginContainer/VBoxContainer/PanelContainer/VBoxContainer/HBoxContainer3"]
+focus_mode = 0
 layout_mode = 2
 text = " Hire "
 
@@ -2655,10 +2778,12 @@ layout_mode = 2
 text = "Name McNameface"
 
 [node name="Button" type="Button" parent="MarginContainer/HBoxContainer/TabBar/R&D/MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer3/Resumes/PanelContainer/MarginContainer/VBoxContainer/PanelContainer/VBoxContainer/HBoxContainer4"]
+focus_mode = 0
 layout_mode = 2
 text = " 👁 "
 
 [node name="Button2" type="Button" parent="MarginContainer/HBoxContainer/TabBar/R&D/MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer3/Resumes/PanelContainer/MarginContainer/VBoxContainer/PanelContainer/VBoxContainer/HBoxContainer4"]
+focus_mode = 0
 layout_mode = 2
 text = " Hire "
 
@@ -2670,10 +2795,12 @@ layout_mode = 2
 text = "Name McNameface"
 
 [node name="Button" type="Button" parent="MarginContainer/HBoxContainer/TabBar/R&D/MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer3/Resumes/PanelContainer/MarginContainer/VBoxContainer/PanelContainer/VBoxContainer/HBoxContainer5"]
+focus_mode = 0
 layout_mode = 2
 text = " 👁 "
 
 [node name="Button2" type="Button" parent="MarginContainer/HBoxContainer/TabBar/R&D/MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer3/Resumes/PanelContainer/MarginContainer/VBoxContainer/PanelContainer/VBoxContainer/HBoxContainer5"]
+focus_mode = 0
 layout_mode = 2
 text = " Hire "
 
@@ -2685,10 +2812,12 @@ layout_mode = 2
 text = "Name McNameface"
 
 [node name="Button" type="Button" parent="MarginContainer/HBoxContainer/TabBar/R&D/MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer3/Resumes/PanelContainer/MarginContainer/VBoxContainer/PanelContainer/VBoxContainer/HBoxContainer6"]
+focus_mode = 0
 layout_mode = 2
 text = " 👁 "
 
 [node name="Button2" type="Button" parent="MarginContainer/HBoxContainer/TabBar/R&D/MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer3/Resumes/PanelContainer/MarginContainer/VBoxContainer/PanelContainer/VBoxContainer/HBoxContainer6"]
+focus_mode = 0
 layout_mode = 2
 text = " Hire "
 
@@ -2700,10 +2829,12 @@ layout_mode = 2
 text = "Name McNameface"
 
 [node name="Button" type="Button" parent="MarginContainer/HBoxContainer/TabBar/R&D/MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer3/Resumes/PanelContainer/MarginContainer/VBoxContainer/PanelContainer/VBoxContainer/HBoxContainer7"]
+focus_mode = 0
 layout_mode = 2
 text = " 👁 "
 
 [node name="Button2" type="Button" parent="MarginContainer/HBoxContainer/TabBar/R&D/MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer3/Resumes/PanelContainer/MarginContainer/VBoxContainer/PanelContainer/VBoxContainer/HBoxContainer7"]
+focus_mode = 0
 layout_mode = 2
 text = " Hire "
 
@@ -2715,10 +2846,12 @@ layout_mode = 2
 text = "Name McNameface"
 
 [node name="Button" type="Button" parent="MarginContainer/HBoxContainer/TabBar/R&D/MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer3/Resumes/PanelContainer/MarginContainer/VBoxContainer/PanelContainer/VBoxContainer/HBoxContainer8"]
+focus_mode = 0
 layout_mode = 2
 text = " 👁 "
 
 [node name="Button2" type="Button" parent="MarginContainer/HBoxContainer/TabBar/R&D/MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer3/Resumes/PanelContainer/MarginContainer/VBoxContainer/PanelContainer/VBoxContainer/HBoxContainer8"]
+focus_mode = 0
 layout_mode = 2
 text = " Hire "
 


### PR DESCRIPTION
## Summary
- Remove ButtonFocusManager autoload
- Explicitly set focus_mode to none on all buttons across scenes and scripts

## Testing
- `apt-get update`
- `apt-get install -y godot4` *(fails: Unable to locate package godot4)*
- `curl -L -o /tmp/godot.zip https://downloads.tuxfamily.org/godotengine/4.2.2/mono/Godot_v4.2.2-stable_mono_linux_x86_64.zip` *(fails: connection timeout)*
- `/tmp/Godot_v4.2.2-stable_linux.x86_64 --headless --path . tests/test_runner.tscn` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b8730216fc832587e8b73e0d23b04e