### PR TITLE
Ensure fake cursor appears above popup overlays

### DIFF
--- a/autoloads/cursor_manager.gd
+++ b/autoloads/cursor_manager.gd
@@ -16,12 +16,13 @@ func _ready():
 	call_deferred("_initialize_cursor_scene")
 
 func _initialize_cursor_scene():
-	cursor_layer = preload("res://components/ui/fake_cursor.tscn").instantiate()
-	cursor_layer.name = "FakeCursorLayer"
-	get_tree().get_root().add_child(cursor_layer)
-	cursor = cursor_layer.get_node("FakeCursor")
-	set_process(true)
-	set_enabled(true) # Start enabled
+        cursor_layer = preload("res://components/ui/fake_cursor.tscn").instantiate()
+        cursor_layer.name = "FakeCursorLayer"
+        cursor_layer.layer = 999
+        get_tree().root.get_popup_overlay().add_child(cursor_layer)
+        cursor = cursor_layer.get_node("FakeCursor")
+        set_process(true)
+        set_enabled(true) # Start enabled
 
 func set_enabled(value: bool):
 	enabled = value

--- a/components/ui/fake_cursor.tscn
+++ b/components/ui/fake_cursor.tscn
@@ -3,10 +3,11 @@
 [ext_resource type="Texture2D" uid="uid://cw1fee715bbo" path="res://assets/cursors/cursor_default.png" id="1_kg4j1"]
 
 [node name="FakeCursor" type="CanvasLayer"]
-layer = 128
+layer = 999
 visible = false
 
 [node name="FakeCursor" type="TextureRect" parent="."]
+top_level = true
 z_index = 1024
 anchors_preset = 15
 anchor_right = 1.0


### PR DESCRIPTION
## Summary
- Load fake cursor into popup overlay so it renders above OptionMenu popups
- Set fake cursor CanvasLayer layer to 999 at instantiation
- Mark fake cursor texture rect as top-level with high z-index

## Testing
- ⚠️ `/tmp/godot/Godot_v4.2.1-stable_linux.x86_64 --headless --path . tests/test_runner.tscn` (missing resources prevented tests from running)


------
https://chatgpt.com/codex/tasks/task_e_68b91470c8e08325b03afac4c491be86