### PR TITLE
Respect top bar when maximizing windows

### DIFF
--- a/autoloads/window_manager.gd
+++ b/autoloads/window_manager.gd
@@ -6,6 +6,7 @@ var open_windows: Dictionary = {} # key: WindowFrame, value: taskbar Button
 var popup_registry: Dictionary = {}
 
 var taskbar_container: Control = null
+var topbar_container: Control = null
 var start_panel = null
 
 var focused_window: WindowFrame = null
@@ -367,7 +368,10 @@ func get_taskbar_icon_center(window: WindowFrame) -> Vector2:
 	return window.global_position
 
 func get_taskbar_height() -> int:
-	return taskbar_container.size.y if is_instance_valid(taskbar_container) else 0
+        return taskbar_container.size.y if is_instance_valid(taskbar_container) else 0
+
+func get_topbar_height() -> int:
+        return topbar_container.size.y if is_instance_valid(topbar_container) else 0
 
 func find_window_by_app(title: String) -> WindowFrame:
 	for win in open_windows.keys():

--- a/autoloads/window_manager.gd
+++ b/autoloads/window_manager.gd
@@ -368,10 +368,10 @@ func get_taskbar_icon_center(window: WindowFrame) -> Vector2:
 	return window.global_position
 
 func get_taskbar_height() -> int:
-        return taskbar_container.size.y if is_instance_valid(taskbar_container) else 0
+	return taskbar_container.size.y if is_instance_valid(taskbar_container) else 0
 
 func get_topbar_height() -> int:
-        return topbar_container.size.y if is_instance_valid(topbar_container) else 0
+	return topbar_container.size.y if is_instance_valid(topbar_container) else 0
 
 func find_window_by_app(title: String) -> WindowFrame:
 	for win in open_windows.keys():

--- a/components/ui/window_frame.gd
+++ b/components/ui/window_frame.gd
@@ -439,13 +439,13 @@ func toggle_maximize() -> void:
 			normal_position = global_position
 			normal_size = size
 
-                var viewport_size = get_viewport().get_visible_rect().size
-                var taskbar_height = WindowManager.get_taskbar_height() if WindowManager and WindowManager.has_method("get_taskbar_height") else 0
-                var topbar_height = WindowManager.get_topbar_height() if WindowManager and WindowManager.has_method("get_topbar_height") else 0
+		var viewport_size = get_viewport().get_visible_rect().size
+		var taskbar_height = WindowManager.get_taskbar_height() if WindowManager and WindowManager.has_method("get_taskbar_height") else 0
+		var topbar_height = WindowManager.get_topbar_height() if WindowManager and WindowManager.has_method("get_topbar_height") else 0
 
-                global_position = Vector2(0, topbar_height)
-                size = Vector2(viewport_size.x, viewport_size.y - taskbar_height - topbar_height)
-                window_state = WindowState.MAXIMIZED
+		global_position = Vector2(0, topbar_height)
+		size = Vector2(viewport_size.x, viewport_size.y - taskbar_height - topbar_height)
+		window_state = WindowState.MAXIMIZED
 
 func restore() -> void:
 	if window_state != WindowState.MINIMIZED:
@@ -456,12 +456,12 @@ func restore() -> void:
 	if previous_state == WindowState.NORMAL:
 		global_position = normal_position
 		size = normal_size
-        elif previous_state == WindowState.MAXIMIZED:
-                var viewport_size = get_viewport().get_visible_rect().size
-                var taskbar_height = WindowManager.get_taskbar_height() if WindowManager and WindowManager.has_method("get_taskbar_height") else 0
-                var topbar_height = WindowManager.get_topbar_height() if WindowManager and WindowManager.has_method("get_topbar_height") else 0
-                global_position = Vector2(0, topbar_height)
-                size = Vector2(viewport_size.x, viewport_size.y - taskbar_height - topbar_height)
+	elif previous_state == WindowState.MAXIMIZED:
+		var viewport_size = get_viewport().get_visible_rect().size
+		var taskbar_height = WindowManager.get_taskbar_height() if WindowManager and WindowManager.has_method("get_taskbar_height") else 0
+		var topbar_height = WindowManager.get_topbar_height() if WindowManager and WindowManager.has_method("get_topbar_height") else 0
+		global_position = Vector2(0, topbar_height)
+		size = Vector2(viewport_size.x, viewport_size.y - taskbar_height - topbar_height)
 
 	_clamp_to_screen()
 

--- a/components/ui/window_frame.gd
+++ b/components/ui/window_frame.gd
@@ -439,12 +439,13 @@ func toggle_maximize() -> void:
 			normal_position = global_position
 			normal_size = size
 
-		var viewport_size = get_viewport().get_visible_rect().size
-		var taskbar_height = WindowManager.get_taskbar_height() + 14 if WindowManager and WindowManager.has_method("get_taskbar_height") else 0
+                var viewport_size = get_viewport().get_visible_rect().size
+                var taskbar_height = WindowManager.get_taskbar_height() if WindowManager and WindowManager.has_method("get_taskbar_height") else 0
+                var topbar_height = WindowManager.get_topbar_height() if WindowManager and WindowManager.has_method("get_topbar_height") else 0
 
-		global_position = Vector2.ZERO
-		size = Vector2(viewport_size.x, viewport_size.y - taskbar_height)
-		window_state = WindowState.MAXIMIZED
+                global_position = Vector2(0, topbar_height)
+                size = Vector2(viewport_size.x, viewport_size.y - taskbar_height - topbar_height)
+                window_state = WindowState.MAXIMIZED
 
 func restore() -> void:
 	if window_state != WindowState.MINIMIZED:
@@ -455,9 +456,12 @@ func restore() -> void:
 	if previous_state == WindowState.NORMAL:
 		global_position = normal_position
 		size = normal_size
-	elif previous_state == WindowState.MAXIMIZED:
-		global_position = Vector2.ZERO
-		size = get_viewport().get_visible_rect().size
+        elif previous_state == WindowState.MAXIMIZED:
+                var viewport_size = get_viewport().get_visible_rect().size
+                var taskbar_height = WindowManager.get_taskbar_height() if WindowManager and WindowManager.has_method("get_taskbar_height") else 0
+                var topbar_height = WindowManager.get_topbar_height() if WindowManager and WindowManager.has_method("get_topbar_height") else 0
+                global_position = Vector2(0, topbar_height)
+                size = Vector2(viewport_size.x, viewport_size.y - taskbar_height - topbar_height)
 
 	_clamp_to_screen()
 

--- a/scripts/desktop_env.gd
+++ b/scripts/desktop_env.gd
@@ -2,6 +2,7 @@ extends Control
 
 @onready var start_panel: StartPanelWindow = %StartPanel
 @onready var taskbar: Control = %Taskbar
+@onready var top_bar: Control = %TopBar
 @onready var trash_window: Pane = %TrashWindow
 @onready var start_button: Button = $TaskbarLayer/TaskbarWrapper/MarginContainer/TaskbarRow/StartButton
 
@@ -29,8 +30,9 @@ func _ready() -> void:
 	
 	GameManager.in_game = true
 	#hide_all_windows_and_panels()
-	WindowManager.taskbar_container = taskbar
-	WindowManager.start_panel = start_panel
+        WindowManager.taskbar_container = taskbar
+        WindowManager.topbar_container = top_bar
+        WindowManager.start_panel = start_panel
 	DesktopLayoutManager.items_loaded.connect(_on_items_loaded)
 	DesktopLayoutManager.item_created.connect(_on_item_created)
 	DesktopLayoutManager.item_deleted.connect(_on_item_deleted)

--- a/scripts/desktop_env.gd
+++ b/scripts/desktop_env.gd
@@ -30,9 +30,9 @@ func _ready() -> void:
 	
 	GameManager.in_game = true
 	#hide_all_windows_and_panels()
-        WindowManager.taskbar_container = taskbar
-        WindowManager.topbar_container = top_bar
-        WindowManager.start_panel = start_panel
+	WindowManager.taskbar_container = taskbar
+	WindowManager.topbar_container = top_bar
+	WindowManager.start_panel = start_panel
 	DesktopLayoutManager.items_loaded.connect(_on_items_loaded)
 	DesktopLayoutManager.item_created.connect(_on_item_created)
 	DesktopLayoutManager.item_deleted.connect(_on_item_deleted)


### PR DESCRIPTION
## Summary
- Register the desktop top bar with WindowManager
- Provide WindowManager.get_topbar_height helper
- Offset maximized windows below the top bar

## Testing
- `godot --headless --path . -s tests/test_runner.gd` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b8f18b271c8325a47ad2f2c75350ed