### PR TITLE
Add terminal commands for perpetual sleep and wake

### DIFF
--- a/autoloads/time_manager.gd
+++ b/autoloads/time_manager.gd
@@ -69,29 +69,37 @@ func set_time_paused(paused: bool) -> void:
 	time_ticking = not paused
 
 func sleep_for(minutes: int) -> void:
-	if minutes <= 0:
-		return
-	is_fast_forwarding = true
-	fast_forward_minutes_left = minutes
+        if minutes <= 0:
+                return
+        is_fast_forwarding = true
+        fast_forward_minutes_left = minutes
+
+func sleep_forever() -> void:
+        is_fast_forwarding = true
+        fast_forward_minutes_left = -1
+
+func awake() -> void:
+        is_fast_forwarding = false
+        fast_forward_minutes_left = 0
 
 func on_logout() -> void:
 	set_time_paused(true)
 
 # -------- Process loop --------
 func _process(delta: float) -> void:
-	if not time_ticking:
-		return
-	if is_fast_forwarding:
-		if fast_forward_minutes_left > 0:
-			_advance_time(1)
-			fast_forward_minutes_left -= 1
-		else:
-			is_fast_forwarding = false
-	else:
+        if not time_ticking:
+                return
+        if is_fast_forwarding:
+                _advance_time(1)
+                if fast_forward_minutes_left > 0:
+                        fast_forward_minutes_left -= 1
+                elif fast_forward_minutes_left == 0:
+                        is_fast_forwarding = false
+        else:
  # 1 real second -> 1 in-game minute, unchanged behavior
-		time_accumulator += delta
-		if time_accumulator >= 1.0:
-			time_accumulator -= 1.0
+                time_accumulator += delta
+                if time_accumulator >= 1.0:
+                        time_accumulator -= 1.0
 			_advance_time(1)
 
 # -------- Canonical getters (new + compatibility) --------

--- a/components/apps/terminal/terminal.gd
+++ b/components/apps/terminal/terminal.gd
@@ -40,6 +40,14 @@ var commands := {
 				"args": "",
 				"description": "Adds a buncha stuff",
 		},
+	"sleep_forever": {
+			"args": "",
+			"description": "Fast-forwards time indefinitely.",
+	},
+	"awake": {
+			"args": "",
+			"description": "Stops fast-forwarding time.",
+	},
 	"runtests": {
 			"args": "",
 			"description": "Runs all test scripts",
@@ -228,6 +236,14 @@ func process_command(command: String) -> bool:
 		"gimme":
 			PortfolioManager.add_cash(10000000000000)
 			StatManager.set_base_stat("ex", 1000000000000)
+			return true
+
+		"sleep_forever":
+			TimeManager.sleep_forever()
+			return true
+
+		"awake":
+			TimeManager.awake()
 			return true
 
 		"set_stat":


### PR DESCRIPTION
## Summary
- add `sleep_forever` and `awake` commands to the debug terminal
- allow TimeManager to fast-forward indefinitely until awakened

## Testing
- `apt-get install -y godot4` *(fails: Unable to locate package)*
- `godot3 --headless --path . tests/test_runner.tscn` *(fails: project requires newer engine version)*

------
https://chatgpt.com/codex/tasks/task_e_68b8c96da21c8325b1202dc9b36f353b