### PR TITLE
Ensure formatted date uses correct weekday

### DIFF
--- a/autoloads/time_manager.gd
+++ b/autoloads/time_manager.gd
@@ -114,7 +114,8 @@ func get_formatted_time() -> String:
 	return "%s %d:%02d %s" % [day_names[day_of_week], hour_12, minute, am_pm]
 
 func get_formatted_date() -> String:
-	return "%s %d/%d/%d" % [day_names[day_of_week], current_day, current_month, current_year]
+        var weekday := get_weekday_for_date(current_day, current_month, current_year)
+        return "%s %d/%d/%d" % [day_names[weekday], current_day, current_month, current_year]
 
 func get_today() -> Dictionary:
 	return {"day": current_day, "month": current_month, "year": current_year}

--- a/tests/time_manager_formatted_date_sync_test.gd
+++ b/tests/time_manager_formatted_date_sync_test.gd
@@ -1,0 +1,12 @@
+extends SceneTree
+
+func _ready():
+    var tm_script = load("res://autoloads/time_manager.gd")
+    var tm = tm_script.new()
+    tm.day_of_week = 1  # intentionally incorrect
+    var formatted = tm.get_formatted_date()
+    var expected_weekday = tm.day_names[tm.get_weekday_for_date(tm.current_day, tm.current_month, tm.current_year)]
+    var expected = "%s %d/%d/%d" % [expected_weekday, tm.current_day, tm.current_month, tm.current_year]
+    assert(formatted == expected)
+    print("time_manager_formatted_date_sync_test passed")
+    quit()


### PR DESCRIPTION
## Summary
- Compute weekday on demand in `get_formatted_date` to avoid stale `day_of_week` values
- Add regression test ensuring formatted date matches calculated weekday

## Testing
- `godot --headless --script tests/test_runner.gd` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b8c407126c8325b43bea889fa3e4bb