### PR TITLE
Include real-time seconds in CalendarPopupUI

### DIFF
--- a/components/popups/calendar_popup_ui.gd
+++ b/components/popups/calendar_popup_ui.gd
@@ -109,9 +109,11 @@ func _on_ower_view_button_pressed() -> void:
 	WindowManager.launch_app_by_name("OwerView")
 
 func _update_elapsed_labels() -> void:
-	in_game_label.text = _format_elapsed(TimeManager.get_total_minutes_played())
-	var real_minutes := int(TimeManager.get_total_real_seconds_played() / 60)
-	real_time_label.text = _format_elapsed(real_minutes)
+       in_game_label.text = _format_elapsed(TimeManager.get_total_minutes_played())
+       var total_real_seconds := int(TimeManager.get_total_real_seconds_played())
+       var real_minutes := total_real_seconds / 60
+       var real_seconds := total_real_seconds % 60
+       real_time_label.text = "%s:%02d" % [_format_elapsed(real_minutes), real_seconds]
 
 func _format_elapsed(total_minutes: int) -> String:
 	var years := total_minutes / (60 * 24 * 365)

--- a/components/popups/calendar_popup_ui.tscn
+++ b/components/popups/calendar_popup_ui.tscn
@@ -66,7 +66,7 @@ horizontal_alignment = 1
 unique_name_in_owner = true
 layout_mode = 2
 theme_override_colors/font_color = Color(0, 0, 0, 1)
-text = "Real: 0:00"
+text = "Real: 0:00:00"
 horizontal_alignment = 1
 
 [node name="HBoxContainer" type="HBoxContainer" parent="MarginContainer/VBoxContainer"]


### PR DESCRIPTION
## Summary
- show real-time seconds in calendar popup
- update placeholder text

## Testing
- `godot3 --headless -s tests/test_runner.gd` *(fails: project config_version 5 requires Godot 4)*

------
https://chatgpt.com/codex/tasks/task_e_68be322fe1388325b7a078a1aebdef05