### PR TITLE
Add persistent credit score bonus from upgrade

### DIFF
--- a/autoloads/portfolio_manager.gd
+++ b/autoloads/portfolio_manager.gd
@@ -142,11 +142,13 @@ func _ready():
 	StatManager.connect_to_stat("credit_used", self, "_on_credit_changed")
 	StatManager.connect_to_stat("credit_limit", self, "_on_credit_changed")
 	StatManager.connect_to_stat("student_loans", self, "_on_student_loans_changed")
+	StatManager.connect_to_stat("bonus_credit_score", self, "_on_bonus_credit_score_changed")
 	MarketManager.stock_price_updated.connect(_on_stock_price_updated)
 	TimeManager.day_passed.connect(_on_day_passed)
 	_on_cash_changed(get_cash())
 	_on_credit_changed(get_credit_used())
 	_on_student_loans_changed(get_student_loans())
+	_on_bonus_credit_score_changed(StatManager.get_stat("bonus_credit_score"))
 
 ## --- Spending Router
 func attempt_spend(amount: float, credit_required_score: int = 0, silent: bool = false, credit_only: bool = false) -> bool:
@@ -303,9 +305,8 @@ func _recalculate_credit_score():
 	# Optional: reward low debt
 	#if get_student_loans() == 0:
 	#	base_score += 20
-	
 	#TODO: Lower score when payday loans are taken
-
+	base_score += int(StatManager.get_stat("bonus_credit_score"))
 	var new_score: int = clamp(base_score, 300, 850)
 	if new_score != credit_score:
 		credit_score = new_score
@@ -352,6 +353,9 @@ func _on_student_loans_changed(_value: float) -> void:
 		_update_student_loan_min_payment()
 		emit_signal("resource_changed", "student_loans", get_student_loans())
 		emit_signal("resource_changed", "debt", get_total_debt())
+		_recalculate_credit_score()
+
+func _on_bonus_credit_score_changed(_value: float) -> void:
 		_recalculate_credit_score()
 
 

--- a/data/stats/base_stats.json
+++ b/data/stats/base_stats.json
@@ -10,5 +10,6 @@
   "affinity_drift_rate": 1.0,
   "love_affinity_gain": 5.0,
   "worm_yield": 1.0,
-  "upgrade_cooldown_multiplier": 1.0
+  "upgrade_cooldown_multiplier": 1.0,
+  "bonus_credit_score": 0.0
 }

--- a/data/upgrades/owerview_credit_up.json
+++ b/data/upgrades/owerview_credit_up.json
@@ -1,8 +1,14 @@
 {
 	"id": "owerview_credit_up",
 	"name": "Credit Up",
-	"description": "Raises your credit score by 10 points per level.",
-	"effects": [],
+        "description": "Raises your credit score by 10 points per level.",
+        "effects": [
+                {
+                        "target": "bonus_credit_score",
+                        "operation": "add",
+                        "value": 10
+                }
+        ],
 	"systems": [
 		"OwerView"
 	],

--- a/tests/owerview_credit_up_upgrade_test.gd
+++ b/tests/owerview_credit_up_upgrade_test.gd
@@ -1,0 +1,18 @@
+extends SceneTree
+
+func _ready() -> void:
+	var pm = Engine.get_singleton("PortfolioManager")
+	var prev_level := UpgradeManager.get_level("owerview_credit_up")
+	pm.credit_used = 0.0
+	pm.credit_limit = 1000.0
+	pm.credit_score = 700
+	UpgradeManager.player_levels["owerview_credit_up"] = 1
+	StatManager.recalculate_all_stats_once()
+	pm._recalculate_credit_score()
+	assert(pm.credit_score == 710)
+	UpgradeManager.player_levels["owerview_credit_up"] = prev_level
+	StatManager.recalculate_all_stats_once()
+	pm._recalculate_credit_score()
+	assert(pm.credit_score == 700)
+	print("owerview_credit_up_upgrade_test passed")
+	quit()


### PR DESCRIPTION
## Summary
- add `bonus_credit_score` stat and apply `Credit Up` upgrade to it
- include bonus credit score in credit score recalculation
- test that `Credit Up` raises the credit score
- align indentation and drop unnecessary `.uid` file

## Testing
- `godot4 --headless --script tests/test_runner.gd` *(fails: command not found)*
- `godot --headless --script tests/test_runner.gd` *(fails: command not found)*
- `godot3 --headless --script tests/test_runner.gd` *(fails: config_version 5 from newer engine)*

------
https://chatgpt.com/codex/tasks/task_e_68bb2a94ad0c83259068dc99a8a2979a