### PR TITLE
Tighten Siggy speech bubble sizing

### DIFF
--- a/components/siggy/siggy.gd
+++ b/components/siggy/siggy.gd
@@ -64,28 +64,10 @@ func slide_in_from_right():
 	tween.tween_property(self, "position", target_pos, slide_duration).set_trans(Tween.TRANS_BACK).set_ease(Tween.EASE_OUT)
 
 func talk(text: String, time_per_char := 0.05) -> void:
-	speech_bubble.speech_label.text = text
-
-	await get_tree().process_frame
-	speech_bubble.speech_label.visible_ratio = 1.0  # ensure full size for size calculation
-
-	# Determine ideal width without wrapping
-	speech_bubble.speech_label.autowrap_mode = TextServer.AUTOWRAP_OFF
-	var label_size = speech_bubble.speech_label.get_combined_minimum_size()
-	var max_width = 260
-	var target_width = clamp(label_size.x, 80, max_width)
-	speech_bubble.speech_label.custom_minimum_size.x = target_width
-
-	# Re-enable wrapping and calculate height
-	speech_bubble.speech_label.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
-	await get_tree().process_frame
-	label_size = speech_bubble.speech_label.get_combined_minimum_size()
-
-	# Add padding/margin
-	var padding = Vector2(20, 20)
-	var target_size = label_size + padding
-	speech_bubble.custom_minimum_size = target_size
-
+	speech_bubble.set_text(text)
+	
+	# Prepare the bubble for a typewriter effect.
+	var target_size = speech_bubble.size
 	speech_bubble.speech_label.visible_ratio = 0.0
 	speech_bubble.visible = true
 	speech_bubble.modulate.a = 0.0


### PR DESCRIPTION
## Summary
- Use SpeechBubble.set_text to auto-size Siggy's speech bubble around text
- Remove manual width/height calculations that left excess vertical space

## Testing
- `godot4 --headless -s tests/test_runner.gd` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b8b714464883259b2cd169d62caca6