### PR TITLE
Add locked connection flag for NPCs

### DIFF
--- a/autoloads/db_manager.gd
+++ b/autoloads/db_manager.gd
@@ -18,6 +18,7 @@ const SCHEMA: Dictionary = {
 		"username": {"data_type": "text"},
 		"occupation": {"data_type": "text"},
 		"relationship_status": {"data_type": "text"},
+		"locked_in_connection": {"data_type": "int"},
 		"relationship_stage": {"data_type": "int"},
 		"relationship_progress": {"data_type": "real"},
 		"exclusivity_core": {"data_type": "int"},
@@ -119,6 +120,8 @@ func _migrate_table(table_name: String, fields: Dictionary):
 		if not existing.has(cname):
 			print("DBManager: Adding missing column %s to table %s" % [cname, table_name])
 			db.query("ALTER TABLE %s ADD COLUMN %s %s" % [table_name, cname, column_defs[cname]])
+			if table_name == "npc" and cname == "locked_in_connection":
+				db.query("UPDATE npc SET locked_in_connection = 1")
 
 # -- NPCs --
 
@@ -134,6 +137,10 @@ func save_npc(idx: int, npc: NPC, slot_id: int = SaveManager.current_slot_id):
 		dict["claimed_serious_monog_boost"] = 1
 	else:
 		dict["claimed_serious_monog_boost"] = 0
+	if npc.locked_in_connection:
+		dict["locked_in_connection"] = 1
+	else:
+		dict["locked_in_connection"] = 0
 	# Serialize all complex fields as JSON
 	dict["gender_vector"] = to_json(dict.get("gender_vector", {"x":0,"y":0,"z":1}))
 	dict["tags"] = to_json(dict.get("tags", []))

--- a/components/npc/npc.gd
+++ b/components/npc/npc.gd
@@ -22,6 +22,8 @@ const BASE_DATE_COST: float = 10.0
 @export var occupation: String = "Funemployed"
 @export var relationship_status: String = "Single"
 
+@export var locked_in_connection: bool = false
+
 @export var relationship_stage: int = NPCManager.RelationshipStage.STRANGER
 @export_range(0, 1000000000, 1) var relationship_progress: float = 0.0
 
@@ -163,6 +165,7 @@ func to_dict() -> Dictionary:
 		"username": username,
 		"occupation": occupation,
 		"relationship_status": relationship_status,
+		"locked_in_connection": locked_in_connection,
 		"relationship_stage": relationship_stage,
 		"relationship_progress": relationship_progress,
 		"exclusivity_core": exclusivity_core,
@@ -229,6 +232,7 @@ static func from_dict(data: Dictionary) -> NPC:
 	npc.username = _safe_string(data.get("username"))
 	npc.occupation  = _safe_string(data.get("occupation"), "Funemployed")
 	npc.relationship_status = _safe_string(data.get("relationship_status"), "Single")
+	npc.locked_in_connection = _safe_int(data.get("locked_in_connection"), 0) != 0
 	npc.relationship_stage = _safe_int(data.get("relationship_stage"), NPCManager.RelationshipStage.STRANGER)
 	npc.relationship_progress = _safe_float(data.get("relationship_progress"))
 	npc.exclusivity_core = _safe_int(data.get("exclusivity_core"), NPCManager.ExclusivityCore.POLY)

--- a/components/npc/npc_factory.gd
+++ b/components/npc/npc_factory.gd
@@ -41,6 +41,7 @@ static func create_npc(npc_index: int) -> NPC:
 	npc.username = _generate_username(npc)
 	npc.occupation = generate_npc_job(full_name)
 	npc.relationship_status = "Single"
+	npc.locked_in_connection = true
 
 	# Personality/OCEAN/Greek
 	var ocean = PersonalityEngine.generate_ocean(full_name)
@@ -143,6 +144,7 @@ static func create_npc_from_name(full_name: String) -> NPC:
 	npc.username = _generate_username(npc)
 	npc.occupation = generate_npc_job(full_name)
 	npc.relationship_status = "Single"
+	npc.locked_in_connection = true
 
 	var ocean := PersonalityEngine.generate_ocean(full_name)
 	npc.ocean = ocean


### PR DESCRIPTION
## Summary
- track whether an NPC is locked into a connection
- persist locked flag in database schema with migration
- set newly-created datable NPCs as locked in

## Testing
- `godot --headless -s tests/test_runner.gd` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b9dda8c6e083258deb099fd850d52e