### PR TITLE
Add reusable pane nav bar and integrate in tarot app

### DIFF
--- a/components/apps/app_scenes/tarot_app.tscn
+++ b/components/apps/app_scenes/tarot_app.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=11 format=3 uid="uid://ba3fd3816f1fd"]
+[gd_scene load_steps=12 format=3 uid="uid://ba3fd3816f1fd"]
 
 [ext_resource type="Theme" uid="uid://cesgvqexxaqev" path="res://assets/themes/windows_95_theme.tres" id="1"]
 [ext_resource type="Script" uid="uid://cvgwn14oqkvd5" path="res://components/apps/tarot/tarot_app.gd" id="2"]
@@ -7,6 +7,7 @@
 [ext_resource type="Shader" uid="uid://dp2anhkkaegyq" path="res://assets/shaders/constellation_shader.gdshader" id="4_8tbyh"]
 [ext_resource type="PackedScene" uid="uid://cbg1lyah31ou3" path="res://components/apps/tarot/tarot_upgrades.tscn" id="4_ye0rw"]
 [ext_resource type="FontFile" uid="uid://cbjispsewggqv" path="res://assets/fonts/GALS.ttf" id="5_6i816"]
+[ext_resource type="PackedScene" path="res://components/ui/pane_nav_bar.tscn" id="6_navbar"]
 
 [sub_resource type="ShaderMaterial" id="ShaderMaterial_6i816"]
 shader = ExtResource("4_8tbyh")
@@ -73,46 +74,33 @@ theme_override_constants/separation = 8
 layout_mode = 2
 size_flags_horizontal = 3
 
-[node name="PanelContainer" type="PanelContainer" parent="MarginContainer/VBox/ContentHBox"]
-custom_minimum_size = Vector2(140, 0)
+[node name="PaneNavBar" parent="MarginContainer/VBox/ContentHBox" instance=ExtResource("6_navbar")]
 layout_mode = 2
-size_flags_horizontal = 0
 size_flags_vertical = 2
-size_flags_stretch_ratio = 0.0
 theme_override_styles/panel = SubResource("StyleBoxFlat_tabbar")
 
-[node name="MarginContainer" type="MarginContainer" parent="MarginContainer/VBox/ContentHBox/PanelContainer"]
-layout_mode = 2
-theme_override_constants/margin_left = 10
-theme_override_constants/margin_top = 10
-theme_override_constants/margin_right = 10
-theme_override_constants/margin_bottom = 10
-
-[node name="TabBar" type="VBoxContainer" parent="MarginContainer/VBox/ContentHBox/PanelContainer/MarginContainer"]
-layout_mode = 2
-
-[node name="DrawTabButton" type="Button" parent="MarginContainer/VBox/ContentHBox/PanelContainer/MarginContainer/TabBar"]
+[node name="DrawTabButton" type="Button" parent="MarginContainer/VBox/ContentHBox/PaneNavBar/VBox"]
 unique_name_in_owner = true
 layout_mode = 2
 focus_mode = 0
 toggle_mode = true
 text = "Daily Draw"
 
-[node name="ReadingsTabButton" type="Button" parent="MarginContainer/VBox/ContentHBox/PanelContainer/MarginContainer/TabBar"]
+[node name="ReadingsTabButton" type="Button" parent="MarginContainer/VBox/ContentHBox/PaneNavBar/VBox"]
 unique_name_in_owner = true
 layout_mode = 2
 focus_mode = 0
 toggle_mode = true
 text = "Readings"
 
-[node name="CollectionTabButton" type="Button" parent="MarginContainer/VBox/ContentHBox/PanelContainer/MarginContainer/TabBar"]
+[node name="CollectionTabButton" type="Button" parent="MarginContainer/VBox/ContentHBox/PaneNavBar/VBox"]
 unique_name_in_owner = true
 layout_mode = 2
 focus_mode = 0
 toggle_mode = true
 text = " Collection "
 
-[node name="Control" type="Control" parent="MarginContainer/VBox/ContentHBox/PanelContainer/MarginContainer/TabBar"]
+[node name="Control" type="Control" parent="MarginContainer/VBox/ContentHBox/PaneNavBar/VBox"]
 custom_minimum_size = Vector2(0, 6)
 layout_mode = 2
 

--- a/components/ui/pane_nav_bar.gd
+++ b/components/ui/pane_nav_bar.gd
@@ -1,0 +1,21 @@
+extends PanelContainer
+class_name PaneNavBar
+
+@export var base_min_width: float = 140.0
+@export var width_ratio: float = 0.25
+
+@onready var _margin: MarginContainer = $MarginContainer
+@onready var _vbox: VBoxContainer = $MarginContainer/VBox
+
+func _ready() -> void:
+    var win := get_window()
+    if win:
+        win.size_changed.connect(_update_size)
+        _update_size()
+
+func _update_size() -> void:
+    var win := get_window()
+    if win:
+        var window_width: float = win.size.x
+        var target: float = min(base_min_width, window_width * width_ratio)
+        custom_minimum_size.x = target

--- a/components/ui/pane_nav_bar.tscn
+++ b/components/ui/pane_nav_bar.tscn
@@ -1,0 +1,15 @@
+[gd_scene load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://components/ui/pane_nav_bar.gd" id="1"]
+
+[node name="PaneNavBar" type="PanelContainer"]
+script = ExtResource("1")
+
+[node name="MarginContainer" type="MarginContainer" parent="."]
+theme_override_constants/margin_left = 10
+theme_override_constants/margin_top = 10
+theme_override_constants/margin_right = 10
+theme_override_constants/margin_bottom = 10
+
+[node name="VBox" type="VBoxContainer" parent="MarginContainer"]
+


### PR DESCRIPTION
## Summary
- add generic `PaneNavBar` control that resizes with the window
- refactor Tarot app to use new nav bar component

## Testing
- `godot --headless --path . -s tests/test_runner.gd` *(fails: command not found)*
- `wget https://downloads.tuxfamily.org/godotengine/4.2.1/Godot_v4.2.1-stable_linux_headless.64.zip -O /tmp/godot_headless.zip` *(fails: 503 Service Unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68b9bd80b7bc8325ac6acdac1c71b263