### PR TITLE
Enable TimeManager processing

### DIFF
--- a/autoloads/time_manager.gd
+++ b/autoloads/time_manager.gd
@@ -53,6 +53,7 @@ var month_names := [
 
 # -------- Lifecycle --------
 func _ready() -> void:
+	set_process(true)
 	# Initialize from defaults and compute derived values
 	load_autosave_setting()
 	_rebuild_total_minutes_from_defaults()


### PR DESCRIPTION
## Summary
- start TimeManager's `_process` loop so real-time playtime and time signals update

## Testing
- `godot --headless -s tests/test_runner.gd` *(fails: Can't load the script "tests/test_runner.gd" as it doesn't inherit from SceneTree or MainLoop)*

------
https://chatgpt.com/codex/tasks/task_e_68bc5987914083258a632c01ed8364c2