### PR TITLE
Fix indentation consistency in pane nav bar script

### DIFF
--- a/components/ui/pane_nav_bar.tscn
+++ b/components/ui/pane_nav_bar.tscn
@@ -22,8 +22,8 @@ func _ready() -> void:
 		_on_root_resized()
 
 func _on_root_resized() -> void:
-    var root_width: float = _root_control.size.x
-    custom_minimum_size.x = min(full_width, root_width * width_ratio)
+	var root_width: float = _root_control.size.x
+	custom_minimum_size.x = min(full_width, root_width * width_ratio)
 "
 
 [node name="PaneNavBar" type="PanelContainer"]


### PR DESCRIPTION
## Summary
- fix mixed indentation in PaneNavBar GDScript embedded in pane_nav_bar.tscn

## Testing
- `godot --headless --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bc51353c8883259284b839ccfa591b