### PR TITLE
Format popup price titles with commas

### DIFF
--- a/components/popups/crypto_popup_ui.gd
+++ b/components/popups/crypto_popup_ui.gd
@@ -38,8 +38,8 @@ func setup(_crypto: Cryptocurrency) -> void:
 
 	price_chart.clear_series()
 	price_chart.add_series(crypto.symbol, "Price", Color(1, 0.6, 0.2))
-	_update_ui()
-	window_title = str(crypto.symbol) + " " + str(crypto.price)
+        _update_ui()
+	window_title = "%s %s" % [crypto.symbol, NumberFormatter.format_commas(crypto.price)]
 	MarketManager.crypto_price_updated.connect(_on_crypto_price_updated)
 
 
@@ -59,7 +59,7 @@ func _on_crypto_price_updated(symbol: String, updated_crypto: Cryptocurrency) ->
 	_update_ui()
 
 func _update_ui() -> void:
-	window_title = str(crypto.symbol) + " " + str(crypto.price)
+	window_title = "%s %s" % [crypto.symbol, NumberFormatter.format_commas(crypto.price)]
 	label_symbol.text = crypto.symbol
 	label_name.text = crypto.display_name
 	label_price.text = "$%.2f" % crypto.price

--- a/components/popups/stock_popup_ui.gd
+++ b/components/popups/stock_popup_ui.gd
@@ -36,8 +36,8 @@ func setup(_stock: Stock) -> void:
 	HistoryManager.add_sample(stock.symbol, TimeManager.get_now_minutes(), stock.price)
 	price_chart.clear_series()
 	price_chart.add_series(stock.symbol, "Price", Color.GREEN)
-	_update_ui()
-	window_title = str(stock.symbol) + " " + str(stock.price)
+        _update_ui()
+	window_title = "%s %s" % [stock.symbol, NumberFormatter.format_commas(stock.price)]
 	# Connect signal
 	MarketManager.stock_price_updated.connect(_on_stock_price_updated)
 
@@ -63,7 +63,7 @@ func _on_stock_price_updated(symbol: String, updated_stock: Stock) -> void:
 	_update_ui()
 
 func _update_ui() -> void:
-	window_title = str(stock.symbol) + " " + str(stock.price)
+	window_title = "%s %s" % [stock.symbol, NumberFormatter.format_commas(stock.price)]
 	label_symbol.text = stock.symbol
 	label_price.text = "$%.2f" % stock.price
 	label_intrinsic.text = "$%.2f" % stock.intrinsic_value


### PR DESCRIPTION
## Summary
- Format crypto popup titles using NumberFormatter.format_commas for prices
- Format stock popup titles with comma-formatted prices
- Normalize window title indentation to match project style

## Testing
- `godot3 --headless --no-window -s tests/test_runner.gd` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b8bb64cdc48325b224ea82cb1e39ae