### PR TITLE
Ensure fugly filter applies to future profile batches

### DIFF
--- a/components/apps/fumble/profile_card_stack.gd
+++ b/components/apps/fumble/profile_card_stack.gd
@@ -217,10 +217,18 @@ func _refill_swipe_pool_async(time_budget_msec: int = 8) -> void:
 					"exclude": exclude.keys(),
 	})
 
-	if new_indices.size() < num_new:
-					var needed: int = num_new - new_indices.size()
-					var fallback: Array[int] = NPCManager.get_batch_of_new_npc_indices(app_name, needed)
-					new_indices += fallback
+        if new_indices.size() < num_new:
+                var needed: int = num_new - new_indices.size()
+                var fallback: Array[int] = NPCManager.get_batch_of_new_npc_indices(app_name, needed)
+                for idx in fallback:
+                        var npc = NPCManager.get_npc_by_index(idx)
+                        if npc.attractiveness >= min_att:
+                                new_indices.append(idx)
+                        else:
+                                NPCManager.encountered_npcs.erase(idx)
+                                if NPCManager.encountered_npcs_by_app.has(app_name):
+                                        NPCManager.encountered_npcs_by_app[app_name].erase(idx)
+                                NPCManager.mark_npc_inactive_in_app(idx, app_name)
 
 	if not NPCManager.encountered_npcs_by_app.has(app_name):
 			NPCManager.encountered_npcs_by_app[app_name] = []

--- a/tests/fugly_filter_next_batch_test.gd
+++ b/tests/fugly_filter_next_batch_test.gd
@@ -1,0 +1,19 @@
+extends SceneTree
+
+func _ready() -> void:
+    RNGManager.init_seed(0)
+    NPCCatalog.generate(20)
+    var npc_manager = Engine.get_singleton("NPCManager")
+    npc_manager.encountered_npcs = []
+    npc_manager.encounter_count = 0
+    npc_manager.encountered_npcs_by_app.clear()
+    npc_manager.active_npcs_by_app.clear()
+    npc_manager.matched_npcs_by_app.clear()
+    PlayerManager.set_var("fumble_fugly_filter_threshold", 1.1)
+    var stack = ProfileCardStack.new()
+    stack.app_name = "fumble"
+    stack.swipe_pool_size = 5
+    await stack._refill_swipe_pool_async()
+    assert(stack.swipe_pool.is_empty())
+    print("fugly_filter_next_batch_test passed")
+    quit()


### PR DESCRIPTION
## Summary
- filter fallback NPC batches in profile card stack by fugly filter threshold
- add regression test for fugly filter batch refills

## Testing
- `godot --headless -s tests/test_runner.gd` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bef00080b88325ab18a63c73efe19f