### PR TITLE
Add OwerView upgrade pane with credit and limit upgrades

### DIFF
--- a/autoloads/portfolio_manager.gd
+++ b/autoloads/portfolio_manager.gd
@@ -51,7 +51,7 @@ const CREDIT_REQUIREMENTS := {
 	"proposal": 800,
 	"bills": 450,
 	"EarlyBird": 550,
-"upgrades": 750,
+	"upgrades": 750,
 
 }
 
@@ -144,6 +144,7 @@ func _ready():
 	StatManager.connect_to_stat("student_loans", self, "_on_student_loans_changed")
 	MarketManager.stock_price_updated.connect(_on_stock_price_updated)
 	TimeManager.day_passed.connect(_on_day_passed)
+	UpgradeManager.upgrade_purchased.connect(_on_upgrade_purchased)
 	_on_cash_changed(get_cash())
 	_on_credit_changed(get_credit_used())
 	_on_student_loans_changed(get_student_loans())
@@ -306,13 +307,18 @@ func _recalculate_credit_score():
 	
 	#TODO: Lower score when payday loans are taken
 
-	var new_score: int = clamp(base_score, 300, 850)
+	var bonus := UpgradeManager.get_level("owerview_credit_up") * 10
+	var new_score: int = clamp(base_score + bonus, 300, 850)
 	if new_score != credit_score:
 		credit_score = new_score
 		emit_signal("credit_score_updated", credit_score)
 		emit_signal("resource_changed", "credit_score", credit_score)
 	else:
 		credit_score = new_score
+
+func _on_upgrade_purchased(id: String, _level: int) -> void:
+	if id == "owerview_credit_up":
+		_recalculate_credit_score()
 
 func pay_down_credit(amount: float) -> bool:
 	if attempt_spend(amount, CREDIT_REQUIREMENTS["pay_down_credit"]):
@@ -418,7 +424,7 @@ func get_crypto_amount(symbol: String) -> float:
 
 func add_crypto(symbol: String, amount: float) -> void:
 	crypto_owned[symbol] = crypto_owned.get(symbol, 0.0) + amount
-	emit_signal("resource_changed", symbol, crypto_owned[symbol])
+		emit_signal("resource_changed", symbol, crypto_owned[symbol])
 
 func sell_crypto(symbol: String, amount: float = 1) -> bool:
 	var owned := get_crypto_amount(symbol)
@@ -431,7 +437,7 @@ func sell_crypto(symbol: String, amount: float = 1) -> bool:
 
 	crypto_owned[symbol] = owned - amount
 	add_cash(amount * crypto.price)
-	emit_signal("resource_changed", symbol, crypto_owned[symbol])
+		emit_signal("resource_changed", symbol, crypto_owned[symbol])
 	return true
 
 func get_crypto_total() -> float:
@@ -507,7 +513,7 @@ func reset():
 	set_credit_interest_rate(0.3)
 	set_student_loans(0.0)
 	set_passive_income(0.0)
-	credit_score = 700
+		credit_score = 700
 	student_loan_min_payment = 0.0
 
 	stocks_owned.clear()

--- a/components/apps/app_scenes/ower_view.tscn
+++ b/components/apps/app_scenes/ower_view.tscn
@@ -1,9 +1,10 @@
-[gd_scene load_steps=6 format=3 uid="uid://bkop7kx52hmpp"]
+[gd_scene load_steps=7 format=3 uid="uid://bkop7kx52hmpp"]
 
 [ext_resource type="Script" uid="uid://ce5ge1lmsdy7g" path="res://components/apps/ower_view/ower_view.gd" id="1"]
 [ext_resource type="Texture2D" uid="uid://bsal74mys2v4b" path="res://assets/logos/owerview_logo.png" id="2"]
 [ext_resource type="Script" uid="uid://bflpybq1kvp4a" path="res://components/apps/ower_view/credit_score_bar.gd" id="3"]
 [ext_resource type="Shader" uid="uid://cn7uadn4j8e8u" path="res://assets/shaders/brown_warp_shader.gdshader" id="3_j5hg3"]
+[ext_resource type="PackedScene" uid="uid://bg4qg6o6zj2oi" path="res://components/upgrade_scenes/owerview_upgrade_ui.tscn" id="4_owupg"]
 
 [sub_resource type="ShaderMaterial" id="ShaderMaterial_aemln"]
 shader = ExtResource("3_j5hg3")
@@ -28,6 +29,7 @@ window_title = "OwerView"
 window_icon = ExtResource("2")
 default_window_size = Vector2(600, 500)
 default_position = "left"
+upgrade_pane = ExtResource("4_owupg")
 
 [node name="ColorRect" type="ColorRect" parent="."]
 material = SubResource("ShaderMaterial_aemln")

--- a/components/upgrade_scenes/owerview_upgrade_ui.gd
+++ b/components/upgrade_scenes/owerview_upgrade_ui.gd
@@ -1,0 +1,2 @@
+extends Pane
+class_name OwerViewUpgradeUI

--- a/components/upgrade_scenes/owerview_upgrade_ui.tscn
+++ b/components/upgrade_scenes/owerview_upgrade_ui.tscn
@@ -1,0 +1,29 @@
+[gd_scene load_steps=3 format=3 uid="uid://bg4qg6o6zj2oi"]
+
+[ext_resource type="Script" uid="uid://cu0y88l5f8trf" path="res://components/upgrade_scenes/owerview_upgrade_ui.gd" id="1_w7t1k"]
+[ext_resource type="PackedScene" uid="uid://c12jraubuv28g" path="res://data/upgrades/system_upgrade_ui.tscn" id="2_w7t1k"]
+
+[node name="OwerViewUpgradeUI" type="PanelContainer"]
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+mouse_filter = 1
+script = ExtResource("1_w7t1k")
+window_title = "OwerView Upgrades"
+default_window_size = Vector2(480, 480)
+
+[node name="MarginContainer" type="MarginContainer" parent="."]
+layout_mode = 2
+theme_override_constants/margin_left = 15
+theme_override_constants/margin_top = 15
+theme_override_constants/margin_right = 15
+theme_override_constants/margin_bottom = 15
+
+[node name="SystemUpgradeUI" parent="MarginContainer" instance=ExtResource("2_w7t1k")]
+layout_mode = 2
+size_flags_vertical = 3
+system_name = "OwerView"

--- a/data/upgrades/owerview_credit_up.json
+++ b/data/upgrades/owerview_credit_up.json
@@ -1,0 +1,19 @@
+{
+    "id": "owerview_credit_up",
+    "name": "Credit Up",
+    "description": "Raises your credit score by 10 points per level.",
+    "effects": [],
+    "systems": [
+        "OwerView"
+    ],
+    "dependencies": [],
+    "cost_per_level": {
+        "cash": 350
+    },
+    "scale_by_formula": true,
+    "cost_formula": {
+        "cash": "base_cost[\"cash\"] * pow(2, level-1)"
+    },
+    "max_level": 20,
+    "repeatable": true
+}

--- a/data/upgrades/owerview_limitless.json
+++ b/data/upgrades/owerview_limitless.json
@@ -1,0 +1,24 @@
+{
+    "id": "owerview_limitless",
+    "name": "Limitless",
+    "description": "Raises credit limit by $2,000 per level.",
+    "effects": [
+        {
+            "target": "credit_limit",
+            "operation": "add",
+            "value": 2000.0
+        }
+    ],
+    "systems": [
+        "OwerView"
+    ],
+    "dependencies": [],
+    "cost_per_level": {
+        "cash": 100
+    },
+    "scale_by_formula": true,
+    "cost_formula": {
+        "cash": "base_cost[\"cash\"] * pow(1.1, level-1)"
+    },
+    "repeatable": true
+}


### PR DESCRIPTION
## Summary
- add upgrade definitions for OwerView: Credit Up and Limitless
- attach new upgrade pane to OwerView scene
- recalculate credit score using Credit Up levels
- remove stray UID file and clean up indentation

## Testing
- `/tmp/godot/Godot_v4.2.1-stable_linux.x86_64 --headless -s tests/test_runner.gd` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68ba69f6453c8325bb0b0705ef1c7f81