### PR TITLE
Improve Fumble card refresh performance

### DIFF
--- a/components/apps/fumble/chats_tab.gd
+++ b/components/apps/fumble/chats_tab.gd
@@ -46,6 +46,8 @@ func refresh_matches(time_budget_msec: int = 8) -> void:
 	for child in matches_container.get_children():
 		child.queue_free()
 
+	await get_tree().process_frame
+
 	var matches_rows: Array = FumbleManager.get_matches_with_times()
 	var battles: Array = FumbleManager.get_active_battles()
 	var battle_lookup: Dictionary = {}
@@ -57,24 +59,24 @@ func refresh_matches(time_budget_msec: int = 8) -> void:
 
 	var start_time: int = Time.get_ticks_msec()
 	for b in battles:
-			battle_lookup[b.npc_idx] = NPCManager.get_npc_by_index(b.npc_idx)
-			if Time.get_ticks_msec() - start_time > time_budget_msec:
-					await get_tree().process_frame
-					start_time = Time.get_ticks_msec()
+		battle_lookup[b.npc_idx] = NPCManager.get_npc_by_index(b.npc_idx)
+		if Time.get_ticks_msec() - start_time > time_budget_msec:
+			await get_tree().process_frame
+			start_time = Time.get_ticks_msec()
 
 	for row in matches_rows:
-			var idx: int = row.npc_id
-			if battle_lookup.has(idx):
-					continue
-			var npc = NPCManager.get_npc_by_index(idx)
-			if npc.attractiveness < min_att:
-					continue
-			total_attractiveness += npc.attractiveness
-			match_count += 1
-			data.append({"npc": npc, "idx": idx, "created_at": row.created_at})
-			if Time.get_ticks_msec() - start_time > time_budget_msec:
-					await get_tree().process_frame
-					start_time = Time.get_ticks_msec()
+		var idx: int = row.npc_id
+		if battle_lookup.has(idx):
+			continue
+		var npc = NPCManager.get_npc_by_index(idx)
+		if npc.attractiveness < min_att:
+			continue
+		total_attractiveness += npc.attractiveness
+		match_count += 1
+		data.append({"npc": npc, "idx": idx, "created_at": row.created_at})
+		if Time.get_ticks_msec() - start_time > time_budget_msec:
+			await get_tree().process_frame
+			start_time = Time.get_ticks_msec()
 
 	match matches_sort.selected:
 		0:
@@ -98,10 +100,10 @@ func refresh_matches(time_budget_msec: int = 8) -> void:
 			start_time = Time.get_ticks_msec()
 
 	for npc in battle_lookup.values():
-			total_attractiveness += npc.attractiveness
-			if Time.get_ticks_msec() - start_time > time_budget_msec:
-					await get_tree().process_frame
-					start_time = Time.get_ticks_msec()
+		total_attractiveness += npc.attractiveness
+		if Time.get_ticks_msec() - start_time > time_budget_msec:
+			await get_tree().process_frame
+			start_time = Time.get_ticks_msec()
 
 	var total_count: int = match_count + battles.size()
 	matches_label.text = "Matches: %d" % total_count

--- a/components/apps/fumble/profile_card_stack.gd
+++ b/components/apps/fumble/profile_card_stack.gd
@@ -37,19 +37,19 @@ func load_initial_cards() -> void:
 
 
 func _add_card_at_top(idx: int) -> void:
-		var card = profile_card_scene.instantiate()
-		card.set("npc_idx", idx)
-		var npc = NPCManager.get_npc_by_index(idx)
-		add_child(card)
-		card.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
-		card.call_deferred("load_npc", npc)
-		cards.append(card)
-		npc_indices.append(idx)
-		_update_card_positions()
+	var card = profile_card_scene.instantiate()
+	card.set("npc_idx", idx)
+	var npc = NPCManager.get_npc_by_index(idx)
+	add_child(card)
+	card.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
+	card.call_deferred("load_npc", npc)
+	cards.append(card)
+	npc_indices.append(idx)
+	_update_card_positions()
 
 
 func add_card_to_top(idx: int) -> void:
-		_add_card_at_top(idx)
+	_add_card_at_top(idx)
 
 
 func _add_card_at_bottom(idx: int) -> void:
@@ -62,6 +62,7 @@ func _add_card_at_bottom(idx: int) -> void:
 	cards.insert(0, card)
 	npc_indices.insert(0, idx)
 	_update_card_positions()
+	await get_tree().process_frame
 
 
 func _update_card_positions() -> void:
@@ -75,15 +76,7 @@ func swipe_left() -> void:
 	is_animating = true
 	var card = cards[cards.size() - 1]
 	var idx = npc_indices[npc_indices.size() - 1]
-	card.animate_swipe_left(func():
-		card.queue_free()
-		cards.pop_back()
-		npc_indices.pop_back()
-		NPCManager.mark_npc_inactive_in_app(idx, app_name)
-		emit_signal("card_swiped_left", idx)
-		_after_swipe()
-		is_animating = false
-	)
+	card.animate_swipe_left(Callable(self, "_on_swipe_left_complete").bind(card, idx))
 
 
 func swipe_left_and_wait() -> void:
@@ -98,14 +91,7 @@ func swipe_right() -> void:
 	is_animating = true
 	var card = cards[cards.size() - 1]
 	var idx = npc_indices[npc_indices.size() - 1]
-	card.animate_swipe_right(func():
-		emit_signal("card_swiped_right", idx)
-		card.queue_free()
-		cards.pop_back()
-		npc_indices.pop_back()
-		_after_swipe()
-		is_animating = false
-	)
+	card.animate_swipe_right(Callable(self, "_on_swipe_right_complete").bind(card, idx))
 
 
 func _after_swipe() -> void:
@@ -113,7 +99,24 @@ func _after_swipe() -> void:
 		await _refill_swipe_pool_async()
 	var idx: int = await _fetch_next_index_from_pool()
 	if idx != -1:
-		_add_card_at_bottom(idx)
+		await _add_card_at_bottom(idx)
+
+func _on_swipe_left_complete(card: Control, idx: int) -> void:
+	card.queue_free()
+	cards.pop_back()
+	npc_indices.pop_back()
+	NPCManager.mark_npc_inactive_in_app(idx, app_name)
+	emit_signal("card_swiped_left", idx)
+	await _after_swipe()
+	is_animating = false
+
+func _on_swipe_right_complete(card: Control, idx: int) -> void:
+	emit_signal("card_swiped_right", idx)
+	card.queue_free()
+	cards.pop_back()
+	npc_indices.pop_back()
+	await _after_swipe()
+	is_animating = false
 
 
 func clear_cards() -> void:
@@ -137,8 +140,8 @@ func refresh_swipe_pool_with_gender(gender_vec: Vector3, threshold: float = -1.0
 	preferred_gender = gender_vec
 	if threshold > 0:
 		gender_similarity_threshold = threshold
-	await _refill_swipe_pool_async()
 	clear_cards()
+	await _refill_swipe_pool_async()
 	await _populate_cards_over_frames(CARD_VISIBLE_COUNT, true)
 	await _ensure_card_count_async()
 
@@ -168,7 +171,7 @@ func _populate_cards_over_frames(count: int, add_at_top: bool = true) -> void:
 		if add_at_top:
 			_add_card_at_top(idx)
 		else:
-			_add_card_at_bottom(idx)
+			await _add_card_at_bottom(idx)
 		await get_tree().process_frame  # Spread out the work
 
 func _ensure_card_count_async(add_at_top: bool = true) -> void:
@@ -180,7 +183,7 @@ func _ensure_card_count_async(add_at_top: bool = true) -> void:
 		if add_at_top:
 			_add_card_at_top(idx)
 		else:
-			_add_card_at_bottom(idx)
+			await _add_card_at_bottom(idx)
 		await get_tree().process_frame
 
 
@@ -332,8 +335,15 @@ func apply_fugly_filter() -> void:
 			var top_idx: int = npc_indices[npc_indices.size() - 1]
 			var top_npc = NPCManager.get_npc_by_index(top_idx)
 			if top_npc.attractiveness < min_att:
-				await swipe_left_and_wait()
-				removed = true
+					var card = cards[cards.size() - 1]
+					card.queue_free()
+					cards.pop_back()
+					npc_indices.pop_back()
+					NPCManager.mark_npc_inactive_in_app(top_idx, app_name)
+					emit_signal("card_swiped_left", top_idx)
+					_update_card_positions()
+					await _after_swipe()
+					removed = true
 
 		# Then check the bottom card
 		if not removed and cards.size() > 1:


### PR DESCRIPTION
## Summary
- Refactor swipe callbacks in `ProfileCardStack` to avoid anonymous lambdas and await card loading
- Yield a frame after clearing match buttons to keep `ChatsTab` responsive
- Normalize indentation in `ProfileCardStack` and `ChatsTab` to match project style
- Clear existing cards before refilling the swipe pool and remove unattractive top cards without triggering swipe animations

## Testing
- `./Godot_v4.3-stable_linux.x86_64 --headless --path /workspace/SigmaSim --run res://tests/test_runner.tscn` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68be5834f89c832590ae85d4f26ac135