### PR TITLE
feat: allow adjusting tarot cost rates

### DIFF
--- a/tests/tarot_cost_scaling_exports_test.gd
+++ b/tests/tarot_cost_scaling_exports_test.gd
@@ -2,24 +2,28 @@ extends SceneTree
 
 func _ready():
     TarotManager.reading_cost_base = 2.0
-    TarotManager.reading_cost_increase = 3.0
+    TarotManager.reading_cost_increase = 1.1
+    TarotManager.reading_cost_min_increase = 1.0
     TarotManager.reading_cost_decrease = 0.5
+    TarotManager.reading_cost_decrease_rate = 2.0
     TarotManager.major_reading_cost_base = 2.0
-    TarotManager.major_reading_cost_increase = 4.0
+    TarotManager.major_reading_cost_increase = 1.1
+    TarotManager.major_reading_cost_min_increase = 1.0
     TarotManager.major_reading_cost_decrease = 0.5
+    TarotManager.major_reading_cost_decrease_rate = 2.0
     TarotManager.reset()
     PortfolioManager.cash = 100.0
     StatManager.set_base_stat("ex", 100.0)
     var cards = TarotManager.draw_reading(1)
     assert(not cards.is_empty())
-    assert(TarotManager.reading_cost == 6.0)
+    assert(TarotManager.reading_cost == 3.0)
     TarotManager._on_hour_passed(0, 0)
-    assert(TarotManager.reading_cost == 5.5)
+    assert(TarotManager.reading_cost == 2.0)
     TarotManager.reset()
     var majors = TarotManager.draw_major_reading(1)
     assert(not majors.is_empty())
-    assert(TarotManager.major_reading_cost == 8.0)
+    assert(TarotManager.major_reading_cost == 3.0)
     TarotManager._on_hour_passed(0, 0)
-    assert(TarotManager.major_reading_cost == 7.5)
+    assert(TarotManager.major_reading_cost == 2.0)
     print("tarot_cost_scaling_exports_test passed")
     quit()


### PR DESCRIPTION
## Summary
- add exports for tarot reading and major reading cost decrease rates and minimum cost increases
- apply minimum cost increases when drawing readings
- update tarot cost scaling test for new settings
- ensure tarot manager uses project-standard tab indentation

## Testing
- `godot3 --headless -q tests/test_runner.tscn` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68be37e8ed0c8325bacf09bf9a56613c