### PR TITLE
Add LockedIn Profile and Feed tabs

### DIFF
--- a/components/apps/app_scenes/locked_in.tscn
+++ b/components/apps/app_scenes/locked_in.tscn
@@ -67,12 +67,6 @@ size_flags_vertical = 3
 [node name="VBoxContainer2" type="VBoxContainer" parent="MarginContainer/VBoxContainer/HBoxContainer"]
 layout_mode = 2
 
-[node name="PaneNavBar" type="PanelContainer" parent="MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer2"]
-layout_mode = 2
-size_flags_horizontal = 3
-script = ExtResource("4_txgot")
-metadata/_custom_type_script = "uid://bkxfxbb443cnq"
-
 [node name="ConnectionsList" parent="MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer2" instance=ExtResource("4_8vpmc")]
 unique_name_in_owner = true
 custom_minimum_size = Vector2(200, 0)
@@ -86,6 +80,19 @@ theme_override_styles/panel = SubResource("StyleBoxFlat_xswks")
 layout_mode = 2
 size_flags_horizontal = 3
 
+[node name="PaneNavBar" type="PanelContainer" parent="MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer"]
+layout_mode = 2
+size_flags_horizontal = 3
+script = ExtResource("4_txgot")
+metadata/_custom_type_script = "uid://bkxfxbb443cnq"
+
 [node name="Profile" parent="MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer" instance=ExtResource("3_6ji7a")]
 unique_name_in_owner = true
 layout_mode = 2
+
+[node name="Feed" type="VBoxContainer" parent="MarginContainer/VBoxContainer/HBoxContainer/VBoxContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+visible = false
+size_flags_horizontal = 3
+size_flags_vertical = 3

--- a/components/apps/locked_in/locked_in.gd
+++ b/components/apps/locked_in/locked_in.gd
@@ -2,13 +2,30 @@ extends Pane
 
 @onready var connections_list: LockedInConnectionsListUI = %ConnectionsList
 @onready var profile_ui: LockedInProfileUI = %Profile
+@onready var feed_ui: Control = %Feed
+@onready var nav_bar: PaneNavBar = %PaneNavBar
 
 func _ready() -> void:
-		var ids: PackedInt32Array = NPCManager.get_locked_in_connection_ids()
-		connections_list.populate(ids)
-		connections_list.connection_selected.connect(func(npc_id: int) -> void:
-				profile_ui.load_npc(NPCManager.get_npc_by_index(npc_id))
-		)
+                var ids: PackedInt32Array = NPCManager.get_locked_in_connection_ids()
+                connections_list.populate(ids)
+                connections_list.connection_selected.connect(func(npc_id: int) -> void:
+                                profile_ui.load_npc(NPCManager.get_npc_by_index(npc_id))
+                )
+
+                nav_bar.add_nav_button("Profile", "Profile")
+                nav_bar.add_nav_button("Feed", "Feed")
+                nav_bar.tab_selected.connect(func(tab_id: String):
+                                _activate_tab(tab_id)
+                )
+                nav_bar.set_active("Profile")
+
+func _activate_tab(tab_id: String) -> void:
+                if tab_id == "Profile":
+                                profile_ui.visible = true
+                                feed_ui.visible = false
+                else:
+                                profile_ui.visible = false
+                                feed_ui.visible = true
 
 # Test helper to seed the connections list with random NPCs.
 # Picks a few random NPCs, marks them as locked in, and repopulates the list.


### PR DESCRIPTION
## Summary
- Add PaneNavBar to LockedIn for switching between Profile and Feed views
- Show player's profile in Profile tab and placeholder Feed tab

## Testing
- `godot --headless --path . --run tests/test_runner.tscn` *(fails: missing imported resources)*

------
https://chatgpt.com/codex/tasks/task_e_68bc54e2c4548325950c1abbed757a98