### PR TITLE
Ensure Fumble profile stack refills after batch

### DIFF
--- a/components/apps/fumble/profile_card_stack.gd
+++ b/components/apps/fumble/profile_card_stack.gd
@@ -95,11 +95,14 @@ func swipe_right() -> void:
 
 
 func _after_swipe() -> void:
-	if swipe_pool.size() < CARD_VISIBLE_COUNT + 2:
-		await _refill_swipe_pool_async()
-	var idx: int = await _fetch_next_index_from_pool()
-	if idx != -1:
-		await _add_card_at_bottom(idx)
+        if swipe_pool.size() < CARD_VISIBLE_COUNT + 2:
+                await _refill_swipe_pool_async()
+
+        while cards.size() < CARD_VISIBLE_COUNT:
+                var idx: int = await _fetch_next_index_from_pool()
+                if idx == -1:
+                        break
+                await _add_card_at_bottom(idx)
 
 func _on_swipe_left_complete(card: Control, idx: int) -> void:
 	card.queue_free()
@@ -243,6 +246,24 @@ func _refill_swipe_pool_async(time_budget_msec: int = 8) -> void:
 		for idx in recycled_indices:
 				if not app_active.has(idx):
 						app_active.append(idx)
+		var total_needed: int = swipe_pool_size - swipe_pool.size()
+		var needed: int = max(total_needed - (new_indices.size() + recycled_indices.size()), 0)
+		if needed > 0:
+			var extra_new: Array[int] = NPCManager.query_npc_indices({
+				"count": needed,
+				"min_attractiveness": min_att,
+				"gender_similarity_vector": preferred_gender,
+				"min_gender_similarity": gender_similarity_threshold,
+				"exclude": exclude.keys(),
+			})
+			for idx in extra_new:
+				exclude[idx] = true
+				if not app_encountered.has(idx):
+					app_encountered.append(idx)
+				if not app_active.has(idx):
+					app_active.append(idx)
+			new_indices += extra_new
+
 
 		pool += new_indices
 		pool += recycled_indices


### PR DESCRIPTION
## Summary
- After recycled candidates run out, request extra fresh NPC indices so Fumble's swipe pool always fills to capacity

## Testing
- `apt-get install -y godot4` *(fails: Unable to locate package godot4)*
- `godot3-server --headless -s tests/test_runner.gd` *(fails: Can't open project at '/workspace/SigmaSim/project.godot', its `config_version` (5) is from a more recent and incompatible version of the engine)*

------
https://chatgpt.com/codex/tasks/task_e_68bed7631b948325987fb0b4d8d37190