### PR TITLE
Prevent windows from overlapping top ticker

### DIFF
--- a/components/ui/window_frame.gd
+++ b/components/ui/window_frame.gd
@@ -293,8 +293,11 @@ func _clamp_to_screen() -> void:
 		var taskbar_height = 0
 		if WindowManager and WindowManager.has_method("get_taskbar_height"):
 				taskbar_height = WindowManager.get_taskbar_height()
+		var topbar_height = 0
+		if WindowManager and WindowManager.has_method("get_topbar_height"):
+					topbar_height = WindowManager.get_topbar_height()
 
-		var min_position = Vector2(SNAP_MARGIN - size.x, SNAP_MARGIN - size.y)
+		var min_position = Vector2(SNAP_MARGIN - size.x, topbar_height)
 		var max_position = Vector2(screen_size.x - SNAP_MARGIN, screen_size.y - taskbar_height - SNAP_MARGIN)
 
 		position = position.clamp(min_position, max_position)


### PR DESCRIPTION
## Summary
- keep window frames below the top bar ticker

## Testing
- `godot --headless -s tests/test_runner.gd` (fails: command not found)
- `apt-get update && apt-get install -y godot4` (fails: waiting for headers; aborted)


------
https://chatgpt.com/codex/tasks/task_e_68ba47ef9630832594ce3e9082ee07d3