### PR TITLE
Round market event price updates to cents

### DIFF
--- a/resources/market_events/market_event.gd
+++ b/resources/market_events/market_event.gd
@@ -95,15 +95,15 @@ func process(now_minutes: int, asset) -> void:
 		var target_price: float = _starting_price * _pump_multiplier
 		var t: float = float(now_minutes - _start_time) / max(1.0, float(_pump_end_time - _start_time))
 		t = clamp(t, 0.0, 1.0)
-		var new_price: float = lerp(_starting_price, target_price, t)
-		var prev: float = asset.price
-		asset.price = new_price
-		asset.last_price = prev
-		if asset.price_history.size() > 0:
-			asset.price_history[asset.price_history.size() - 1] = asset.price
-		else:
-			asset.price_history.append(asset.price)
-		asset.all_time_high = max(asset.all_time_high, asset.price)
+               var new_price: float = lerp(_starting_price, target_price, t)
+               var prev: float = asset.price
+               asset.price = max(snapped(new_price, 0.01), 0.01)
+               asset.last_price = prev
+               if asset.price_history.size() > 0:
+                       asset.price_history[asset.price_history.size() - 1] = asset.price
+               else:
+                       asset.price_history.append(asset.price)
+               asset.all_time_high = max(asset.all_time_high, asset.price)
 
 		print("market event pumping:",
 			" symbol=", target_symbol,
@@ -128,15 +128,15 @@ func process(now_minutes: int, asset) -> void:
 		var target_price: float = _starting_price * _dump_multiplier
 		var t: float = float(now_minutes - _pump_end_time) / max(1.0, float(_dump_end_time - _pump_end_time))
 		t = clamp(t, 0.0, 1.0)
-		var new_price: float = lerp(pump_price, target_price, t)
-		var prev: float = asset.price
-		asset.price = new_price
-		asset.last_price = prev
-		if asset.price_history.size() > 0:
-			asset.price_history[asset.price_history.size() - 1] = asset.price
-		else:
-			asset.price_history.append(asset.price)
-		asset.all_time_high = max(asset.all_time_high, asset.price)
+               var new_price: float = lerp(pump_price, target_price, t)
+               var prev: float = asset.price
+               asset.price = max(snapped(new_price, 0.01), 0.01)
+               asset.last_price = prev
+               if asset.price_history.size() > 0:
+                       asset.price_history[asset.price_history.size() - 1] = asset.price
+               else:
+                       asset.price_history.append(asset.price)
+               asset.all_time_high = max(asset.all_time_high, asset.price)
 
 		print("market event dumping:",
 			" symbol=", target_symbol,

--- a/tests/hawk2_price_precision_test.gd
+++ b/tests/hawk2_price_precision_test.gd
@@ -1,0 +1,28 @@
+extends SceneTree
+
+func _ready() -> void:
+    var crypto := preload("res://resources/crypto/hawk2_crypto.tres").duplicate(true)
+
+    var event := MarketEvent.new()
+    event.target_symbol = "HAWK2"
+    event.target_type = "crypto"
+    event.start_min_minutes = 0
+    event.start_max_minutes = 0
+    event.pump_duration_min = 1
+    event.pump_duration_max = 1
+    event.pump_multiplier_min = 1.333333
+    event.pump_multiplier_max = 1.333333
+    event.dump_duration_min = 1
+    event.dump_duration_max = 1
+    event.dump_multiplier_min = 1.0
+    event.dump_multiplier_max = 1.0
+
+    var rng := RandomNumberGenerator.new()
+    event.schedule(0, rng)
+    event.process(0, crypto)
+    event.process(1, crypto)
+
+    assert(is_equal_approx(crypto.price, snapped(crypto.price, 0.01)))
+    print("hawk2_price_precision_test passed")
+    quit()
+


### PR DESCRIPTION
## Summary
- Snap market event price changes to cents to avoid long decimals
- Add test ensuring Hawk2 crypto prices retain two decimal precision

## Testing
- `godot3 --headless --path . -s tests/test_runner.gd` *(fails: project requires newer Godot version)*

------
https://chatgpt.com/codex/tasks/task_e_68b8a15546648325bc6d0e05b8661f6a