### PR TITLE
feat: add pane nav bar and use in tarot app

### DIFF
--- a/components/apps/app_scenes/tarot_app.tscn
+++ b/components/apps/app_scenes/tarot_app.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=11 format=3 uid="uid://ba3fd3816f1fd"]
+[gd_scene load_steps=12 format=3 uid="uid://ba3fd3816f1fd"]
 
 [ext_resource type="Theme" uid="uid://cesgvqexxaqev" path="res://assets/themes/windows_95_theme.tres" id="1"]
 [ext_resource type="Script" uid="uid://cvgwn14oqkvd5" path="res://components/apps/tarot/tarot_app.gd" id="2"]
@@ -7,6 +7,7 @@
 [ext_resource type="Shader" uid="uid://dp2anhkkaegyq" path="res://assets/shaders/constellation_shader.gdshader" id="4_8tbyh"]
 [ext_resource type="PackedScene" uid="uid://cbg1lyah31ou3" path="res://components/apps/tarot/tarot_upgrades.tscn" id="4_ye0rw"]
 [ext_resource type="FontFile" uid="uid://cbjispsewggqv" path="res://assets/fonts/GALS.ttf" id="5_6i816"]
+[ext_resource type="PackedScene" uid="uid://bnh3x1n0cg4qr" path="res://components/ui/pane_nav_bar.tscn" id="6"]
 
 [sub_resource type="ShaderMaterial" id="ShaderMaterial_6i816"]
 shader = ExtResource("4_8tbyh")
@@ -73,46 +74,32 @@ theme_override_constants/separation = 8
 layout_mode = 2
 size_flags_horizontal = 3
 
-[node name="PanelContainer" type="PanelContainer" parent="MarginContainer/VBox/ContentHBox"]
-custom_minimum_size = Vector2(140, 0)
+[node name="PaneNavBar" parent="MarginContainer/VBox/ContentHBox" instance=ExtResource("6")]
 layout_mode = 2
-size_flags_horizontal = 0
-size_flags_vertical = 2
-size_flags_stretch_ratio = 0.0
 theme_override_styles/panel = SubResource("StyleBoxFlat_tabbar")
 
-[node name="MarginContainer" type="MarginContainer" parent="MarginContainer/VBox/ContentHBox/PanelContainer"]
-layout_mode = 2
-theme_override_constants/margin_left = 10
-theme_override_constants/margin_top = 10
-theme_override_constants/margin_right = 10
-theme_override_constants/margin_bottom = 10
-
-[node name="TabBar" type="VBoxContainer" parent="MarginContainer/VBox/ContentHBox/PanelContainer/MarginContainer"]
-layout_mode = 2
-
-[node name="DrawTabButton" type="Button" parent="MarginContainer/VBox/ContentHBox/PanelContainer/MarginContainer/TabBar"]
+[node name="DrawTabButton" type="Button" parent="MarginContainer/VBox/ContentHBox/PaneNavBar/TabBar"]
 unique_name_in_owner = true
 layout_mode = 2
 focus_mode = 0
 toggle_mode = true
 text = "Daily Draw"
 
-[node name="ReadingsTabButton" type="Button" parent="MarginContainer/VBox/ContentHBox/PanelContainer/MarginContainer/TabBar"]
+[node name="ReadingsTabButton" type="Button" parent="MarginContainer/VBox/ContentHBox/PaneNavBar/TabBar"]
 unique_name_in_owner = true
 layout_mode = 2
 focus_mode = 0
 toggle_mode = true
 text = "Readings"
 
-[node name="CollectionTabButton" type="Button" parent="MarginContainer/VBox/ContentHBox/PanelContainer/MarginContainer/TabBar"]
+[node name="CollectionTabButton" type="Button" parent="MarginContainer/VBox/ContentHBox/PaneNavBar/TabBar"]
 unique_name_in_owner = true
 layout_mode = 2
 focus_mode = 0
 toggle_mode = true
 text = " Collection "
 
-[node name="Control" type="Control" parent="MarginContainer/VBox/ContentHBox/PanelContainer/MarginContainer/TabBar"]
+[node name="Control" type="Control" parent="MarginContainer/VBox/ContentHBox/PaneNavBar/TabBar"]
 custom_minimum_size = Vector2(0, 6)
 layout_mode = 2
 

--- a/components/ui/pane_nav_bar.gd
+++ b/components/ui/pane_nav_bar.gd
@@ -1,0 +1,23 @@
+extends PanelContainer
+class_name PaneNavBar
+
+@export var full_width: float = 140.0
+@export var width_ratio: float = 0.25
+
+@onready var margin_container: MarginContainer = %MarginContainer
+@onready var tab_bar: VBoxContainer = %TabBar
+
+var _root_control: Control
+
+func _ready() -> void:
+    custom_minimum_size.x = full_width
+    _root_control = self
+    while _root_control.get_parent() is Control:
+        _root_control = _root_control.get_parent()
+    if _root_control:
+        _root_control.size_changed.connect(_on_root_resized)
+        _on_root_resized()
+
+func _on_root_resized() -> void:
+    var root_width: float = _root_control.size.x
+    custom_minimum_size.x = min(full_width, root_width * width_ratio)

--- a/components/ui/pane_nav_bar.gd.uid
+++ b/components/ui/pane_nav_bar.gd.uid
@@ -1,0 +1,1 @@
+uid://ctk2ux8f8l14m

--- a/components/ui/pane_nav_bar.tscn
+++ b/components/ui/pane_nav_bar.tscn
@@ -1,0 +1,21 @@
+[gd_scene load_steps=2 format=3 uid="uid://bnh3x1n0cg4qr"]
+
+[ext_resource type="Script" uid="uid://ctk2ux8f8l14m" path="res://components/ui/pane_nav_bar.gd" id="1"]
+
+[node name="PaneNavBar" type="PanelContainer"]
+custom_minimum_size = Vector2(140, 0)
+layout_mode = 2
+size_flags_horizontal = 0
+size_flags_vertical = 2
+size_flags_stretch_ratio = 0.0
+script = ExtResource("1")
+
+[node name="MarginContainer" type="MarginContainer" parent="."]
+layout_mode = 2
+theme_override_constants/margin_left = 10
+theme_override_constants/margin_top = 10
+theme_override_constants/margin_right = 10
+theme_override_constants/margin_bottom = 10
+
+[node name="TabBar" type="VBoxContainer" parent="MarginContainer"]
+layout_mode = 2


### PR DESCRIPTION
## Summary
- add reusable `PaneNavBar` component that shrinks with window size
- replace tarot app's bespoke nav buttons with `PaneNavBar`

## Testing
- `apt-get install -y godot4` *(fails: Unable to locate package)*
- `./godot4 --headless -s tests/test_runner.gd` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b9bd80b7bc8325ac6acdac1c71b263