### PR TITLE
Ensure Fumble profile stack refills after batch

### DIFF
--- a/autoloads/npc_catalog.gd
+++ b/autoloads/npc_catalog.gd
@@ -58,13 +58,46 @@ func generate(count: int = -1) -> void:
 # because each NPC's data is derived from its index and the global name
 # seed, so existing indices retain their original names and traits.
 func ensure_unencountered(min_unencountered: int = extend_threshold, batch_size: int = extend_batch_size) -> void:
-	var encountered := 0
-	if Engine.has_singleton("NPCManager"):
-		encountered = NPCManager.encountered_npcs.size()
-	var remaining: int = npc_catalog.size() - encountered
-	if remaining < min_unencountered:
-		var target := npc_catalog.size() + batch_size
-		generate(target)
+        var encountered := 0
+        if Engine.has_singleton("NPCManager"):
+                encountered = NPCManager.encountered_npcs.size()
+        var remaining: int = npc_catalog.size() - encountered
+        if remaining < min_unencountered:
+                var target := npc_catalog.size() + batch_size
+                generate(target)
+
+# Ensures the catalogue keeps a buffer of unencountered NPCs that match
+# incoming query filters. Currently only gender similarity is checked,
+# but this can be expanded for other criteria. When the remaining
+# unencountered count of matching entries falls below
+# `min_unencountered` the catalogue is regenerated with an additional
+# `batch_size` entries.
+func ensure_filtered_unencountered(filters: Dictionary, min_unencountered: int = extend_threshold, batch_size: int = extend_batch_size) -> void:
+        if min_unencountered <= 0:
+                return
+
+        var pref_gender: Vector3 = filters.get("gender_similarity_vector", Vector3.ZERO)
+        var min_gender: float = float(filters.get("min_gender_similarity", 0.0))
+        if pref_gender == Vector3.ZERO or min_gender <= 0.0:
+                return
+
+        var encountered: Dictionary = {}
+        if Engine.has_singleton("NPCManager"):
+                for idx in NPCManager.encountered_npcs:
+                        encountered[int(idx)] = true
+
+        var remaining := 0
+        for record in npc_catalog:
+                var idx: int = int(record["index"])
+                if encountered.has(idx):
+                        continue
+                var gv: Vector3 = record.get("gender_vector", Vector3.ZERO)
+                if gender_dot_similarity(pref_gender, gv) >= min_gender:
+                        remaining += 1
+
+        if remaining < min_unencountered:
+                var target := npc_catalog.size() + batch_size
+                generate(target)
 
 func get_by_attractiveness_range(min_value: float, max_value: float) -> Array:
 	var getter := func(i: int) -> float:
@@ -99,12 +132,17 @@ func get_by_gender_range(component: String, min_value: float, max_value: float) 
 	return result
 
 func _lower_bound(arr: Array[int], value: float, getter: Callable) -> int:
-	var lo := 0
-	var hi := arr.size()
-	while lo < hi:
-		var mid := (lo + hi) / 2
-		if getter.call(arr[mid]) < value:
-			lo = mid + 1
-		else:
-			hi = mid
-	return lo
+        var lo := 0
+        var hi := arr.size()
+        while lo < hi:
+                var mid := (lo + hi) / 2
+                if getter.call(arr[mid]) < value:
+                        lo = mid + 1
+                else:
+                        hi = mid
+        return lo
+
+func gender_dot_similarity(a: Vector3, b: Vector3) -> float:
+        if a.length() == 0 or b.length() == 0:
+                return 0.0
+        return a.dot(b) / (a.length() * b.length())

--- a/components/apps/fumble/profile_card_stack.gd
+++ b/components/apps/fumble/profile_card_stack.gd
@@ -95,11 +95,14 @@ func swipe_right() -> void:
 
 
 func _after_swipe() -> void:
-	if swipe_pool.size() < CARD_VISIBLE_COUNT + 2:
-		await _refill_swipe_pool_async()
-	var idx: int = await _fetch_next_index_from_pool()
-	if idx != -1:
-		await _add_card_at_bottom(idx)
+        if swipe_pool.size() < CARD_VISIBLE_COUNT + 2:
+                await _refill_swipe_pool_async()
+
+        while cards.size() < CARD_VISIBLE_COUNT:
+                var idx: int = await _fetch_next_index_from_pool()
+                if idx == -1:
+                        break
+                await _add_card_at_bottom(idx)
 
 func _on_swipe_left_complete(card: Control, idx: int) -> void:
 	card.queue_free()
@@ -111,12 +114,13 @@ func _on_swipe_left_complete(card: Control, idx: int) -> void:
 	is_animating = false
 
 func _on_swipe_right_complete(card: Control, idx: int) -> void:
-	emit_signal("card_swiped_right", idx)
-	card.queue_free()
-	cards.pop_back()
-	npc_indices.pop_back()
-	await _after_swipe()
-	is_animating = false
+       emit_signal("card_swiped_right", idx)
+       card.queue_free()
+       cards.pop_back()
+       npc_indices.pop_back()
+       NPCManager.mark_npc_inactive_in_app(idx, app_name)
+       await _after_swipe()
+       is_animating = false
 
 
 func clear_cards() -> void:
@@ -203,13 +207,18 @@ func _refill_swipe_pool_async(time_budget_msec: int = 8) -> void:
 				exclude[id] = true
 		var min_att: float = PlayerManager.get_var("fumble_fugly_filter_threshold", 0.0) * 10.0
 
-		var new_indices: Array[int] = NPCManager.query_npc_indices({
-				"count": num_new,
-				"min_attractiveness": min_att,
-				"gender_similarity_vector": preferred_gender,
-				"min_gender_similarity": gender_similarity_threshold,
-				"exclude": exclude.keys(),
-		})
+               var new_indices: Array[int] = NPCManager.query_npc_indices({
+                               "count": num_new,
+                               "min_attractiveness": min_att,
+                               "gender_similarity_vector": preferred_gender,
+                               "min_gender_similarity": gender_similarity_threshold,
+                               "exclude": exclude.keys(),
+               })
+
+               if new_indices.size() < num_new:
+                               var needed: int = num_new - new_indices.size()
+                               var fallback: Array[int] = NPCManager.get_batch_of_new_npc_indices(app_name, needed)
+                               new_indices += fallback
 
 		if not NPCManager.encountered_npcs_by_app.has(app_name):
 				NPCManager.encountered_npcs_by_app[app_name] = []

--- a/components/npc/npc_manager.gd
+++ b/components/npc/npc_manager.gd
@@ -799,10 +799,11 @@ func reset() -> void:
 	persistent_by_wealth = {}
 
 func query_npc_indices(filters: Dictionary) -> Array[int]:
-	# Ensure the NPC catalogue has a healthy buffer of unencountered
-	# entries before we attempt to query it. This will lazily extend the
-	# catalogue in deterministic batches when we are running low.
-	NPCCatalog.ensure_unencountered()
+        # Ensure the NPC catalogue has a healthy buffer of unencountered
+        # entries before we attempt to query it. This will lazily extend the
+        # catalogue in deterministic batches when we are running low.
+        NPCCatalog.ensure_unencountered()
+        NPCCatalog.ensure_filtered_unencountered(filters)
 
 	var count: int = int(filters.get("count", 1))
 	var min_attr: float = float(filters.get("min_attractiveness", 0.0))

--- a/tests/npc_catalog_gender_buffer_test.gd
+++ b/tests/npc_catalog_gender_buffer_test.gd
@@ -1,0 +1,31 @@
+extends SceneTree
+
+func _ready() -> void:
+        RNGManager.init_seed(0)
+        NPCCatalog.generate(20)
+        NPCCatalog.extend_threshold = 2
+        NPCCatalog.extend_batch_size = 5
+        var npc_manager = Engine.get_singleton("NPCManager")
+        npc_manager.encountered_npcs = []
+        npc_manager.encounter_count = 0
+
+        var fem_ids: Array[int] = []
+        for record in NPCCatalog.npc_catalog:
+                var idx: int = int(record["index"])
+                var gv: Vector3 = record["gender_vector"]
+                if gv.x >= 0.7:
+                        fem_ids.append(idx)
+        assert(fem_ids.size() > 1)
+        for i in range(fem_ids.size() - 1):
+                npc_manager.encountered_npcs.append(fem_ids[i])
+
+        var res = npc_manager.query_npc_indices({
+                "count": 1,
+                "gender_similarity_vector": Vector3(1,0,0),
+                "min_gender_similarity": 0.7,
+        })
+        assert(res.size() == 1)
+        assert(NPCCatalog.npc_catalog.size() == 25)
+
+        print("npc_catalog_gender_buffer_test passed")
+        quit()


### PR DESCRIPTION
## Summary
- Fallback to NPCManager.get_batch_of_new_npc_indices when query returns too few
- Mark right-swiped cards inactive so stack can recycle them
- Expand NPCCatalog when gender-filtered queries run low to keep the swipe stack supplied

## Testing
- `godot3-server --headless -s tests/test_runner.gd` *(fails: Can't open project at '/workspace/SigmaSim/project.godot', config_version 5 from Godot 4 required)*

------
https://chatgpt.com/codex/tasks/task_e_68bed7631b948325987fb0b4d8d37190