### PR TITLE
Update login card metadata when portrait changes

### DIFF
--- a/autoloads/player_manager.gd
+++ b/autoloads/player_manager.gd
@@ -120,7 +120,9 @@ func get_var(key: String, default_value = null):
 	return user_data.get(key, default_value)
 
 func set_var(key: String, value) -> void:
-				user_data[key] = value
+        user_data[key] = value
+        if key == "portrait_config":
+                SaveManager.update_current_slot_metadata("portrait_config", value)
 
 func get_stat(name: String, default_value: float = 0.0) -> float:
 		return float(user_data.get(name, default_value))

--- a/autoloads/save_manager.gd
+++ b/autoloads/save_manager.gd
@@ -36,8 +36,19 @@ func load_slot_metadata() -> Dictionary:
 
 
 func get_profile_metadata(slot_id: int) -> Dictionary:
-	var metadata = load_slot_metadata()
-	return metadata.get("slot_%d" % slot_id, {})
+        var metadata = load_slot_metadata()
+        return metadata.get("slot_%d" % slot_id, {})
+
+
+func update_current_slot_metadata(field: String, value) -> void:
+        if current_slot_id <= 0:
+                return
+        var metadata = load_slot_metadata()
+        var slot_key = "slot_%d" % current_slot_id
+        if not metadata.has(slot_key):
+                metadata[slot_key] = {}
+        metadata[slot_key][field] = value
+        save_slot_metadata(metadata)
 
 
 func get_next_available_slot() -> int:

--- a/components/apps/new_you/new_you.gd
+++ b/components/apps/new_you/new_you.gd
@@ -55,13 +55,13 @@ func setup_custom(args: Dictionary) -> void:
 
 
 func _on_portrait_applied(cfg: PortraitConfig) -> void:
-	if portrait_view:
-		portrait_view.apply_config(cfg)
-	if target_type == "player":
-		PlayerManager.user_data["portrait_config"] = cfg.to_dict()
-	elif target_type == "npc" and target_npc_idx != -1:
-		var npc = NPCManager.get_npc_by_index(target_npc_idx)
-		if npc != null:
-			npc.portrait_config = cfg
+        if portrait_view:
+                portrait_view.apply_config(cfg)
+        if target_type == "player":
+                PlayerManager.set_var("portrait_config", cfg.to_dict())
+        elif target_type == "npc" and target_npc_idx != -1:
+                var npc = NPCManager.get_npc_by_index(target_npc_idx)
+                if npc != null:
+                        npc.portrait_config = cfg
 			NPCManager.set_npc_field(target_npc_idx, "portrait_config", cfg)
 			DBManager.save_npc(target_npc_idx, npc)

--- a/components/ui/profile_creation/portrait_creation_screen.gd
+++ b/components/ui/profile_creation/portrait_creation_screen.gd
@@ -21,4 +21,4 @@ func _on_portrait_applied(cfg: PortraitConfig) -> void:
 	emit_signal("step_valid", true)
 
 func save_data() -> void:
-	PlayerManager.user_data["portrait_config"] = current_config.to_dict()
+        PlayerManager.set_var("portrait_config", current_config.to_dict())


### PR DESCRIPTION
## Summary
- update slot metadata helper in SaveManager
- sync metadata when player portrait config changes

## Testing
- `godot --headless -s tests/test_runner.gd` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bc46b4f2688325a7fc37034e4ef2df