### PR TITLE
Enable credit-only transactions on right-click

### DIFF
--- a/autoloads/gpu_manager.gd
+++ b/autoloads/gpu_manager.gd
@@ -90,8 +90,8 @@ func add_gpu(crypto_symbol: String, overclocked := false) -> void:
 
 	emit_signal("gpus_changed")
 
-func buy_gpu() -> bool:
-	if PortfolioManager.attempt_spend(current_gpu_price, PortfolioManager.CREDIT_REQUIREMENTS["gpu"]):
+func buy_gpu(credit_only := false) -> bool:
+	if PortfolioManager.attempt_spend(current_gpu_price, PortfolioManager.CREDIT_REQUIREMENTS["gpu"], false, credit_only):
 		add_gpu("")  # Add a free GPU (unassigned)
 		current_gpu_price *= gpu_price_growth
 		emit_signal("gpus_changed")

--- a/autoloads/portfolio_manager.gd
+++ b/autoloads/portfolio_manager.gd
@@ -162,9 +162,25 @@ func _ready():
 	_on_student_loans_changed(get_student_loans())
 
 ## --- Spending Router
-func attempt_spend(amount: float, credit_required_score: int = 0, silent: bool = false) -> bool:
+func attempt_spend(amount: float, credit_required_score: int = 0, silent: bool = false, credit_only: bool = false) -> bool:
 		if amount <= 0.0:
 				printerr("Attempted to spend non-positive amount")
+				return false
+
+		if credit_only:
+				if not can_pay_with_credit(amount):
+						if not silent:
+								StatpopManager.spawn("DECLINED", get_viewport().get_mouse_position(), "click", Color.RED)
+						return false
+				if credit_score >= credit_required_score:
+						var total_with_interest := amount * (1.0 + get_credit_interest_rate())
+						set_credit_used(get_credit_used() + total_with_interest)
+						if not silent:
+								StatpopManager.spawn("-$" + str(NumberFormatter.format_number(amount)), get_viewport().get_mouse_position(), "click", Color.ORANGE)
+						WindowManager.launch_app_by_name("OwerView")
+						return true
+				if not silent:
+						StatpopManager.spawn("DECLINED", get_viewport().get_mouse_position(), "click", Color.RED)
 				return false
 
 		# Cash first

--- a/autoloads/upgrade_manager.gd
+++ b/autoloads/upgrade_manager.gd
@@ -287,9 +287,9 @@ func _get_currency_amount(currency: String) -> float:
 		return StatManager.get_stat("ex")
 	return PortfolioManager.get_crypto_amount(currency)
 
-func _deduct_currency(currency: String, amount: float) -> bool:
+func _deduct_currency(currency: String, amount: float, credit_only: bool = false) -> bool:
 	if currency == "cash":
-			return PortfolioManager.attempt_spend(amount, PortfolioManager.CREDIT_REQUIREMENTS["upgrades"])
+			return PortfolioManager.attempt_spend(amount, PortfolioManager.CREDIT_REQUIREMENTS["upgrades"], false, credit_only)
 	if currency == "ex":
 		if StatManager.get_stat("ex") < amount:
 			return false
@@ -345,7 +345,7 @@ func can_purchase(id: String) -> bool:
 				return false
 	return true
 
-func purchase(id: String) -> bool:
+func purchase(id: String, credit_only: bool = false) -> bool:
 	if not can_purchase(id):
 		return false
 	var upgrade := get_upgrade(id)
@@ -353,7 +353,7 @@ func purchase(id: String) -> bool:
 		return false
 	var cost: Dictionary = get_cost_for_next_level(id)
 	for currency in cost.keys():
-			if not _deduct_currency(currency, cost[currency]):
+			if not _deduct_currency(currency, cost[currency], credit_only):
 					return false
 	var level: int = get_level(id) + 1
 	player_levels[id] = level

--- a/components/apps/minerr/minerr_ui.gd
+++ b/components/apps/minerr/minerr_ui.gd
@@ -22,6 +22,7 @@ var crypto_cards: Dictionary = {}
 @onready var charts_cash_label: Label = %ChartsCashLabel
 @onready var charts_crypto_label: Label = %ChartsCryptoLabel
 @onready var charts_content: Control = _ensure_charts_content()
+@onready var buy_new_gpu_button: Button = %BuyNewGPUButton
 var crypto_popup_scene: PackedScene = preload("res://components/popups/crypto_popup_ui.tscn")
 
 func _ensure_charts_content() -> Control:
@@ -74,6 +75,7 @@ func _ready() -> void:
 		_build_charts_view()
 		_update_charts_labels()
 		_activate_tab(&"Mine")
+		buy_new_gpu_button.gui_input.connect(_on_buy_new_gpu_button_gui_input)
 
 func refresh_cards_from_market() -> void:
 	# Clear out any old cards
@@ -174,6 +176,14 @@ func _on_buy_new_gpu_button_pressed() -> void:
 				update_gpu_label()
 		else:
 				print("Could not purchase GPU (insufficient funds).")
+
+func _on_buy_new_gpu_button_gui_input(event: InputEvent) -> void:
+	if event is InputEventMouseButton and event.button_index == MOUSE_BUTTON_RIGHT and event.pressed:
+		if GPUManager.buy_gpu(true):
+			update_gpu_label()
+		else:
+			print("Could not purchase GPU (insufficient credit).")
+		event.accept()
 
 func _on_sort_property_selected(index: int) -> void:
 		match index:

--- a/components/apps/sigma_mail/email_view.gd
+++ b/components/apps/sigma_mail/email_view.gd
@@ -23,14 +23,19 @@ func setup(email_res: EmailResource) -> void:
 		btn.text = action.get("text", "Action")
 		btn.focus_mode = Control.FOCUS_NONE
 		btn.pressed.connect(func(): _on_email_action(action))
+		btn.gui_input.connect(func(event):
+			if event is InputEventMouseButton and event.button_index == MOUSE_BUTTON_RIGHT and event.pressed:
+				_on_email_action(action, true)
+				event.accept()
+		)
 		button_container.add_child(btn)
 
-func _on_email_action(action: Dictionary) -> void:
+func _on_email_action(action: Dictionary, credit_only: bool = false) -> void:
 	for stat in action.get("stat_changes", {}).keys():
 		var amt = action["stat_changes"][stat]
 		StatManager.set_base_stat(stat, StatManager.get_stat(stat) + amt)
 	for upgrade_id in action.get("upgrade_ids", []):
-		UpgradeManager.purchase(upgrade_id)
+		UpgradeManager.purchase(upgrade_id, credit_only)
 	var app_name: String = action.get("app_name", "")
 	if app_name != "":
 		WindowManager.launch_app_by_name(app_name)

--- a/components/apps/sigma_mail/sigma_mail.gd
+++ b/components/apps/sigma_mail/sigma_mail.gd
@@ -96,12 +96,12 @@ func _open_email(email: EmailResource) -> void:
 	var key = "email_%s" % email.get_instance_id()
 	WindowManager.launch_popup(popup_scene, key, email)
 
-func _on_email_action(action: Dictionary) -> void:
+func _on_email_action(action: Dictionary, credit_only: bool = false) -> void:
 	for stat in action.get("stat_changes", {}).keys():
 		var amt = action["stat_changes"][stat]
 		StatManager.set_base_stat(stat, StatManager.get_stat(stat) + amt)
 	for upgrade_id in action.get("upgrade_ids", []):
-		UpgradeManager.purchase(upgrade_id)
+		UpgradeManager.purchase(upgrade_id, credit_only)
 	var app_name: String = action.get("app_name", "")
 	if app_name != "":
 		WindowManager.launch_app_by_name(app_name)

--- a/components/apps/soft_wares/soft_ware_item.gd
+++ b/components/apps/soft_wares/soft_ware_item.gd
@@ -26,6 +26,7 @@ func _ready() -> void:
 	upgrades_button.visible = upgrade_scene != null
 	_update_action_button()
 	action_button.pressed.connect(_on_action_button_pressed)
+	action_button.gui_input.connect(_on_action_button_gui_input)
 	upgrades_button.pressed.connect(_on_upgrades_button_pressed)
 	WindowManager.app_unlocked.connect(_on_app_unlocked)
 
@@ -61,6 +62,27 @@ func _on_action_button_pressed() -> void:
 	else:
 					feedback_label.text = "Not enough funds!"
 					feedback_label.add_theme_color_override("font_color", Color.RED)
+
+func _on_action_button_gui_input(event: InputEvent) -> void:
+	if event is InputEventMouseButton and event.button_index == MOUSE_BUTTON_RIGHT and event.pressed:
+		feedback_label.text = ""
+		feedback_label.remove_theme_color_override("font_color")
+		if WindowManager.is_app_unlocked(app_id):
+			WindowManager.launch_app(app_id)
+			event.accept()
+			return
+		var required_score: int = PortfolioManager.CREDIT_REQUIREMENTS.get(app_title, 0)
+		if PortfolioManager.attempt_spend(float(app_cost), required_score, false, true):
+			var data = {
+				"app_id": app_id,
+				"app_title": app_title,
+				"app_icon": app_icon,
+			}
+			WindowManager.launch_app_by_name("Installer", data)
+		else:
+			feedback_label.text = "Not enough credit!"
+			feedback_label.add_theme_color_override("font_color", Color.RED)
+		event.accept()
 
 func _on_upgrades_button_pressed() -> void:
 		if upgrade_scene:

--- a/components/popups/crypto_popup_ui.gd
+++ b/components/popups/crypto_popup_ui.gd
@@ -46,6 +46,7 @@ func setup(_crypto: Cryptocurrency) -> void:
 func _ready() -> void:
 	super._ready()
 	buy_button.pressed.connect(_on_buy_pressed)
+	buy_button.gui_input.connect(_on_buy_button_gui_input)
 	sell_button.pressed.connect(_on_sell_pressed)
 	for amount in ["0.01", "0.1", "1", "10", "100", "MAX"]:
 			quantity_option.add_item(amount)
@@ -91,6 +92,19 @@ func _on_sell_pressed() -> void:
 			amount = float(sel_text)
 		if PortfolioManager.sell_crypto(crypto.symbol, amount):
 			_update_ui()
+
+func _on_buy_button_gui_input(event: InputEvent) -> void:
+	if event is InputEventMouseButton and event.button_index == MOUSE_BUTTON_RIGHT and event.pressed and crypto:
+		var sel_text := quantity_option.get_item_text(quantity_option.get_selected_id())
+		var amount: float
+		if sel_text == "MAX":
+			amount = PortfolioManager.get_cash() / crypto.price
+		else:
+			amount = float(sel_text)
+		if PortfolioManager.attempt_spend(crypto.price * amount, 0, false, true):
+			PortfolioManager.add_crypto(crypto.symbol, amount)
+			_update_ui()
+		event.accept()
 
 
 func get_custom_save_data() -> Dictionary:

--- a/components/popups/ex_factor_logic.gd
+++ b/components/popups/ex_factor_logic.gd
@@ -107,10 +107,10 @@ func process(delta: float) -> void:
 
 # ---------------------------- User actions ----------------------------
 
-func try_gift() -> bool:
+func try_gift(credit_only: bool = false) -> bool:
 	if npc == null:
 		return false
-	var ok: bool = PortfolioManager.attempt_spend(npc.gift_cost, PortfolioManager.CREDIT_REQUIREMENTS["gift"])
+	var ok: bool = PortfolioManager.attempt_spend(npc.gift_cost, PortfolioManager.CREDIT_REQUIREMENTS["gift"], false, credit_only)
 	if not ok:
 		return false
 	npc.affinity = min(npc.affinity + 5.0, 100.0)
@@ -121,12 +121,12 @@ func try_gift() -> bool:
 	emit_signal("request_persist", {"affinity": npc.affinity, "gift_count": npc.gift_count})
 	return true
 
-func try_date() -> bool:
+func try_date(credit_only: bool = false) -> bool:
 	if npc == null:
-			return false
-	var ok: bool = PortfolioManager.attempt_spend(npc.date_cost, PortfolioManager.CREDIT_REQUIREMENTS["date"])
+		return false
+	var ok: bool = PortfolioManager.attempt_spend(npc.date_cost, PortfolioManager.CREDIT_REQUIREMENTS["date"], false, credit_only)
 	if not ok:
-			return false
+		return false
 	npc.date_count += 1
 	_recalc_costs()
 
@@ -255,11 +255,11 @@ func apologize_try() -> bool:
 func get_apologize_cost() -> int:
 	return APOLOGIZE_COST
 
-func request_next_stage_primary() -> void:
+func request_next_stage_primary(credit_only: bool = false) -> void:
 	if npc.relationship_stage == NPCManager.RelationshipStage.DATING:
 		_transition_dating_to_serious_monog()
 	elif npc.relationship_stage == NPCManager.RelationshipStage.SERIOUS:
-		var ok: bool = PortfolioManager.attempt_spend(npc.proposal_cost, PortfolioManager.CREDIT_REQUIREMENTS["proposal"])
+		var ok: bool = PortfolioManager.attempt_spend(npc.proposal_cost, PortfolioManager.CREDIT_REQUIREMENTS["proposal"], false, credit_only)
 		if ok:
 			_advance_one_stage()
 	else:

--- a/components/popups/ex_factor_view.gd
+++ b/components/popups/ex_factor_view.gd
@@ -100,13 +100,16 @@ func _finalize_setup() -> void:
 
 func _ready() -> void:
 	gift_button.pressed.connect(_on_gift_pressed)
+	gift_button.gui_input.connect(_on_gift_button_gui_input)
 	date_button.pressed.connect(_on_date_pressed)
+	date_button.gui_input.connect(_on_date_button_gui_input)
 	breakup_button.pressed.connect(_on_breakup_pressed)
 	apologize_button.pressed.connect(_on_apologize_pressed)
 	next_stage_button.pressed.connect(_on_next_stage_pressed)
 	breakup_confirm_yes_button.pressed.connect(_on_breakup_confirm_yes_pressed)
 	breakup_confirm_no_button.pressed.connect(_on_breakup_confirm_no_pressed)
 	next_stage_confirm_primary_button.pressed.connect(_on_next_stage_confirm_primary_pressed)
+	next_stage_confirm_primary_button.gui_input.connect(_on_next_stage_confirm_primary_gui_input)
 	next_stage_confirm_alt_button.pressed.connect(_on_next_stage_confirm_alt_pressed)
 	next_stage_confirm_no_button.pressed.connect(_on_next_stage_confirm_no_pressed)
 	love_button.pressed.connect(_on_love_pressed)
@@ -406,6 +409,14 @@ func _on_gift_pressed() -> void:
 				_update_buttons_text()
 				_show_quip("gift")
 
+func _on_gift_button_gui_input(event: InputEvent) -> void:
+	if event is InputEventMouseButton and event.button_index == MOUSE_BUTTON_RIGHT and event.pressed:
+		if logic.try_gift(true):
+			_update_affinity_bar()
+			_update_buttons_text()
+			_show_quip("gift")
+		event.accept()
+
 func _on_date_pressed() -> void:
 
 		if logic.try_date():
@@ -413,6 +424,15 @@ func _on_date_pressed() -> void:
 				_update_buttons_text()
 				_update_next_stage_button()
 				_show_quip("date")
+
+func _on_date_button_gui_input(event: InputEvent) -> void:
+	if event is InputEventMouseButton and event.button_index == MOUSE_BUTTON_RIGHT and event.pressed:
+		if logic.try_date(true):
+			_update_relationship_bar()
+			_update_buttons_text()
+			_update_next_stage_button()
+			_show_quip("date")
+		event.accept()
 
 
 func _on_love_pressed() -> void:
@@ -474,6 +494,14 @@ func _on_next_stage_confirm_primary_pressed() -> void:
 	logic.request_next_stage_primary()
 	_refresh_all()
 	_show_quip("next level")
+
+func _on_next_stage_confirm_primary_gui_input(event: InputEvent) -> void:
+	if event is InputEventMouseButton and event.button_index == MOUSE_BUTTON_RIGHT and event.pressed:
+		next_stage_confirm.visible = false
+		logic.request_next_stage_primary(true)
+		_refresh_all()
+		_show_quip("next level")
+		event.accept()
 
 func _on_next_stage_confirm_alt_pressed() -> void:
 	next_stage_confirm.visible = false

--- a/components/ui/hire_popup.gd
+++ b/components/ui/hire_popup.gd
@@ -33,10 +33,10 @@ func _populate_hire_tab() -> void:
 		card.show_status = false
 		card.button_label = "Hire"
 		card.setup(worker)
-		card.action_pressed.connect(func(w):
+		card.action_pressed.connect(func(w, credit_only):
 			var cost = w.get_hire_cost()
 			print("worker costs: " + str(cost))
-			if PortfolioManager.attempt_spend(cost):
+			if PortfolioManager.attempt_spend(cost, 0, false, credit_only):
 				WorkerManager.hire_worker(w)
 				WorkerManager.available_workers.erase(w)
 				_populate_hire_tab()

--- a/components/ui/worker_card/worker_card_redux.gd
+++ b/components/ui/worker_card/worker_card_redux.gd
@@ -1,7 +1,7 @@
 extends PanelContainer
 #class_name WorkerCardRedux
 
-signal action_pressed(worker: Worker)
+signal action_pressed(worker: Worker, credit_only: bool = false)
 
 @export var show_cost: bool = false
 @export var show_status: bool = true
@@ -50,7 +50,12 @@ func setup(worker_ref: Worker) -> void:
 
 	action_button.text = button_label
 	action_button.pressed.connect(func():
-		emit_signal("action_pressed", worker)
+		emit_signal("action_pressed", worker, false)
+	)
+	action_button.gui_input.connect(func(event):
+		if event is InputEventMouseButton and event.button_index == MOUSE_BUTTON_RIGHT and event.pressed:
+			emit_signal("action_pressed", worker, true)
+			event.accept()
 	)
 	##TODO : connect to assignment_target_changed from TaskManager, toggle select button accordingly
 	update_all()

--- a/components/upgrade_scenes/deprecated/upgrade_tooltip.gd
+++ b/components/upgrade_scenes/deprecated/upgrade_tooltip.gd
@@ -13,6 +13,7 @@ var current_upgrade: Dictionary = {}
 func _ready() -> void:
 		hide_tooltip()
 		TimeManager.minute_passed.connect(_on_minute_passed)
+		buy_button.gui_input.connect(_on_buy_button_gui_input)
 
 func show_tooltip(upgrade: Dictionary):
 		current_upgrade = upgrade
@@ -67,6 +68,14 @@ func _on_buy_button_pressed():
 		if id != "" and UpgradeManager.can_purchase(id):
 				UpgradeManager.purchase(id)
 				_update_display()
+
+func _on_buy_button_gui_input(event: InputEvent) -> void:
+	if event is InputEventMouseButton and event.button_index == MOUSE_BUTTON_RIGHT and event.pressed:
+		var id = current_upgrade.get("id", "")
+		if id != "" and UpgradeManager.can_purchase(id):
+			UpgradeManager.purchase(id, true)
+			_update_display()
+		event.accept()
 
 func format_cost(upgrade: Dictionary) -> String:
 		var cost = UpgradeManager.get_cost_for_next_level(upgrade.get("id"))

--- a/data/upgrades/system_upgrade_ui.gd
+++ b/data/upgrades/system_upgrade_ui.gd
@@ -131,8 +131,8 @@ func _on_sort_option_selected(index: int) -> void:
 		sort_mode = index
 		_queue_refresh()
 
-func _on_purchase_requested(upgrade_id: String):
-	if UpgradeManager.purchase(upgrade_id):
+func _on_purchase_requested(upgrade_id: String, credit_only: bool = false):
+	if UpgradeManager.purchase(upgrade_id, credit_only):
 		_display_message("Upgrade purchased: %s" % upgrade_id)
 		# UpgradeManager emits an `upgrade_purchased` signal on success
 		# which is already connected to `_on_upgrade_changed`. That

--- a/data/upgrades/upgrade_ui.gd
+++ b/data/upgrades/upgrade_ui.gd
@@ -2,7 +2,7 @@ extends PanelContainer
 class_name UpgradeUI
 
 #signal buy_requested(upgrade_id: String)
-signal purchase_requested(upgrade_id: String)
+signal purchase_requested(upgrade_id: String, credit_only: bool = false)
 
 
 var upgrade_data: Dictionary
@@ -18,6 +18,7 @@ var upgrade_queued: bool = false
 
 func _ready() -> void:
 		buy_button.pressed.connect(_on_buy_button_pressed)
+		buy_button.gui_input.connect(_on_buy_button_gui_input)
 		TimeManager.minute_passed.connect(_on_minute_passed)
 		# Re-evaluate affordability whenever relevant stats change so the Buy
 		# button correctly enables when the player gains resources.
@@ -91,7 +92,12 @@ func _refresh_cost() -> void:
 
 
 func _on_buy_button_pressed() -> void:
-		emit_signal("purchase_requested", upgrade_data["id"])
+		emit_signal("purchase_requested", upgrade_data["id"], false)
+
+func _on_buy_button_gui_input(event: InputEvent) -> void:
+	if event is InputEventMouseButton and event.button_index == MOUSE_BUTTON_RIGHT and event.pressed:
+		emit_signal("purchase_requested", upgrade_data["id"], true)
+		event.accept()
 
 func _on_PurchaseButton_pressed() -> void:
 		emit_signal("buy_requested", upgrade_data["id"])

--- a/tests/attempt_spend_credit_only_test.gd
+++ b/tests/attempt_spend_credit_only_test.gd
@@ -1,0 +1,14 @@
+extends Node
+
+func _ready():
+	var pm = Engine.get_singleton("PortfolioManager")
+	pm.reset()
+	pm.cash = 100.0
+	pm.credit_limit = 1000.0
+	pm.credit_used = 0.0
+	pm.credit_interest_rate = 0.0
+	var ok = pm.attempt_spend(50.0, 0, true, true)
+	assert(ok)
+	assert(pm.cash == 100.0)
+	assert(pm.credit_used == 50.0)
+	print("attempt_spend_credit_only_test passed")


### PR DESCRIPTION
## Summary
- Let all spend buttons support right-click credit-only purchases
- Show red "DECLINED" statpop on insufficient credit or score
- Forward credit-only requests through upgrades, hiring, and resource purchases
- Normalize indentation to match project style

## Testing
- `godot4 --headless -s tests/test_runner.gd` *(fails: command not found)*
- `godot --headless -s tests/test_runner.gd` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b8a4df10c48325965b2b950e9c8e07