### PR TITLE
Ensure Fumble profile stack refills after batch

### DIFF
--- a/components/apps/fumble/profile_card_stack.gd
+++ b/components/apps/fumble/profile_card_stack.gd
@@ -95,11 +95,14 @@ func swipe_right() -> void:
 
 
 func _after_swipe() -> void:
-	if swipe_pool.size() < CARD_VISIBLE_COUNT + 2:
-		await _refill_swipe_pool_async()
-	var idx: int = await _fetch_next_index_from_pool()
-	if idx != -1:
-		await _add_card_at_bottom(idx)
+        if swipe_pool.size() < CARD_VISIBLE_COUNT + 2:
+                await _refill_swipe_pool_async()
+
+        while cards.size() < CARD_VISIBLE_COUNT:
+                var idx: int = await _fetch_next_index_from_pool()
+                if idx == -1:
+                        break
+                await _add_card_at_bottom(idx)
 
 func _on_swipe_left_complete(card: Control, idx: int) -> void:
 	card.queue_free()


### PR DESCRIPTION
## Summary
- After each swipe in Fumble, ensure ProfileCardStack replenishes cards until the visible count is met, enabling loading of the next NPC batch

## Testing
- `godot3-server --headless -s tests/test_runner.gd` *(fails: Can't open project config version 5 – Godot 4 required)*

------
https://chatgpt.com/codex/tasks/task_e_68bed7631b948325987fb0b4d8d37190