### PR TITLE
Double sell price for upside-down tarot cards

### DIFF
--- a/autoloads/tarot_manager.gd
+++ b/autoloads/tarot_manager.gd
@@ -148,21 +148,23 @@ func draw_reading(count: int) -> Array:
 func _on_hour_passed(_current_hour: int, _total_minutes: int) -> void:
 	reading_cost = max(1.0, reading_cost - 1.0)
 
-func sell_card(card_id: String, rarity: int) -> void:
-	var rarities: Dictionary = collection.get(card_id, {})
-	var count := int(rarities.get(rarity, 0))
-	if count <= 0:
-		return
-	rarities[rarity] = count - 1
-	if rarities[rarity] <= 0:
-		rarities.erase(rarity)
-	if rarities.is_empty():
-		collection.erase(card_id)
-	else:
-		collection[card_id] = rarities
-	var price := get_sell_price(rarity)
-	PortfolioManager.add_cash(price)
-	collection_changed.emit(card_id, get_card_count(card_id))
+func sell_card(card_id: String, rarity: int, upside_down: bool = false) -> void:
+        var rarities: Dictionary = collection.get(card_id, {})
+        var count := int(rarities.get(rarity, 0))
+        if count <= 0:
+                return
+        rarities[rarity] = count - 1
+        if rarities[rarity] <= 0:
+                rarities.erase(rarity)
+        if rarities.is_empty():
+                collection.erase(card_id)
+        else:
+                collection[card_id] = rarities
+        var price := get_sell_price(rarity)
+        if upside_down:
+                price *= 2.0
+        PortfolioManager.add_cash(price)
+        collection_changed.emit(card_id, get_card_count(card_id))
 
 func get_sell_price(rarity: int) -> float:
 	return RARITY_SELL_VALUES.get(rarity, 1.0)

--- a/components/apps/tarot/tarot_card_view.gd
+++ b/components/apps/tarot/tarot_card_view.gd
@@ -68,16 +68,18 @@ func update_count(new_count: int) -> void:
 		sell_button.text = "Sell for $%d" % int(sell_price)
 
 func update_rarity(new_rarity: int) -> void:
-	rarity = new_rarity
-	rarity_label.text = RARITY_NAMES.get(rarity, "")
-	if rarity == 5:
-		rarity_label.material = RAINBOW_MATERIAL
-		rarity_label.add_theme_color_override("font_color", Color.WHITE)
-	else:
-		rarity_label.material = null
-		rarity_label.add_theme_color_override("font_color", RARITY_COLORS.get(rarity, Color.WHITE))
-	sell_price = TarotManager.get_sell_price(rarity)
-	sell_button.text = "Sell for $%d" % int(sell_price)
+        rarity = new_rarity
+        rarity_label.text = RARITY_NAMES.get(rarity, "")
+        if rarity == 5:
+                rarity_label.material = RAINBOW_MATERIAL
+                rarity_label.add_theme_color_override("font_color", Color.WHITE)
+        else:
+                rarity_label.material = null
+                rarity_label.add_theme_color_override("font_color", RARITY_COLORS.get(rarity, Color.WHITE))
+        sell_price = TarotManager.get_sell_price(rarity)
+        if is_upside_down:
+                sell_price *= 2.0
+        sell_button.text = "Sell for $%d" % int(sell_price)
 
 func set_rarity_label_visible(is_visible: bool) -> void:
 	if not is_node_ready():
@@ -85,12 +87,12 @@ func set_rarity_label_visible(is_visible: bool) -> void:
 	rarity_label.visible = is_visible
 
 func _on_sell_pressed() -> void:
-	TarotManager.sell_card(card_id, rarity)
-	var new_count = TarotManager.get_card_rarity_count(card_id, rarity)
-	update_count(new_count)
-	if mark_sold_on_sell:
-		sell_button.text = "SOLD"
-		sell_button.disabled = true
+        TarotManager.sell_card(card_id, rarity, is_upside_down)
+        var new_count = TarotManager.get_card_rarity_count(card_id, rarity)
+        update_count(new_count)
+        if mark_sold_on_sell:
+                sell_button.text = "SOLD"
+                sell_button.disabled = true
 		sell_button.visible = true
 
 func _ready() -> void:
@@ -104,11 +106,15 @@ func _gui_input(event: InputEvent) -> void:
 		card_pressed.emit(card_id)
 
 func set_upside_down(flag: bool) -> void:
-	if not is_node_ready():
-		await ready
-	is_upside_down = flag
-	if is_upside_down:
-		texture_rect.pivot_offset = texture_rect.size * 0.5
-	else:
-		texture_rect.pivot_offset = Vector2.ZERO
-	texture_rect.rotation_degrees = 0
+        if not is_node_ready():
+                await ready
+        is_upside_down = flag
+        if is_upside_down:
+                texture_rect.pivot_offset = texture_rect.size * 0.5
+        else:
+                texture_rect.pivot_offset = Vector2.ZERO
+        texture_rect.rotation_degrees = 0
+        sell_price = TarotManager.get_sell_price(rarity)
+        if is_upside_down:
+                sell_price *= 2.0
+        sell_button.text = "Sell for $%d" % int(sell_price)

--- a/tests/tarot_upside_down_sell_test.gd
+++ b/tests/tarot_upside_down_sell_test.gd
@@ -1,0 +1,18 @@
+extends SceneTree
+
+func _ready():
+    TarotManager.reset()
+    PortfolioManager.cash = 0.0
+    var cards = TarotManager.get_all_cards_ordered()
+    var id = cards[0].get("id", "")
+    var rarity = 3
+    TarotManager.collection[id] = {rarity: 1}
+    var base_price = TarotManager.get_sell_price(rarity)
+    TarotManager.sell_card(id, rarity, true)
+    assert(PortfolioManager.cash == base_price * 2.0)
+    PortfolioManager.cash = 0.0
+    TarotManager.collection[id] = {rarity: 1}
+    TarotManager.sell_card(id, rarity)
+    assert(PortfolioManager.cash == base_price)
+    print("tarot_upside_down_sell_test passed")
+    quit()

--- a/tests/tarot_upside_down_sell_test.gd.uid
+++ b/tests/tarot_upside_down_sell_test.gd.uid
@@ -1,0 +1,1 @@
+uid://tarotupsidedownsell


### PR DESCRIPTION
## Summary
- Allow tarot cards drawn upside-down to sell for twice their normal value
- Update card view to show enhanced sell price when upside-down
- Add regression test ensuring upside-down cards yield double cash

## Testing
- `godot --headless --run tests/test_runner.tscn` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb1f01372083258b798729b966d628