### PR TITLE
Make locked-in connections list dynamic with flat buttons

### DIFF
--- a/components/apps/locked_in/locked_in.gd
+++ b/components/apps/locked_in/locked_in.gd
@@ -13,13 +13,10 @@ func _ready() -> void:
 # Test helper to seed the connections list with random NPCs.
 # Picks a few random NPCs, marks them as locked in, and repopulates the list.
 func test_seed_connections(count: int = 3) -> void:
-		var all_ids: Array = NPCManager.npcs.keys()
-		RNGManager.locked_in.shuffle(all_ids)
-		var selected := PackedInt32Array()
-		var limit = min(count, all_ids.size())
-		for i in range(limit):
-				var idx: int = int(all_ids[i])
-				var npc: NPC = NPCManager.get_npc_by_index(idx)
-				npc.locked_in_connection = true
-				selected.append(idx)
-		connections_list.populate(selected)
+                var all_ids: Array = NPCManager.npcs.keys()
+                RNGManager.locked_in.shuffle(all_ids)
+                var limit = min(count, all_ids.size())
+                for i in range(limit):
+                                var idx: int = int(all_ids[i])
+                                NPCManager.set_npc_field(idx, "locked_in_connection", true)
+                connections_list.populate(NPCManager.get_locked_in_connection_ids())

--- a/components/npc/npc_manager.gd
+++ b/components/npc/npc_manager.gd
@@ -9,6 +9,7 @@ signal cheating_detected(primary_idx: int, other_idx: int)
 signal affinity_equilibrium_changed(idx: int, value: float)
 signal breakup_occurred(idx: int)
 signal entered_dating_stage(idx: int)
+signal locked_in_connection_changed(idx: int, locked: bool)
 
 enum RelationshipStage { STRANGER, TALKING, DATING, SERIOUS, ENGAGED, MARRIED, DIVORCED, EX }
 enum ExclusivityCore { MONOG, POLY, CHEATING }
@@ -130,10 +131,12 @@ func set_npc_field(idx: int, field: String, value) -> void:
 			if field == "portrait_config":
 					promote_to_persistent(idx)
 
-	if field == "portrait_config":
-			emit_signal("portrait_changed", idx, value)
-	if field == "affinity":
-			emit_signal("affinity_changed", idx, value)
+        if field == "portrait_config":
+                        emit_signal("portrait_changed", idx, value)
+        if field == "affinity":
+                        emit_signal("affinity_changed", idx, value)
+        if field == "locked_in_connection":
+                        emit_signal("locked_in_connection_changed", idx, value)
 
 
 

--- a/src/locked_in/locked_in_connections_list_ui.gd
+++ b/src/locked_in/locked_in_connections_list_ui.gd
@@ -5,13 +5,20 @@ signal connection_selected(npc_id: int)
 
 @onready var buttons_container: VBoxContainer = %ButtonsContainer
 
-func populate(ids: PackedInt32Array) -> void:
-	for child in buttons_container.get_children():
-		child.queue_free()
+func _ready() -> void:
+                NPCManager.locked_in_connection_changed.connect(func(_idx: int, _locked: bool) -> void:
+                                populate(NPCManager.get_locked_in_connection_ids())
+                )
 
-	for npc_id in ids:
-		var npc: NPC = NPCManager.get_npc_by_index(npc_id)
-		var btn := Button.new()
-		btn.text = npc.full_name
-		btn.pressed.connect(func(): emit_signal("connection_selected", npc_id))
-		buttons_container.add_child(btn)
+func populate(ids: PackedInt32Array) -> void:
+                for child in buttons_container.get_children():
+                                child.queue_free()
+
+                for npc_id in ids:
+                                var npc: NPC = NPCManager.get_npc_by_index(npc_id)
+                                var btn := Button.new()
+                                btn.text = npc.full_name
+                                btn.flat = true
+                                btn.add_theme_font_size_override("font_size", 12)
+                                btn.pressed.connect(func(): emit_signal("connection_selected", npc_id))
+                                buttons_container.add_child(btn)

--- a/src/locked_in/locked_in_connections_list_ui.tscn
+++ b/src/locked_in/locked_in_connections_list_ui.tscn
@@ -18,6 +18,7 @@ layout_mode = 2
 [node name="Label" type="Label" parent="MarginContainer/VBoxContainer"]
 layout_mode = 2
 text = "Connections"
+theme_override_font_sizes/font_size = 12
 
 [node name="ButtonsContainer" type="VBoxContainer" parent="MarginContainer/VBoxContainer"]
 unique_name_in_owner = true

--- a/tests/locked_in_connections_list_test.gd
+++ b/tests/locked_in_connections_list_test.gd
@@ -18,13 +18,23 @@ func _ready() -> void:
 		npc_mgr.npcs[idx] = npc
 		npc_mgr.persistent_npcs[idx] = {}
 
-	var app = LockedInScene.instantiate()
-	add_child(app)
-	await get_tree().process_frame
+        var app = LockedInScene.instantiate()
+        add_child(app)
+        await get_tree().process_frame
+        assert(app.connections_list.buttons_container.get_child_count() == 0)
 
-	app.test_seed_connections(3)
+        NPCManager.set_npc_field(1000, "locked_in_connection", true)
+        await get_tree().process_frame
+        assert(app.connections_list.buttons_container.get_child_count() == 1)
 
-	assert(app.connections_list.buttons_container.get_child_count() == 3)
-	var locked := NPCManager.get_locked_in_connection_ids()
-	assert(locked.size() == 3)
-	print("locked_in_connections_list_test passed")
+        NPCManager.set_npc_field(1001, "locked_in_connection", true)
+        await get_tree().process_frame
+        assert(app.connections_list.buttons_container.get_child_count() == 2)
+
+        NPCManager.set_npc_field(1002, "locked_in_connection", true)
+        await get_tree().process_frame
+        assert(app.connections_list.buttons_container.get_child_count() == 3)
+
+        var locked := NPCManager.get_locked_in_connection_ids()
+        assert(locked.size() == 3)
+        print("locked_in_connections_list_test passed")


### PR DESCRIPTION
## Summary
- Flatten locked-in connections list buttons and fix font size
- Emit locked-in connection change signals and refresh list on updates
- Cover dynamic list updates with new test

## Testing
- `godot --headless --path . tests/test_runner.tscn` *(fails: Error opening file 'uid://gl0rjxkrh4wh')*

------
https://chatgpt.com/codex/tasks/task_e_68ba039dc7208325acfe58e6f4a0545c