### PR TITLE
Animate upside-down tarot cards

### DIFF
--- a/components/apps/tarot/tarot_app.gd
+++ b/components/apps/tarot/tarot_app.gd
@@ -18,26 +18,26 @@ var card_views: Dictionary = {}
 var _active_tab: String = "Draw"
 
 func _ready() -> void:
-		draw_button.pressed.connect(_on_draw_button_pressed)
-		reading_button.pressed.connect(_on_reading_button_pressed)
-		nav_bar.add_nav_button("Draw", "Draw")
-		nav_bar.add_nav_button("Readings", "Readings")
-		nav_bar.add_nav_button("Collection", "Collection")
-		nav_bar.tab_selected.connect(func(tab_id: String): _activate_tab(tab_id))
-		TarotManager.collection_changed.connect(_on_collection_changed)
-		TimeManager.minute_passed.connect(_on_minute_passed)
-		TimeManager.hour_passed.connect(_on_hour_passed)
-		UpgradeManager.upgrade_purchased.connect(_on_upgrade_purchased)
-		_build_collection_view()
-		_update_cooldown_label()
-		_update_reading_cost_label()
-		_show_last_drawn_card()
-		nav_bar.set_active("Draw")
+	draw_button.pressed.connect(_on_draw_button_pressed)
+	reading_button.pressed.connect(_on_reading_button_pressed)
+	nav_bar.add_nav_button("Draw", "Draw")
+	nav_bar.add_nav_button("Readings", "Readings")
+	nav_bar.add_nav_button("Collection", "Collection")
+	nav_bar.tab_selected.connect(func(tab_id: String): _activate_tab(tab_id))
+	TarotManager.collection_changed.connect(_on_collection_changed)
+	TimeManager.minute_passed.connect(_on_minute_passed)
+	TimeManager.hour_passed.connect(_on_hour_passed)
+	UpgradeManager.upgrade_purchased.connect(_on_upgrade_purchased)
+	_build_collection_view()
+	_update_cooldown_label()
+	_update_reading_cost_label()
+	_show_last_drawn_card()
+	nav_bar.set_active("Draw")
 
 
 func _build_collection_view() -> void:
 	for child in collection_grid.get_children():
-			child.queue_free()
+		child.queue_free()
 	card_views.clear()
 	for card in TarotManager.get_all_cards_ordered():
 		var id: String = card.get("id", "")
@@ -73,42 +73,50 @@ func _on_reading_button_pressed() -> void:
 	var count := 1 + UpgradeManager.get_level("tarot_extra_card")
 	var cards = TarotManager.draw_reading(count)
 	if cards.is_empty():
-			return
+		return
 	_show_reading_cards(cards)
 	_update_reading_cost_label()
 
 func _show_last_drawn_card() -> void:
 	for child in draw_result.get_children():
-			child.queue_free()
+		child.queue_free()
 	var id = TarotManager.last_card_id
 	var rarity = TarotManager.last_card_rarity
 	if id == "" or rarity <= 0:
 		return
 	var count_for_rarity = TarotManager.get_card_rarity_count(id, rarity)
 	var view = TarotManager.instantiate_card_view(id, count_for_rarity, true, rarity)
-	view.set_upside_down(RNGManager.tarot_orientation.get_rng().randf() < 0.5)
+	var upside_down = RNGManager.tarot_orientation.get_rng().randf() < 0.5
+	view.set_upside_down(upside_down)
 	view.show_single_count = true
 	view.modulate.a = 0.0
 	draw_result.add_child(view)
-	create_tween().tween_property(view, "modulate:a", 1.0, 0.3)
+	var t = create_tween()
+	t.tween_property(view, "modulate:a", 1.0, 0.3)
+	if upside_down:
+			t.tween_property(view.texture_rect, "rotation_degrees", 180, 0.3)
 
 func _show_reading_cards(cards: Array) -> void:
 	for child in reading_result.get_children():
-			if child != reading_button and child != reading_cost_label and child != reading_button:
-					child.queue_free()
+		if child != reading_button and child != reading_cost_label and child != reading_button:
+			child.queue_free()
 	var index := 0
 	var flip_rng = RNGManager.tarot_orientation.get_rng()
 	for c in cards:
-			var id: String = c.get("id", "")
-			var rarity: int = int(c.get("rarity", 1))
-			var count_for_rarity = TarotManager.get_card_rarity_count(id, rarity)
-			var view = TarotManager.instantiate_card_view(id, count_for_rarity, true, rarity)
-			view.set_upside_down(flip_rng.randf() < 0.5)
-			view.show_single_count = true
-			view.modulate.a = 0.0
-			reading_result.add_child(view)
-			create_tween().tween_property(view, "modulate:a", 1.0, 0.3).set_delay(index * 0.2)
-			index += 1
+		var id: String = c.get("id", "")
+		var rarity: int = int(c.get("rarity", 1))
+		var count_for_rarity = TarotManager.get_card_rarity_count(id, rarity)
+		var view = TarotManager.instantiate_card_view(id, count_for_rarity, true, rarity)
+		var upside_down = flip_rng.randf() < 0.5
+		view.set_upside_down(upside_down)
+		view.show_single_count = true
+		view.modulate.a = 0.0
+		reading_result.add_child(view)
+		var t = create_tween()
+		t.tween_property(view, "modulate:a", 1.0, 0.3).set_delay(index * 0.2)
+		if upside_down:
+			t.tween_property(view.texture_rect, "rotation_degrees", 180, 0.3)
+		index += 1
 
 
 func _update_cooldown_label() -> void:
@@ -135,19 +143,19 @@ func _on_hour_passed(_current_hour: int, _total_minutes: int) -> void:
 	_update_reading_cost_label()
 
 func _activate_tab(tab_name: String) -> void:
-		if tab_name == "Draw":
-						draw_view.visible = true
-						readings_view.visible = false
-						collection_view.visible = false
-		elif tab_name == "Readings":
-						draw_view.visible = false
-						readings_view.visible = true
-						collection_view.visible = false
-		else:
-						draw_view.visible = false
-						readings_view.visible = false
-						collection_view.visible = true
-		_active_tab = tab_name
+	if tab_name == "Draw":
+		draw_view.visible = true
+		readings_view.visible = false
+		collection_view.visible = false
+	elif tab_name == "Readings":
+		draw_view.visible = false
+		readings_view.visible = true
+		collection_view.visible = false
+	else:
+		draw_view.visible = false
+		readings_view.visible = false
+		collection_view.visible = true
+	_active_tab = tab_name
 
 func _on_upgrade_purchased(id: String, _new_level: int) -> void:
 	if id == "tarot_extra_card":

--- a/components/apps/tarot/tarot_card_view.gd
+++ b/components/apps/tarot/tarot_card_view.gd
@@ -7,6 +7,7 @@ var count: int = 0
 var sell_price: float = 0.0
 var mark_sold_on_sell: bool = false
 var show_single_count: bool = false
+var is_upside_down: bool = false
 
 signal card_pressed(card_id: String)
 
@@ -17,18 +18,18 @@ signal card_pressed(card_id: String)
 @onready var sell_button: Button = %SellButton
 
 const RARITY_NAMES := {
-		1: "Paper",
-		2: "Bronze",
-		3: "Silver",
-		4: "Gold",
-		5: "Divine"
+	1: "Paper",
+	2: "Bronze",
+	3: "Silver",
+	4: "Gold",
+	5: "Divine"
 }
 
 const RARITY_COLORS := {
-		1: Color("6e6e6e"), # dull grey
-		2: Color("cd7f32"), # bronze brown
-		3: Color("e0e0e0"), # silvery white
-		4: Color("ffd700")  # golden yellow
+	1: Color("6e6e6e"), # dull grey
+	2: Color("cd7f32"), # bronze brown
+	3: Color("e0e0e0"), # silvery white
+	4: Color("ffd700")  # golden yellow
 }
 
 const RAINBOW_MATERIAL := preload("res://components/apps/fumble/fumble_label_pride_month_material.tres")
@@ -63,24 +64,24 @@ func update_count(new_count: int) -> void:
 	sell_button.visible = count > 0
 	texture_rect.modulate = Color(1,1,1,1) if count > 0 else Color(0.5,0.5,0.5,1)
 	if count > 0:
-					sell_button.disabled = false
-					sell_button.text = "Sell for $%d" % int(sell_price)
+		sell_button.disabled = false
+		sell_button.text = "Sell for $%d" % int(sell_price)
 
 func update_rarity(new_rarity: int) -> void:
 	rarity = new_rarity
 	rarity_label.text = RARITY_NAMES.get(rarity, "")
 	if rarity == 5:
-					rarity_label.material = RAINBOW_MATERIAL
-					rarity_label.add_theme_color_override("font_color", Color.WHITE)
+		rarity_label.material = RAINBOW_MATERIAL
+		rarity_label.add_theme_color_override("font_color", Color.WHITE)
 	else:
-					rarity_label.material = null
-					rarity_label.add_theme_color_override("font_color", RARITY_COLORS.get(rarity, Color.WHITE))
+		rarity_label.material = null
+		rarity_label.add_theme_color_override("font_color", RARITY_COLORS.get(rarity, Color.WHITE))
 	sell_price = TarotManager.get_sell_price(rarity)
 	sell_button.text = "Sell for $%d" % int(sell_price)
 
 func set_rarity_label_visible(is_visible: bool) -> void:
 	if not is_node_ready():
-					await ready
+		await ready
 	rarity_label.visible = is_visible
 
 func _on_sell_pressed() -> void:
@@ -102,8 +103,12 @@ func _gui_input(event: InputEvent) -> void:
 	if event is InputEventMouseButton and event.pressed and event.button_index == MOUSE_BUTTON_LEFT:
 		card_pressed.emit(card_id)
 
-func set_upside_down(is_upside_down: bool) -> void:
+func set_upside_down(flag: bool) -> void:
 	if not is_node_ready():
-					await ready
-	texture_rect.pivot_offset = texture_rect.size * 0.5
-	texture_rect.rotation_degrees = 180 if is_upside_down else 0
+		await ready
+	is_upside_down = flag
+	if is_upside_down:
+		texture_rect.pivot_offset = texture_rect.size * 0.5
+	else:
+		texture_rect.pivot_offset = Vector2.ZERO
+	texture_rect.rotation_degrees = 0


### PR DESCRIPTION
## Summary
- Randomly flip tarot card views and delay rotation until after fade-in
- Center the pivot on upside-down cards and animate a 180-degree spin
- Normalize indentation in tarot scripts for consistency

## Testing
- ❌ `/tmp/godot/Godot_v4.2.2-stable_linux.x86_64 --headless --path . -s res://tests/tarot_rng_test.gd` (No such file or directory)


------
https://chatgpt.com/codex/tasks/task_e_68ba51f0861c8325afef35609aabd5d0