### PR TITLE
Shrink PaneNavBar on small windows

### DIFF
--- a/components/ui/pane_nav_bar.gd
+++ b/components/ui/pane_nav_bar.gd
@@ -8,6 +8,8 @@ var margin: MarginContainer
 var box: BoxContainer
 
 var _use_vertical: bool = false
+var _root_control: Control
+const SHRINK_THRESHOLD := 300.0
 @export var use_vertical: bool = false:
 	set(value):
 			_use_vertical = value
@@ -17,13 +19,20 @@ var _use_vertical: bool = false
 			return _use_vertical
 
 func _ready() -> void:
-		margin = MarginContainer.new()
-		margin.add_theme_constant_override("margin_left", 10)
-		margin.add_theme_constant_override("margin_top", 10)
-		margin.add_theme_constant_override("margin_right", 10)
-		margin.add_theme_constant_override("margin_bottom", 10)
-		add_child(margin)
-		_rebuild_box_container()
+                margin = MarginContainer.new()
+                margin.add_theme_constant_override("margin_left", 10)
+                margin.add_theme_constant_override("margin_top", 10)
+                margin.add_theme_constant_override("margin_right", 10)
+                margin.add_theme_constant_override("margin_bottom", 10)
+                add_child(margin)
+                _rebuild_box_container()
+
+                _root_control = self
+                while _root_control.get_parent() is Control:
+                                _root_control = _root_control.get_parent()
+                if _root_control:
+                                _root_control.resized.connect(_on_root_resized)
+                                _on_root_resized()
 
 func _rebuild_box_container() -> void:
 		if margin == null:
@@ -59,5 +68,15 @@ func _on_button_pressed(tab_id: String) -> void:
 		tab_selected.emit(tab_id)
 
 func set_active(tab_id: String) -> void:
-		if buttons.has(tab_id):
-				_on_button_pressed(tab_id)
+                if buttons.has(tab_id):
+                                _on_button_pressed(tab_id)
+
+func _on_root_resized() -> void:
+                if _root_control == null:
+                                return
+                var size: Vector2 = _root_control.size
+                if size.x < SHRINK_THRESHOLD or size.y < SHRINK_THRESHOLD:
+                                var factor := clamp(min(size.x, size.y) / SHRINK_THRESHOLD, 0.1, 1.0)
+                                scale = Vector2(factor, factor)
+                else:
+                                scale = Vector2.ONE


### PR DESCRIPTION
## Summary
- Auto-shrink `PaneNavBar` by scaling when its window frame becomes smaller than 300px.

## Testing
- ⚠️ `godot --headless -s res://tests/test_runner.gd` *(Godot not installed: `bash: command not found: godot`)*


------
https://chatgpt.com/codex/tasks/task_e_68b9dae00d80832594340f8933c8a1de