### PR TITLE
Prevent duplicate installer popups

### DIFF
--- a/autoloads/window_manager.gd
+++ b/autoloads/window_manager.gd
@@ -204,6 +204,15 @@ func launch_app_by_name(app_name: String, setup_args: Variant = null) -> void:
 			if not pane:
 				push_error("Scene does not extend Pane!")
 				return
+			# ð· Prevent duplicate installer popups for the same app
+			if pane is Installer and setup_args is Dictionary:
+				var app_title: String = setup_args.get("app_title", "")
+				var app_id: String = setup_args.get("app_id", "")
+				if app_title != "":
+					pane.window_title = "Installing " + app_title
+				if app_id != "":
+					pane.unique_popup_key = "installer_%s" % app_id
+
 			if not pane.allow_multiple:
 				var existing = find_window_by_app(pane.window_title)
 				if existing:


### PR DESCRIPTION
## Summary
- Ensure app installers reuse an existing window when opened multiple times

## Testing
- `timeout 5 /tmp/godot/Godot_v4.2.2-stable_linux.x86_64 --headless --run res://tests/test_runner.gd 2>&1 | head -n 40` *(fails: Could not find type "ContextAction")*


------
https://chatgpt.com/codex/tasks/task_e_68b89ce4f1308325862e86e810e2fc5f