### PR TITLE
Persist tarot card upside-down state

### DIFF
--- a/components/apps/tarot/tarot_app.gd
+++ b/components/apps/tarot/tarot_app.gd
@@ -85,16 +85,17 @@ func _show_last_drawn_card() -> void:
 	if id == "" or rarity <= 0:
 		return
 	var count_for_rarity = TarotManager.get_card_rarity_count(id, rarity)
-	var view = TarotManager.instantiate_card_view(id, count_for_rarity, true, rarity)
-	var upside_down = RNGManager.tarot_orientation.get_rng().randf() < 0.5
-	view.set_upside_down(upside_down)
-	view.show_single_count = true
-	view.modulate.a = 0.0
-	draw_result.add_child(view)
-	var t = create_tween()
-	t.tween_property(view, "modulate:a", 1.0, 0.3)
-	if upside_down:
-			t.tween_property(view.texture_rect, "rotation_degrees", 180, 0.3)
+        var view = TarotManager.instantiate_card_view(id, count_for_rarity, true, rarity)
+        var upside_down = RNGManager.tarot_orientation.get_rng().randf() < 0.5
+        view.set_upside_down(upside_down)
+        view.show_single_count = true
+        view.modulate.a = 0.0
+        draw_result.add_child(view)
+        var t = create_tween()
+        t.tween_property(view, "modulate:a", 1.0, 0.3)
+        if upside_down:
+                        view.texture_rect.rotation_degrees = 0
+                        t.tween_property(view.texture_rect, "rotation_degrees", 180, 0.3)
 
 func _show_reading_cards(cards: Array) -> void:
 	for child in reading_result.get_children():
@@ -106,17 +107,18 @@ func _show_reading_cards(cards: Array) -> void:
 		var id: String = c.get("id", "")
 		var rarity: int = int(c.get("rarity", 1))
 		var count_for_rarity = TarotManager.get_card_rarity_count(id, rarity)
-		var view = TarotManager.instantiate_card_view(id, count_for_rarity, true, rarity)
-		var upside_down = flip_rng.randf() < 0.5
-		view.set_upside_down(upside_down)
-		view.show_single_count = true
-		view.modulate.a = 0.0
-		reading_result.add_child(view)
-		var t = create_tween()
-		t.tween_property(view, "modulate:a", 1.0, 0.3).set_delay(index * 0.2)
-		if upside_down:
-			t.tween_property(view.texture_rect, "rotation_degrees", 180, 0.3)
-		index += 1
+                var view = TarotManager.instantiate_card_view(id, count_for_rarity, true, rarity)
+                var upside_down = flip_rng.randf() < 0.5
+                view.set_upside_down(upside_down)
+                view.show_single_count = true
+                view.modulate.a = 0.0
+                reading_result.add_child(view)
+                var t = create_tween()
+                t.tween_property(view, "modulate:a", 1.0, 0.3).set_delay(index * 0.2)
+                if upside_down:
+                        view.texture_rect.rotation_degrees = 0
+                        t.tween_property(view.texture_rect, "rotation_degrees", 180, 0.3)
+                index += 1
 
 
 func _update_cooldown_label() -> void:

--- a/components/apps/tarot/tarot_card_view.gd
+++ b/components/apps/tarot/tarot_card_view.gd
@@ -96,25 +96,27 @@ func _on_sell_pressed() -> void:
 		sell_button.visible = true
 
 func _ready() -> void:
-	texture_rect.mouse_filter = Control.MOUSE_FILTER_PASS
-	name_label.mouse_filter = Control.MOUSE_FILTER_PASS
-	rarity_label.mouse_filter = Control.MOUSE_FILTER_PASS
-	count_label.mouse_filter = Control.MOUSE_FILTER_PASS
+        texture_rect.mouse_filter = Control.MOUSE_FILTER_PASS
+        name_label.mouse_filter = Control.MOUSE_FILTER_PASS
+        rarity_label.mouse_filter = Control.MOUSE_FILTER_PASS
+        count_label.mouse_filter = Control.MOUSE_FILTER_PASS
+        set_upside_down(is_upside_down)
 
 func _gui_input(event: InputEvent) -> void:
 	if event is InputEventMouseButton and event.pressed and event.button_index == MOUSE_BUTTON_LEFT:
 		card_pressed.emit(card_id)
 
 func set_upside_down(flag: bool) -> void:
-		if not is_node_ready():
-				await ready
-		is_upside_down = flag
-		if is_upside_down:
-				texture_rect.pivot_offset = texture_rect.size * 0.5
-		else:
-				texture_rect.pivot_offset = Vector2.ZERO
-		texture_rect.rotation_degrees = 0
-		sell_price = TarotManager.get_sell_price(rarity)
-		if is_upside_down:
-				sell_price *= 2.0
-		sell_button.text = "Sell for $%d" % int(sell_price)
+                if not is_node_ready():
+                                await ready
+                is_upside_down = flag
+                if is_upside_down:
+                                texture_rect.pivot_offset = texture_rect.size * 0.5
+                                texture_rect.rotation_degrees = 180
+                else:
+                                texture_rect.pivot_offset = Vector2.ZERO
+                                texture_rect.rotation_degrees = 0
+                sell_price = TarotManager.get_sell_price(rarity)
+                if is_upside_down:
+                                sell_price *= 2.0
+                sell_button.text = "Sell for $%d" % int(sell_price)


### PR DESCRIPTION
## Summary
- Restore saved upside-down orientation when tarot card views reload
- Rotate texture and adjust pivot when toggling card orientation
- Ensure draw and reading cards reapply upside-down rotation after reload

## Testing
- `godot3-server --headless -s tests/test_runner.gd` *(fails: project requires newer Godot engine)*

------
https://chatgpt.com/codex/tasks/task_e_68bb28865de483259486f97f953bd490