### PR TITLE
Keep tarot collection centered when window expands

### DIFF
--- a/components/apps/app_scenes/tarot_app.tscn
+++ b/components/apps/app_scenes/tarot_app.tscn
@@ -165,12 +165,13 @@ text = "  Paid Reading  "
 unique_name_in_owner = true
 visible = false
 layout_mode = 2
+size_flags_horizontal = 3
 size_flags_vertical = 3
 
 [node name="CollectionGrid" type="GridContainer" parent="MarginContainer/VBox/CollectionView"]
 unique_name_in_owner = true
 layout_mode = 2
-size_flags_horizontal = 3
+size_flags_horizontal = 4
 size_flags_vertical = 3
 columns = 6
 


### PR DESCRIPTION
## Summary
- Expand collection view to full width
- Center card grid horizontally within the scroll container

## Testing
- `Godot_v4.2.2-stable_linux.x86_64 --headless --path . -s tests/test_runner.gd` *(fails: Resource file not found: (expected type: ))*

------
https://chatgpt.com/codex/tasks/task_e_68ba43deeec8832592e56c40da3f6e9d