### PR TITLE
Remove unused income fields

### DIFF
--- a/autoloads/player_manager.gd
+++ b/autoloads/player_manager.gd
@@ -73,7 +73,6 @@ var default_user_data: Dictionary = {
 	"productivity_per_click": 1.0,
 	"power_per_click": 1.0,
 	"gpu_power": 1.0,
-	"worker_productivity": 100,
 	
 	# Chat Battle Stats
 	"attractiveness": 50,

--- a/autoloads/portfolio_manager.gd
+++ b/autoloads/portfolio_manager.gd
@@ -69,12 +69,6 @@ const STUDENT_LOAN_INTEREST_DAILY := 0.001  # 0.1% per day
 const STUDENT_LOAN_MIN_PAYMENT_PERCENT := 0.01  # 1% per 4 weeks
 
 ## --- Income sources
-var employee_income: float:
-	get:
-		return get_employee_income()
-	set(value):
-		set_employee_income(value)
-
 var passive_income: float:
 	get:
 		return get_passive_income_stat()
@@ -136,12 +130,6 @@ func get_credit_interest_rate() -> float:
 
 func set_credit_interest_rate(value: float) -> void:
 	StatManager.set_base_stat("credit_interest_rate", value)
-
-func get_employee_income() -> float:
-	return StatManager.get_stat("employee_income")
-
-func set_employee_income(value: float) -> void:
-	StatManager.set_base_stat("employee_income", value)
 
 func get_passive_income_stat() -> float:
 	return StatManager.get_stat("passive_income")
@@ -372,9 +360,6 @@ func _on_student_loans_changed(_value: float) -> void:
 func get_balance() -> float:
 		return snapped(get_cash() + get_total_investments() - get_total_debt(), 0.01)
 
-func get_passive_income() -> float:
-		return snapped(get_rent() + get_employee_income() + get_interest() / 365.0 / 24.0 / 60.0 / 60.0, 0.01)
-
 func halve_assets() -> void:
 	set_cash(get_cash() / 2.0)
 	for symbol in stocks_owned.keys():
@@ -521,7 +506,6 @@ func reset():
 	set_credit_used(0.0)
 	set_credit_interest_rate(0.3)
 	set_student_loans(0.0)
-	set_employee_income(0.0)
 	set_passive_income(0.0)
 	credit_score = 700
 	student_loan_min_payment = 0.0

--- a/components/apps/broke_rage/broke_rage_ui.gd
+++ b/components/apps/broke_rage/broke_rage_ui.gd
@@ -66,7 +66,7 @@ func _ready() -> void:
 	await get_tree().process_frame
 	# Initial UI update
 	_on_cash_updated(PortfolioManager.cash)
-	_on_passive_income_updated(PortfolioManager.get_passive_income())
+	_on_passive_income_updated(PortfolioManager.passive_income)
 	_on_investments_updated(PortfolioManager.get_total_investments())
 	_on_debt_updated()
 	MarketManager.refresh_prices()
@@ -91,7 +91,7 @@ func _on_cash_updated(_cash: float) -> void:
 
 
 func _on_passive_income_updated(_amount: float) -> void:
-	passive_income_label.text = "Passive Income: $%.2f" % PortfolioManager.get_passive_income()
+	passive_income_label.text = "Passive Income: $%.2f" % PortfolioManager.passive_income
 
 func _on_investments_updated(amount: float):
 	var delta = amount - last_invested
@@ -118,7 +118,7 @@ func _on_resource_changed(resource: String, _value: float) -> void:
 	if resource == "cash":
 		_on_cash_updated(PortfolioManager.cash)
 	elif resource == "passive_income":
-		_on_passive_income_updated(PortfolioManager.get_passive_income())
+		_on_passive_income_updated(PortfolioManager.passive_income)
 	elif resource == "debt":
 		_on_debt_updated()
 


### PR DESCRIPTION
## Summary
- drop unused `worker_productivity` from player defaults
- remove `employee_income` property and references in portfolio manager
- reference `passive_income` directly in BrokeRage UI

## Testing
- `apt-get install -y godot3`
- `/tmp/godot4/Godot_v4.1.3-stable_linux.x86_64 --headless -s tests/test_runner.gd` *(fails: script does not inherit from SceneTree)*
- `/tmp/godot4/Godot_v4.1.3-stable_linux.x86_64 --headless --path . tests/test_runner.tscn` *(fails: missing resources and parse errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b9b7f19f9483259b91eaf6466a70d3