### PR TITLE
Display EX stat in top bar

### DIFF
--- a/components/desktop_env.tscn
+++ b/components/desktop_env.tscn
@@ -588,6 +588,15 @@ size_flags_horizontal = 2
 theme_override_font_sizes/font_size = 24
 text = "$3"
 
+[node name="EXLabel" type="Label" parent="TaskbarLayer/TopBar/TopBarContainer/StatMonitorPanel/MarginContainer/HBoxContainer"]
+unique_name_in_owner = true
+material = SubResource("ShaderMaterial_dag3j")
+custom_minimum_size = Vector2(300, 0)
+layout_mode = 2
+size_flags_horizontal = 2
+theme_override_font_sizes/font_size = 24
+text = "0 EX"
+
 [node name="TaskbarWrapper" type="Panel" parent="TaskbarLayer"]
 z_index = 1024
 anchors_preset = 12

--- a/components/ticker.gd
+++ b/components/ticker.gd
@@ -3,6 +3,7 @@ extends Panel
 @onready var timer: Timer = $TickerTimer
 @onready var text_label: RichTextLabel = %TickerTextLabel
 @onready var cash_label: Label = %CashLabel
+@onready var ex_label: Label = %EXLabel
 
 
 var current_template: String = ""
@@ -95,6 +96,7 @@ func _process(_delta):
 	if current_template != "":
 		text_label.text = format_ticker_text(current_template)
 	cash_label.text = "$" + str(NumberFormatter.format_number(PortfolioManager.cash))
+	ex_label.text = str(NumberFormatter.format_number(StatManager.get_stat("ex", 0.0))) + " EX"
 
 func _on_timer_timeout():
 	#print("ticker timeout")


### PR DESCRIPTION
## Summary
- Add EX stat label to the StatMonitorPanel
- Update ticker script to show current EX value

## Testing
- `godot --headless tests/test_runner.tscn` *(fails: resources not imported)*

------
https://chatgpt.com/codex/tasks/task_e_68be31433d248325b52e708c1efb5c04