### PR TITLE
Add NPC catalog query

### DIFF
--- a/components/npc/npc_manager.gd
+++ b/components/npc/npc_manager.gd
@@ -797,3 +797,30 @@ func reset() -> void:
 
 	persistent_by_gender = {}
 	persistent_by_wealth = {}
+
+func query_npc_indices(filters: Dictionary) -> Array[int]:
+    var count: int = int(filters.get("count", 1))
+    var min_attr: float = float(filters.get("min_attractiveness", 0.0))
+    var pref_gender: Vector3 = filters.get("gender_similarity_vector", Vector3.ZERO)
+    var min_gender_sim: float = float(filters.get("min_gender_similarity", 0.0))
+    var exclude: Array[int] = filters.get("exclude", [])
+    var candidates: Array[int] = []
+    for record in NPCCatalog.npc_catalog:
+        var idx: int = int(record["index"])
+        if encountered_npcs.has(idx) or exclude.has(idx):
+            continue
+        if float(record.get("attractiveness", 0.0)) < min_attr:
+            continue
+        if pref_gender != Vector3.ZERO:
+            var sim = gender_dot_similarity(pref_gender, record.get("gender_vector", Vector3.ZERO))
+            if sim < min_gender_sim:
+                continue
+        candidates.append(idx)
+    RNGManager.npc_manager.shuffle(candidates)
+    var result: Array[int] = candidates.slice(0, count)
+    for idx in result:
+        if not encountered_npcs.has(idx):
+            encountered_npcs.append(idx)
+        if idx >= encounter_count:
+            encounter_count = idx + 1
+    return result

--- a/tests/query_npc_indices_test.gd
+++ b/tests/query_npc_indices_test.gd
@@ -1,0 +1,28 @@
+extends SceneTree
+
+func _ready() -> void:
+    RNGManager.init_seed(0)
+    NPCCatalog.generate(20)
+    var npc_manager = Engine.get_singleton("NPCManager")
+    npc_manager.encountered_npcs = []
+    npc_manager.encounter_count = 0
+
+    var exclude_idx = NPCCatalog.npc_catalog[0]["index"]
+    var res = npc_manager.query_npc_indices({"count": 2, "exclude": [exclude_idx]})
+    assert(res.size() == 2)
+    assert(not res.has(exclude_idx))
+    for idx in res:
+        assert(npc_manager.encountered_npcs.has(idx))
+
+    var fem_result = npc_manager.query_npc_indices({
+        "count": 1,
+        "gender_similarity_vector": Vector3(1,0,0),
+        "min_gender_similarity": 0.99
+    })
+    assert(fem_result.size() == 1)
+    var gv = NPCCatalog.npc_catalog[fem_result[0]]["gender_vector"]
+    var sim = npc_manager.gender_dot_similarity(Vector3(1,0,0), gv)
+    assert(sim >= 0.99)
+    assert(npc_manager.encountered_npcs.has(fem_result[0]))
+    print("query_npc_indices_test passed")
+    quit()


### PR DESCRIPTION
## Summary
- add NPCManager.query_npc_indices to pull IDs from NPC catalog with filters
- cover new query method with tests

## Testing
- `godot --headless -s tests/test_runner.gd` *(fails: command not found)*
- `apt-get install -y godot` *(fails: Unable to locate package)*
- `wget https://downloads.tuxfamily.org/godotengine/4.2.1/Godot_v4.2.1-stable_linux.x86_64.zip -O /tmp/godot.zip` *(fails: 503 Service Unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68be497667408325901b14115e9764a4