### PR TITLE
Focus exfactorview from AIMChatUI header

### DIFF
--- a/components/apps/alpha_instant_messenger/aim_chat_ui.gd
+++ b/components/apps/alpha_instant_messenger/aim_chat_ui.gd
@@ -3,7 +3,7 @@ class_name AimChatUI
 
 const EX_FACTOR_VIEW_SCENE: PackedScene = preload("res://components/popups/ex_factor_view.tscn")
 
-@onready var header: HBoxContainer = %HeaderHBox
+@onready var header_container: PanelContainer = %HeaderContainer
 @onready var name_label: Label = %NameLabel
 @onready var portrait_view: PortraitView = %Portrait
 @onready var messages_vbox: VBoxContainer = %MessagesVBox
@@ -25,11 +25,12 @@ func setup_custom(data: Dictionary) -> void:
 		ready.connect(_finalize_setup, CONNECT_ONE_SHOT)
 
 func _ready() -> void:
-	header.gui_input.connect(_on_header_gui_input)
-	greet_button.pressed.connect(_on_greet_pressed)
-	gift_button.pressed.connect(_on_gift_pressed)
-	date_button.pressed.connect(_on_date_pressed)
-	relationship_button.pressed.connect(_on_relationship_pressed)
+        name_label.mouse_filter = Control.MOUSE_FILTER_PASS
+        header_container.gui_input.connect(_on_header_gui_input)
+        greet_button.pressed.connect(_on_greet_pressed)
+        gift_button.pressed.connect(_on_gift_pressed)
+        date_button.pressed.connect(_on_date_pressed)
+        relationship_button.pressed.connect(_on_relationship_pressed)
 
 func _finalize_setup() -> void:
 	if npc == null:
@@ -44,10 +45,14 @@ func _finalize_setup() -> void:
 		portrait_view.apply_config(npc.portrait_config)
 
 func _on_header_gui_input(event: InputEvent) -> void:
-	if event is InputEventMouseButton and event.pressed and event.button_index == MOUSE_BUTTON_LEFT:
-		if _is_romantically_pursuing():
-			var key := "ex_factor_%d" % npc_idx
-			WindowManager.launch_popup(EX_FACTOR_VIEW_SCENE, key, {"npc": npc, "npc_idx": npc_idx})
+        if event is InputEventMouseButton and event.pressed and event.button_index == MOUSE_BUTTON_LEFT:
+                if _is_romantically_pursuing():
+                        var key := "ex_factor_%d" % npc_idx
+                        var existing := WindowManager.find_popup_by_key(key)
+                        if existing:
+                                WindowManager.focus_window(existing)
+                        else:
+                                WindowManager.launch_popup(EX_FACTOR_VIEW_SCENE, key, {"npc": npc, "npc_idx": npc_idx})
 
 func _is_romantically_pursuing() -> bool:
 	if npc_idx == -1:


### PR DESCRIPTION
## Summary
- make AimChatUI `%HeaderContainer` open or focus ex-factor view for that NPC
- ensure name label forwards click events to the header container

## Testing
- `godot4 --headless --run tests/test_runner.gd` *(fails: Could not find type "ContextAction" in the current scope)*

------
https://chatgpt.com/codex/tasks/task_e_68bb5dd113a483259473c132bf66a8ca