### PR TITLE
Persist upside-down tarot cards

### DIFF
--- a/autoloads/tarot_manager.gd
+++ b/autoloads/tarot_manager.gd
@@ -15,6 +15,8 @@ var collection: Dictionary = {}
 var last_draw_minutes: int = -COOLDOWN_MINUTES
 var last_card_id: String = ""
 var last_card_rarity: int = 0
+var last_card_upside_down: bool = false
+var last_reading: Array = []
 var reading_cost: float = 1.0
 
 func _ready() -> void:
@@ -22,21 +24,25 @@ func _ready() -> void:
 	TimeManager.hour_passed.connect(_on_hour_passed)
 
 func reset() -> void:
-		collection.clear()
-		last_draw_minutes = -COOLDOWN_MINUTES
-		last_card_id = ""
-		last_card_rarity = 0
-		reading_cost = 1.0
-		deck.load_from_file(DATA_PATH)
+collection.clear()
+last_draw_minutes = -COOLDOWN_MINUTES
+last_card_id = ""
+last_card_rarity = 0
+last_card_upside_down = false
+last_reading.clear()
+reading_cost = 1.0
+deck.load_from_file(DATA_PATH)
 
 func get_save_data() -> Dictionary:
-		return {
-				"collection": collection,
-			"last_draw": last_draw_minutes,
-			"last_card_id": last_card_id,
-			"last_card_rarity": last_card_rarity,
-		"reading_cost": reading_cost
-		}
+return {
+"collection": collection,
+"last_draw": last_draw_minutes,
+"last_card_id": last_card_id,
+"last_card_rarity": last_card_rarity,
+"last_card_upside_down": last_card_upside_down,
+"last_reading": last_reading,
+"reading_cost": reading_cost
+}
 
 func load_from_data(data: Dictionary) -> void:
 	collection.clear()
@@ -50,10 +56,12 @@ func load_from_data(data: Dictionary) -> void:
 			collection[id] = fixed_rarities
 
 	last_draw_minutes = int(data.get("last_draw", -COOLDOWN_MINUTES))
-	last_card_id = data.get("last_card_id", "")
-	last_card_rarity = int(data.get("last_card_rarity", 0))
-	reading_cost = float(data.get("reading_cost", 1.0))
-	deck.load_from_file(DATA_PATH)
+last_card_id = data.get("last_card_id", "")
+last_card_rarity = int(data.get("last_card_rarity", 0))
+last_card_upside_down = bool(data.get("last_card_upside_down", false))
+last_reading = data.get("last_reading", [])
+reading_cost = float(data.get("reading_cost", 1.0))
+deck.load_from_file(DATA_PATH)
 
 func get_card_count(id: String) -> int:
 		var rarities: Dictionary = collection.get(id, {})
@@ -101,9 +109,10 @@ func _roll_rarity(rng: RandomNumberGenerator) -> int:
 func draw_card() -> Dictionary:
 		if not can_draw():
 				return {}
-		var card_rng := RNGManager.tarot_card.get_rng()
-		var rarity_rng := RNGManager.tarot_rarity.get_rng()
-		var rarity := _roll_rarity(rarity_rng)
+var card_rng := RNGManager.tarot_card.get_rng()
+var rarity_rng := RNGManager.tarot_rarity.get_rng()
+var orientation_rng := RNGManager.tarot_orientation.get_rng()
+var rarity := _roll_rarity(rarity_rng)
 		var all_cards: Array = deck.cards
 		if all_cards.is_empty():
 				return {}
@@ -115,8 +124,10 @@ func draw_card() -> Dictionary:
 		last_draw_minutes = TimeManager.get_now_minutes()
 		last_card_id = id
 		last_card_rarity = rarity
-		collection_changed.emit(id, get_card_count(id))
-		return {"id": id, "rarity": rarity}
+var upside_down := orientation_rng.randf() < 0.5
+last_card_upside_down = upside_down
+collection_changed.emit(id, get_card_count(id))
+return {"id": id, "rarity": rarity, "upside_down": upside_down}
 
 func draw_reading(count: int) -> Array:
 	var total_cost := reading_cost * count
@@ -126,9 +137,10 @@ func draw_reading(count: int) -> Array:
 			return []
 		StatManager.set_base_stat("ex", current_ex - total_cost)
 		reading_cost *= 2.0
-	var card_rng := RNGManager.tarot_card.get_rng()
-	var rarity_rng := RNGManager.tarot_rarity.get_rng()
-	var results: Array = []
+var card_rng := RNGManager.tarot_card.get_rng()
+var rarity_rng := RNGManager.tarot_rarity.get_rng()
+var orientation_rng := RNGManager.tarot_orientation.get_rng()
+var results: Array = []
 	for i in range(count):
 			var rarity := _roll_rarity(rarity_rng)
 			var all_cards: Array = deck.cards
@@ -136,14 +148,16 @@ func draw_reading(count: int) -> Array:
 					continue
 			var card: Dictionary = all_cards[card_rng.randi_range(0, all_cards.size() - 1)]
 			var id: String = card.get("id", "")
-			var rarities: Dictionary = collection.get(id, {})
-			rarities[rarity] = int(rarities.get(rarity, 0)) + 1
-			collection[id] = rarities
-			last_card_id = id
-			last_card_rarity = rarity
-			collection_changed.emit(id, get_card_count(id))
-			results.append({"id": id, "rarity": rarity})
-	return results
+var rarities: Dictionary = collection.get(id, {})
+rarities[rarity] = int(rarities.get(rarity, 0)) + 1
+collection[id] = rarities
+last_card_id = id
+last_card_rarity = rarity
+var upside_down := orientation_rng.randf() < 0.5
+collection_changed.emit(id, get_card_count(id))
+results.append({"id": id, "rarity": rarity, "upside_down": upside_down})
+last_reading = results.duplicate()
+return results
 
 func _on_hour_passed(_current_hour: int, _total_minutes: int) -> void:
 	reading_cost = max(1.0, reading_cost - 1.0)

--- a/components/apps/tarot/tarot_app.gd
+++ b/components/apps/tarot/tarot_app.gd
@@ -32,6 +32,7 @@ func _ready() -> void:
 	_update_cooldown_label()
 	_update_reading_cost_label()
 	_show_last_drawn_card()
+	_show_reading_cards(TarotManager.last_reading)
 	nav_bar.set_active("Draw")
 
 
@@ -86,29 +87,33 @@ func _show_last_drawn_card() -> void:
 		return
 	var count_for_rarity = TarotManager.get_card_rarity_count(id, rarity)
 	var view = TarotManager.instantiate_card_view(id, count_for_rarity, true, rarity)
-	var upside_down = RNGManager.tarot_orientation.get_rng().randf() < 0.5
+	var upside_down = TarotManager.last_card_upside_down
 	view.set_upside_down(upside_down)
+	if upside_down:
+		view.texture_rect.rotation_degrees = 0
 	view.show_single_count = true
 	view.modulate.a = 0.0
 	draw_result.add_child(view)
 	var t = create_tween()
 	t.tween_property(view, "modulate:a", 1.0, 0.3)
 	if upside_down:
-			t.tween_property(view.texture_rect, "rotation_degrees", 180, 0.3)
-
+		t.tween_property(view.texture_rect, "rotation_degrees", 180, 0.3)
 func _show_reading_cards(cards: Array) -> void:
 	for child in reading_result.get_children():
 		if child != reading_button and child != reading_cost_label and child != reading_button:
 			child.queue_free()
+	if cards.is_empty():
+		return
 	var index := 0
-	var flip_rng = RNGManager.tarot_orientation.get_rng()
 	for c in cards:
 		var id: String = c.get("id", "")
 		var rarity: int = int(c.get("rarity", 1))
+		var upside_down: bool = bool(c.get("upside_down", false))
 		var count_for_rarity = TarotManager.get_card_rarity_count(id, rarity)
 		var view = TarotManager.instantiate_card_view(id, count_for_rarity, true, rarity)
-		var upside_down = flip_rng.randf() < 0.5
 		view.set_upside_down(upside_down)
+		if upside_down:
+			view.texture_rect.rotation_degrees = 0
 		view.show_single_count = true
 		view.modulate.a = 0.0
 		reading_result.add_child(view)
@@ -117,8 +122,6 @@ func _show_reading_cards(cards: Array) -> void:
 		if upside_down:
 			t.tween_property(view.texture_rect, "rotation_degrees", 180, 0.3)
 		index += 1
-
-
 func _update_cooldown_label() -> void:
 	var remaining = TarotManager.time_until_next_draw()
 	if remaining <= 0:

--- a/components/apps/tarot/tarot_card_view.gd
+++ b/components/apps/tarot/tarot_card_view.gd
@@ -77,7 +77,7 @@ func update_rarity(new_rarity: int) -> void:
 				rarity_label.material = null
 				rarity_label.add_theme_color_override("font_color", RARITY_COLORS.get(rarity, Color.WHITE))
 		sell_price = TarotManager.get_sell_price(rarity)
-		if is_upside_down:
+	if is_upside_down:
 				sell_price *= 2.0
 		sell_button.text = "Sell for $%d" % int(sell_price)
 
@@ -100,6 +100,8 @@ func _ready() -> void:
 	name_label.mouse_filter = Control.MOUSE_FILTER_PASS
 	rarity_label.mouse_filter = Control.MOUSE_FILTER_PASS
 	count_label.mouse_filter = Control.MOUSE_FILTER_PASS
+	if is_upside_down:
+		set_upside_down(true)
 
 func _gui_input(event: InputEvent) -> void:
 	if event is InputEventMouseButton and event.pressed and event.button_index == MOUSE_BUTTON_LEFT:
@@ -111,9 +113,10 @@ func set_upside_down(flag: bool) -> void:
 		is_upside_down = flag
 		if is_upside_down:
 				texture_rect.pivot_offset = texture_rect.size * 0.5
+				texture_rect.rotation_degrees = 180
 		else:
 				texture_rect.pivot_offset = Vector2.ZERO
-		texture_rect.rotation_degrees = 0
+				texture_rect.rotation_degrees = 0
 		sell_price = TarotManager.get_sell_price(rarity)
 		if is_upside_down:
 				sell_price *= 2.0


### PR DESCRIPTION
## Summary
- persist upside-down state for tarot cards and readings via TarotManager
- restore rotation on card views when reloaded
- show stored upside-down card orientation on draw/read tabs

## Testing
- `godot --headless --path . tests/test_runner.tscn` *(fails: Error opening file 'uid://gl0rjxkrh4wh')*

------
https://chatgpt.com/codex/tasks/task_e_68bb28865de483259486f97f953bd490