### PR TITLE
Separate tarot reading costs between cash and EX

### DIFF
--- a/autoloads/tarot_manager.gd
+++ b/autoloads/tarot_manager.gd
@@ -17,6 +17,7 @@ var last_card_id: String = ""
 var last_card_rarity: int = 0
 var last_card_upside_down: bool = false
 var reading_cost: float = 1.0
+var major_reading_cost: float = 1.0
 var last_reading: Array = []
 var last_major_reading: Array = []
 
@@ -27,28 +28,30 @@ func _ready() -> void:
 
 
 func reset() -> void:
-	collection.clear()
-	last_draw_minutes = -COOLDOWN_MINUTES
-	last_card_id = ""
-	last_card_rarity = 0
-	last_card_upside_down = false
-	reading_cost = 1.0
-	last_reading.clear()
-	last_major_reading.clear()
-	deck.load_from_file(DATA_PATH)
+collection.clear()
+last_draw_minutes = -COOLDOWN_MINUTES
+last_card_id = ""
+last_card_rarity = 0
+last_card_upside_down = false
+reading_cost = 1.0
+major_reading_cost = 1.0
+last_reading.clear()
+last_major_reading.clear()
+deck.load_from_file(DATA_PATH)
 
 
 func get_save_data() -> Dictionary:
-	return {
-		"collection": collection,
-		"last_draw": last_draw_minutes,
-		"last_card_id": last_card_id,
-		"last_card_rarity": last_card_rarity,
-		"last_card_upside_down": last_card_upside_down,
-		"reading_cost": reading_cost,
-		"last_reading": last_reading,
-		"last_major_reading": last_major_reading
-	}
+        return {
+                "collection": collection,
+                "last_draw": last_draw_minutes,
+                "last_card_id": last_card_id,
+                "last_card_rarity": last_card_rarity,
+                "last_card_upside_down": last_card_upside_down,
+                "reading_cost": reading_cost,
+                "major_reading_cost": major_reading_cost,
+                "last_reading": last_reading,
+                "last_major_reading": last_major_reading
+        }
 
 
 func load_from_data(data: Dictionary) -> void:
@@ -64,12 +67,13 @@ func load_from_data(data: Dictionary) -> void:
 
 	last_draw_minutes = int(data.get("last_draw", -COOLDOWN_MINUTES))
 	last_card_id = data.get("last_card_id", "")
-	last_card_rarity = int(data.get("last_card_rarity", 0))
-	last_card_upside_down = bool(data.get("last_card_upside_down", false))
-	reading_cost = float(data.get("reading_cost", 1.0))
-	last_reading = data.get("last_reading", [])
-	last_major_reading = data.get("last_major_reading", [])
-	deck.load_from_file(DATA_PATH)
+        last_card_rarity = int(data.get("last_card_rarity", 0))
+        last_card_upside_down = bool(data.get("last_card_upside_down", false))
+        reading_cost = float(data.get("reading_cost", 1.0))
+        major_reading_cost = float(data.get("major_reading_cost", 1.0))
+        last_reading = data.get("last_reading", [])
+        last_major_reading = data.get("last_major_reading", [])
+        deck.load_from_file(DATA_PATH)
 
 
 func get_card_count(id: String) -> int:
@@ -149,13 +153,11 @@ func draw_card() -> Dictionary:
 
 
 func draw_reading(count: int) -> Array:
-	var total_cost := reading_cost * count
-	if total_cost > 0.0:
-		var current_ex = StatManager.get_stat("ex", 0.0)
-		if current_ex < total_cost:
-			return []
-		StatManager.set_base_stat("ex", current_ex - total_cost)
-		reading_cost *= 2.0
+    var total_cost := reading_cost * count
+    if total_cost > 0.0:
+        if not PortfolioManager.pay_with_cash(total_cost):
+            return []
+        reading_cost *= 2.0
 	var card_rng := RNGManager.tarot_card.get_rng()
 	var rarity_rng := RNGManager.tarot_rarity.get_rng()
 	var orientation_rng := RNGManager.tarot_orientation.get_rng()
@@ -178,13 +180,13 @@ func draw_reading(count: int) -> Array:
 
 
 func draw_major_reading(count: int) -> Array:
-	var total_cost := reading_cost * count
-	if total_cost > 0.0:
-		var current_ex = StatManager.get_stat("ex", 0.0)
-		if current_ex < total_cost:
-			return []
-		StatManager.set_base_stat("ex", current_ex - total_cost)
-		reading_cost *= 2.0
+    var total_cost := major_reading_cost * count
+    if total_cost > 0.0:
+        var current_ex = StatManager.get_stat("ex", 0.0)
+        if current_ex < total_cost:
+            return []
+        StatManager.set_base_stat("ex", current_ex - total_cost)
+        major_reading_cost *= 2.0
 	var card_rng := RNGManager.tarot_card.get_rng()
 	var rarity_rng := RNGManager.tarot_rarity.get_rng()
 	var orientation_rng := RNGManager.tarot_orientation.get_rng()
@@ -210,7 +212,8 @@ func draw_major_reading(count: int) -> Array:
 
 
 func _on_hour_passed(_current_hour: int, _total_minutes: int) -> void:
-	reading_cost = max(1.0, reading_cost - 1.0)
+    reading_cost = max(1.0, reading_cost - 1.0)
+    major_reading_cost = max(1.0, major_reading_cost - 1.0)
 
 
 func sell_card(card_id: String, rarity: int, upside_down: bool = false) -> void:

--- a/components/apps/tarot/tarot_app.gd
+++ b/components/apps/tarot/tarot_app.gd
@@ -184,11 +184,12 @@ func _update_cooldown_label() -> void:
 
 
 func _update_reading_cost_label() -> void:
-	var extra := UpgradeManager.get_level("tarot_extra_card")
-	var count := 1 + extra
-	var cost = TarotManager.reading_cost * count
-	reading_cost_label.text = "%d EX for %d card(s)" % [int(cost), count]
-	major_cost_label.text = "%d EX for %d card(s)" % [int(cost), count]
+    var extra := UpgradeManager.get_level("tarot_extra_card")
+    var count := 1 + extra
+    var reading_cost = TarotManager.reading_cost * count
+    var major_cost = TarotManager.major_reading_cost * count
+    reading_cost_label.text = "$%d for %d card(s)" % [int(reading_cost), count]
+    major_cost_label.text = "%d EX for %d card(s)" % [int(major_cost), count]
 
 
 func _on_minute_passed(_total_minutes: int) -> void:

--- a/tests/tarot_persistence_independence_test.gd
+++ b/tests/tarot_persistence_independence_test.gd
@@ -3,6 +3,7 @@ extends SceneTree
 func _ready():
     RNGManager.init_seed(0)
     TarotManager.reset()
+    PortfolioManager.cash = 100.0
     TarotManager.last_draw_minutes = -TarotManager.COOLDOWN_MINUTES
     var single = TarotManager.draw_card()
     var single_id = single.get("id")

--- a/tests/tarot_reading_cost_ex_test.gd
+++ b/tests/tarot_reading_cost_ex_test.gd
@@ -2,11 +2,20 @@ extends SceneTree
 
 func _ready():
     TarotManager.reset()
+    PortfolioManager.cash = 100.0
     StatManager.set_base_stat("ex", 100.0)
     var cards = TarotManager.draw_reading(1)
     assert(not cards.is_empty())
     assert(TarotManager.reading_cost == 2.0)
+    assert(TarotManager.major_reading_cost == 1.0)
+    assert(PortfolioManager.cash == 99.0)
+    var majors = TarotManager.draw_major_reading(1)
+    assert(not majors.is_empty())
+    assert(TarotManager.reading_cost == 2.0)
+    assert(TarotManager.major_reading_cost == 2.0)
+    assert(StatManager.get_stat("ex") == 99.0)
     TarotManager._on_hour_passed(0, 0)
     assert(TarotManager.reading_cost == 1.0)
+    assert(TarotManager.major_reading_cost == 1.0)
     print("tarot_reading_cost_ex_test passed")
     quit()


### PR DESCRIPTION
## Summary
- Track normal and major tarot reading costs independently
- Charge cash for normal readings while majors continue to spend EX
- Update UI and tests for new cost structure

## Testing
- `godot3 --headless -s tests/test_runner.gd` *(fails: project config version 5)*
- `/tmp/godot4/Godot_v4.2.1-stable_linux.x86_64 --headless tests/test_runner.tscn` *(fails: missing project resources)*

------
https://chatgpt.com/codex/tasks/task_e_68bde7ff80a48325b9c644afec18dcd6