### PR TITLE
Enable BBCode links in SigmaMail emails

### DIFF
--- a/components/apps/sigma_mail/email_view.gd
+++ b/components/apps/sigma_mail/email_view.gd
@@ -14,7 +14,9 @@ func setup(email_res: EmailResource) -> void:
 	window_title = email.subject
 	from_label.text = "From: %s" % email.from
 	subject_label.text = "Subject: %s" % email.subject
-	body_label.text = email.body
+	body_label.bbcode_enabled = true
+	body_label.parse_bbcode(email.body)
+	body_label.meta_clicked.connect(_on_body_meta_clicked)
 
 	for child in button_container.get_children():
 		child.queue_free()
@@ -29,6 +31,14 @@ func setup(email_res: EmailResource) -> void:
 				#event.accept()
 		)
 		button_container.add_child(btn)
+
+func _on_body_meta_clicked(meta: Variant) -> void:
+	var meta_str := str(meta)
+	for action in email.buttons:
+		if action.get("id", "") == meta_str:
+			_on_email_action(action)
+			return
+	_on_email_action({"app_name": meta_str})
 
 func _on_email_action(action: Dictionary, credit_only: bool = false) -> void:
 	for stat in action.get("stat_changes", {}).keys():

--- a/resources/emails/README.md
+++ b/resources/emails/README.md
@@ -1,0 +1,16 @@
+# Email Content Guidelines
+
+Email bodies support [Godot BBCode](https://docs.godotengine.org/en/stable/tutorials/ui/bbcode_in_richtextlabel.html) formatting. Useful tags include:
+
+- `[b]bold[/b]`
+- `[i]italic[/i]`
+- `[u]underline[/u]`
+- `[url=ACTION_ID]Link text[/url]` – triggers an email action when clicked.
+
+Use `\n` to insert new lines.
+
+## Action IDs
+- If `ACTION_ID` matches the `id` of a button dictionary in `email.buttons`, that action is invoked.
+- Otherwise, the `ACTION_ID` is treated as an app name and `WindowManager.launch_app_by_name` is called.
+
+This lets content authors embed inline links that launch apps or reuse existing button actions.

--- a/resources/emails/intro_earlybird_friend_email.tres
+++ b/resources/emails/intro_earlybird_friend_email.tres
@@ -6,6 +6,6 @@
 script = ExtResource("1_t4vte")
 from = ""
 subject = "earlybird is literally cracked 🐦💸"
-body = "dude. i cannot stop playing earlybird. it’s like the most addicting thing ever… one run turns into ten, ten turns into a hundred, and suddenly i’m sweating like i’m the worm hahahahaand here’s the kicker: i legit made almost $3 just from playing. three bucks from gaming! yeah, it costs $5, but you can just put that on your credit card. pretty soon it’ll be puuuure profit baby!!anyways, use my referral code to get $1 back after you buy it. i bet you can’t beat my high score—188!your boy,{friend1_first_name}"
+body = "dude. i cannot stop playing [url=EarlyBird]earlybird[/url]. it’s like the most addicting thing ever… one run turns into ten, ten turns into a hundred, and suddenly i’m sweating like i’m the worm hahahaha\n\nand here’s the kicker: i legit made almost $3 just from playing. three bucks from gaming! yeah, it costs $5, but you can just put that on your credit card. pretty soon it’ll be puuuure profit baby!!\n\nanyways, use my referral code to get $1 back after you buy it. i bet you can’t beat my high score—188!\n\nyour boy,\n{friend1_first_name}"
 buttons = Array[Dictionary]([])
 metadata/_custom_type_script = "uid://cpywhkip1uugb"


### PR DESCRIPTION
## Summary
- Parse email bodies with BBCode and support inline action links via `meta_clicked`
- Add inline EarlyBird link and documentation for BBCode tags and action IDs

## Testing
- `godot3-server -s tests/test_runner.gd` *(fails: Can't open project at '/workspace/SigmaSim/project.godot', config_version 5 is from a more recent and incompatible version)*

------
https://chatgpt.com/codex/tasks/task_e_68b8e59cb5b48325ba05bc873dbf949e