### PR TITLE
Prevent repeat purchases by unlocking apps on first buy

### DIFF
--- a/components/apps/soft_wares/soft_ware_item.gd
+++ b/components/apps/soft_wares/soft_ware_item.gd
@@ -17,7 +17,6 @@ var upgrade_scene: PackedScene = null
 @onready var feedback_label: Label = %FeedbackLabel
 
 func _ready() -> void:
-
 	icon_rect.texture = _prepare_icon(app_icon)
 	#icon_rect.stretch_mode = TextureRect.STRETCH_SCALE
 	icon_rect.texture_repeat = CanvasItem.TEXTURE_REPEAT_DISABLED
@@ -30,38 +29,38 @@ func _ready() -> void:
 	upgrades_button.pressed.connect(_on_upgrades_button_pressed)
 	WindowManager.app_unlocked.connect(_on_app_unlocked)
 
-
 func _prepare_icon(source: Texture2D) -> Texture2D:
 	if source == null:
-			return null
+		return null
 	var img: Image = source.get_image()
 	if img.get_width() != 64 or img.get_height() != 64:
-			img.resize(64, 64, Image.INTERPOLATE_LANCZOS)
+		img.resize(64, 64, Image.INTERPOLATE_LANCZOS)
 	return ImageTexture.create_from_image(img)
 
 func _update_action_button() -> void:
 	if WindowManager.is_app_unlocked(app_id):
-			action_button.text = "Launch"
+		action_button.text = "Launch"
 	else:
-			action_button.text = "Buy App for $" + str(app_cost)
+		action_button.text = "Buy App for $" + str(app_cost)
 
 func _on_action_button_pressed() -> void:
 	feedback_label.text = ""
 	feedback_label.remove_theme_color_override("font_color")
 	if WindowManager.is_app_unlocked(app_id):
-			WindowManager.launch_app(app_id)
-			return
+		WindowManager.launch_app(app_id)
+		return
 	var required_score: int = PortfolioManager.CREDIT_REQUIREMENTS.get(app_title, 0)
 	if PortfolioManager.attempt_spend(float(app_cost), required_score):
-					var data = {
-							"app_id": app_id,
-							"app_title": app_title,
-							"app_icon": app_icon,
-					}
-					WindowManager.launch_app_by_name("Installer", data)
+		WindowManager.unlock_app(app_id, app_title)
+		var data = {
+			"app_id": app_id,
+			"app_title": app_title,
+			"app_icon": app_icon,
+		}
+		WindowManager.launch_app_by_name("Installer", data)
 	else:
-					feedback_label.text = "Not enough funds!"
-					feedback_label.add_theme_color_override("font_color", Color.RED)
+		feedback_label.text = "Not enough funds!"
+		feedback_label.add_theme_color_override("font_color", Color.RED)
 
 func _on_action_button_gui_input(event: InputEvent) -> void:
 	if event is InputEventMouseButton and event.button_index == MOUSE_BUTTON_RIGHT and event.pressed:
@@ -73,11 +72,13 @@ func _on_action_button_gui_input(event: InputEvent) -> void:
 			return
 		var required_score: int = PortfolioManager.CREDIT_REQUIREMENTS.get(app_title, 0)
 		if PortfolioManager.attempt_spend(float(app_cost), required_score, false, true):
+			WindowManager.unlock_app(app_id, app_title)
 			var data = {
 				"app_id": app_id,
 				"app_title": app_title,
 				"app_icon": app_icon,
 			}
+
 			WindowManager.launch_app_by_name("Installer", data)
 		else:
 			feedback_label.text = "Not enough credit!"
@@ -85,8 +86,8 @@ func _on_action_button_gui_input(event: InputEvent) -> void:
 		event.accept()
 
 func _on_upgrades_button_pressed() -> void:
-		if upgrade_scene:
-				WindowManager.launch_popup(upgrade_scene, app_title + "::upgrade")
+	if upgrade_scene:
+		WindowManager.launch_popup(upgrade_scene, app_title + "::upgrade")
 
 func _on_app_unlocked(unlocked_id: String) -> void:
 	if unlocked_id == app_id:


### PR DESCRIPTION
## Summary
- Unlock software apps immediately after purchase so the action button switches to Launch right away
- Avoids spending multiple times on the same app
- Align SoftWareItem script indentation with project style

## Testing
- `/tmp/godot/Godot_v4.2.2-stable_linux.x86_64 --headless --run tests/test_runner.gd` *(fails: missing resources, parse errors, and crash)*

------
https://chatgpt.com/codex/tasks/task_e_68b8b6d9ae6483258669e6b5459241c8