### PR TITLE
Restore upside-down tarot card orientation

### DIFF
--- a/components/apps/tarot/tarot_app.gd
+++ b/components/apps/tarot/tarot_app.gd
@@ -94,6 +94,7 @@ func _show_last_drawn_card() -> void:
 	var t = create_tween()
 	t.tween_property(view, "modulate:a", 1.0, 0.3)
 	if upside_down:
+			view.texture_rect.rotation_degrees = 0
 			t.tween_property(view.texture_rect, "rotation_degrees", 180, 0.3)
 
 func _show_reading_cards(cards: Array) -> void:
@@ -115,6 +116,7 @@ func _show_reading_cards(cards: Array) -> void:
 		var t = create_tween()
 		t.tween_property(view, "modulate:a", 1.0, 0.3).set_delay(index * 0.2)
 		if upside_down:
+			view.texture_rect.rotation_degrees = 0
 			t.tween_property(view.texture_rect, "rotation_degrees", 180, 0.3)
 		index += 1
 

--- a/components/apps/tarot/tarot_card_view.gd
+++ b/components/apps/tarot/tarot_card_view.gd
@@ -106,15 +106,16 @@ func _gui_input(event: InputEvent) -> void:
 		card_pressed.emit(card_id)
 
 func set_upside_down(flag: bool) -> void:
-		if not is_node_ready():
-				await ready
-		is_upside_down = flag
-		if is_upside_down:
-				texture_rect.pivot_offset = texture_rect.size * 0.5
-		else:
-				texture_rect.pivot_offset = Vector2.ZERO
+	if not is_node_ready():
+		await ready
+	is_upside_down = flag
+	if is_upside_down:
+		texture_rect.pivot_offset = texture_rect.size * 0.5
+		texture_rect.rotation_degrees = 180
+	else:
+		texture_rect.pivot_offset = Vector2.ZERO
 		texture_rect.rotation_degrees = 0
-		sell_price = TarotManager.get_sell_price(rarity)
-		if is_upside_down:
-				sell_price *= 2.0
-		sell_button.text = "Sell for $%d" % int(sell_price)
+	sell_price = TarotManager.get_sell_price(rarity)
+	if is_upside_down:
+		sell_price *= 2.0
+	sell_button.text = "Sell for $%d" % int(sell_price)


### PR DESCRIPTION
## Summary
- rotate tarot card textures 180° when marked upside down so saved cards reappear reversed
- reset texture rotation before tweening so draw and reading animations still play correctly

## Testing
- `godot --headless --path . -s tests/tarot_upside_down_sell_test.gd` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68bb885dd480832597f3757f8ec47dd8