### PR TITLE
Fix AIMChatUI header click event

### DIFF
--- a/components/apps/alpha_instant_messenger/aim_chat_ui.gd
+++ b/components/apps/alpha_instant_messenger/aim_chat_ui.gd
@@ -25,12 +25,11 @@ func setup_custom(data: Dictionary) -> void:
 		ready.connect(_finalize_setup, CONNECT_ONE_SHOT)
 
 func _ready() -> void:
-	name_label.mouse_filter = Control.MOUSE_FILTER_PASS
-	header_container.gui_input.connect(_on_header_gui_input)
-	greet_button.pressed.connect(_on_greet_pressed)
-	gift_button.pressed.connect(_on_gift_pressed)
-	date_button.pressed.connect(_on_date_pressed)
-	relationship_button.pressed.connect(_on_relationship_pressed)
+        header_container.gui_input.connect(_on_header_gui_input)
+        greet_button.pressed.connect(_on_greet_pressed)
+        gift_button.pressed.connect(_on_gift_pressed)
+        date_button.pressed.connect(_on_date_pressed)
+        relationship_button.pressed.connect(_on_relationship_pressed)
 
 func _finalize_setup() -> void:
 	if npc == null:

--- a/components/apps/alpha_instant_messenger/aim_chat_ui.tscn
+++ b/components/apps/alpha_instant_messenger/aim_chat_ui.tscn
@@ -38,6 +38,7 @@ layout_mode = 2
 [node name="HeaderHBox" type="HBoxContainer" parent="MarginContainer/VBoxContainer/HeaderContainer"]
 unique_name_in_owner = true
 layout_mode = 2
+mouse_filter = 2
 
 [node name="Portrait" parent="MarginContainer/VBoxContainer/HeaderContainer/HeaderHBox" instance=ExtResource("2")]
 unique_name_in_owner = true
@@ -50,6 +51,7 @@ portrait_creator_enabled = false
 [node name="NameLabel" type="Label" parent="MarginContainer/VBoxContainer/HeaderContainer/HeaderHBox"]
 unique_name_in_owner = true
 layout_mode = 2
+mouse_filter = 2
 text = "@username"
 vertical_alignment = 1
 


### PR DESCRIPTION
## Summary
- let AIM chat header container handle opening the Ex Factor view
- ignore mouse events from header children so clicks reach the container

## Testing
- `Godot_v4.2.1-stable_linux.x86_64 --headless --path . tests/test_runner.tscn` *(fails: command not found)*
- `apt-get install -y godot4` *(fails: Unable to locate package)*
- `curl -L -o /tmp/Godot_v4.2.1-stable_linux.x86_64.zip https://downloads.tuxfamily.org/godotengine/4.2.1/Godot_v4.2.1-stable_linux.x86_64.zip` *(fails: connection timeout)*

------
https://chatgpt.com/codex/tasks/task_e_68bb699701f48325b0f8a0469eb4c71d