### PR TITLE
Set default student loan interest to 10% and add test

### DIFF
--- a/autoloads/bill_manager.gd
+++ b/autoloads/bill_manager.gd
@@ -815,14 +815,15 @@ func get_last_credit_txn_ago() -> String:
 	return "—"
 
 func get_student_loan_summary() -> Dictionary:
-	var out: Dictionary = {}
-	out["principal"] = 0.0
-	out["interest_rate"] = 0.0
-	out["accrued_interest"] = 0.0
-	out["next_due"] = ""
-	out["min_due"] = 0.0
-	out["autopay"] = false
-	return out
+       var out: Dictionary = {}
+       out["principal"] = PortfolioManager.get_student_loans()
+       # Annual percentage rate shown as a percent (e.g. 10 for 10%).
+       out["interest_rate"] = PortfolioManager.STUDENT_LOAN_INTEREST_DAILY * 365.0 * 100.0
+       out["accrued_interest"] = 0.0
+       out["next_due"] = ""
+       out["min_due"] = PortfolioManager.get_min_student_loan_payment()
+       out["autopay"] = false
+       return out
 
 func pay_student_loan(amount: float) -> void:
 	pay_debt("Student Loan", amount)

--- a/autoloads/portfolio_manager.gd
+++ b/autoloads/portfolio_manager.gd
@@ -66,7 +66,9 @@ var student_loans: float:
 		set_student_loans(value)
 
 var student_loan_min_payment: float = 0.0
-const STUDENT_LOAN_INTEREST_DAILY := 0.001  # 0.1% per day
+## Daily interest rate used to accrue student loan debt.
+## 10% annual interest divided by 365 to apply interest each day.
+const STUDENT_LOAN_INTEREST_DAILY := 0.10 / 365.0
 const STUDENT_LOAN_MIN_PAYMENT_PERCENT := 0.01  # 1% per 4 weeks
 
 ## --- Income sources

--- a/tests/student_loan_interest_default_test.gd
+++ b/tests/student_loan_interest_default_test.gd
@@ -1,0 +1,12 @@
+extends SceneTree
+
+func _ready():
+        var pm = Engine.get_singleton("PortfolioManager")
+        pm.reset()
+        pm.set_student_loans(100.0)
+        pm._accrue_student_loan_interest()
+        var expected = snapped(100.0 * (1.0 + PortfolioManager.STUDENT_LOAN_INTEREST_DAILY), 0.01)
+        assert(pm.get_student_loans() == expected)
+        print("student_loan_interest_default_test passed")
+        quit()
+

--- a/tests/student_loan_interest_default_test.gd.uid
+++ b/tests/student_loan_interest_default_test.gd.uid
@@ -1,0 +1,1 @@
+uid://y3mwdgp6uemv


### PR DESCRIPTION
## Summary
- set daily student loan interest to 10% APR equivalent
- expose student loan details including APR and minimum payment
- add test ensuring student loan interest accrues at the default rate

## Testing
- `/tmp/godot/Godot_v4.2.1-stable_linux.x86_64 --headless --path . tests/test_runner.tscn` *(fails: missing resources and unresolved types)*

------
https://chatgpt.com/codex/tasks/task_e_68b9149d13fc83258c977d748663fc15