### PR TITLE
Add LockedIn connections list UI

### DIFF
--- a/src/locked_in/locked_in_connections_list_ui.gd
+++ b/src/locked_in/locked_in_connections_list_ui.gd
@@ -1,0 +1,17 @@
+class_name LockedInConnectionsListUI
+extends PanelContainer
+
+signal connection_selected(npc_id: int)
+
+@onready var buttons_container: VBoxContainer = %ButtonsContainer
+
+func populate(ids: PackedInt32Array) -> void:
+	for child in buttons_container.get_children():
+		child.queue_free()
+
+	for npc_id in ids:
+		var npc: NPC = NPCManager.get_npc_by_index(npc_id)
+		var btn := Button.new()
+		btn.text = npc.full_name
+		btn.pressed.connect(func(): emit_signal("connection_selected", npc_id))
+		buttons_container.add_child(btn)

--- a/src/locked_in/locked_in_connections_list_ui.tscn
+++ b/src/locked_in/locked_in_connections_list_ui.tscn
@@ -1,0 +1,14 @@
+[gd_scene format=3]
+
+[ext_resource type="Script" path="res://src/locked_in/locked_in_connections_list_ui.gd" id="1"]
+
+[node name="LockedInConnectionsListUI" type="PanelContainer"]
+script = ExtResource("1")
+
+[node name="MarginContainer" type="MarginContainer" parent="."]
+[node name="VBoxContainer" type="VBoxContainer" parent="MarginContainer"]
+[node name="Label" type="Label" parent="MarginContainer/VBoxContainer"]
+text = "Connections"
+
+[node name="ButtonsContainer" type="VBoxContainer" parent="MarginContainer/VBoxContainer"]
+unique_name_in_owner = true


### PR DESCRIPTION
## Summary
- Add `locked_in_connections_list_ui.tscn` scene to host connections list
- Implement `locked_in_connections_list_ui.gd` with signal and populate method creating buttons for NPCs

## Testing
- `godot --headless --run-tests` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b9e27f5e308325baeab16e502848f3