### PR TITLE
Add Majors tab for major arcana tarot readings

### DIFF
--- a/components/apps/app_scenes/tarot_app.tscn
+++ b/components/apps/app_scenes/tarot_app.tscn
@@ -167,6 +167,30 @@ size_flags_horizontal = 4
 focus_mode = 0
 text = "  Paid Reading  "
 
+[node name="MajorsView" type="VBoxContainer" parent="MarginContainer/VBox"]
+unique_name_in_owner = true
+visible = false
+layout_mode = 2
+theme_override_constants/separation = 8
+
+[node name="MajorResult" type="HBoxContainer" parent="MarginContainer/VBox/MajorsView"]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_vertical = 3
+alignment = 1
+
+[node name="MajorCostLabel" type="Label" parent="MarginContainer/VBox/MajorsView"]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 4
+
+[node name="MajorButton" type="Button" parent="MarginContainer/VBox/MajorsView"]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 4
+focus_mode = 0
+text = "  Majors Reading  "
+
 [node name="CollectionView" type="ScrollContainer" parent="MarginContainer/VBox"]
 unique_name_in_owner = true
 visible = false


### PR DESCRIPTION
## Summary
- Add a new Majors tab to the tarot app for major arcana-only readings
- Support major arcana draws in TarotManager and persist last major reading
- Update UI scene to include Majors tab layout and controls

## Testing
- `godot3 --headless -s tests/test_runner.gd` *(fails: Can't open project; config version mismatch)*
- `/tmp/godot4/Godot_v4.2.1-stable_linux.x86_64 --headless --path . -s res://tests/test_runner.gd` *(fails: project resources missing and script errors)*

------
https://chatgpt.com/codex/tasks/task_e_68bde15611bc8325bd212a59ddd4db97