### PR TITLE
Handle failing tests without crashing

### DIFF
--- a/components/apps/terminal/terminal.gd
+++ b/components/apps/terminal/terminal.gd
@@ -387,8 +387,13 @@ func _run_tests() -> bool:
 
 			var ok: bool = false
 			if script != null:
-				var inst: Object = script.new()
-				if inst != null:
+				var inst: Object = null
+				var success: bool = true
+				try:
+					inst = script.new()
+				catch err:
+					success = false
+				if success and inst != null:
 					ok = true
 
 			if ok:

--- a/tests/test_runner.gd
+++ b/tests/test_runner.gd
@@ -21,7 +21,16 @@ func _ready():
 			var script_path = "res://tests/%s" % file_name
 			print("Running %s" % script_path)
 			var script = load(script_path)
-			script.new()
+			var success := true
+			if script != null:
+				try:
+					script.new()
+				catch err:
+					success = false
+			if success:
+				print("%s: PASS" % file_name)
+			else:
+				print("%s: FAIL" % file_name)
 	dir.list_dir_end()
 	print("Finished running tests")
 	get_tree().quit()


### PR DESCRIPTION
## Summary
- Catch runtime errors when instantiating test scripts in terminal `run_tests`
- Allow `tests/test_runner.gd` to continue on assertion failures and report PASS/FAIL

## Testing
- `godot --headless -s tests/test_runner.gd` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b9be4971a08325bbac7fbaf2612c58