### PR TITLE
Implement async NPC index query and update Fumble stack

### DIFF
--- a/components/apps/fumble/profile_card_stack.gd
+++ b/components/apps/fumble/profile_card_stack.gd
@@ -209,7 +209,7 @@ func _refill_swipe_pool_async(time_budget_msec: int = 8) -> void:
 			exclude[id] = true
 	var min_att: float = PlayerManager.get_var("fumble_fugly_filter_threshold", 0.0) * 10.0
 
-    var new_indices: Array[int] = await NPCManager.query_npc_indices({
+    var new_indices: Array[int] = await NPCManager.query_npc_indices_async({
 					"count": num_new,
 					"min_attractiveness": min_att,
 					"gender_similarity_vector": preferred_gender,
@@ -255,7 +255,7 @@ func _refill_swipe_pool_async(time_budget_msec: int = 8) -> void:
 	var total_needed: int = swipe_pool_size - swipe_pool.size()
 	var needed: int = max(total_needed - (new_indices.size() + recycled_indices.size()), 0)
 	if needed > 0:
-            var extra_new: Array[int] = await NPCManager.query_npc_indices({
+            var extra_new: Array[int] = await NPCManager.query_npc_indices_async({
 			"count": needed,
 			"min_attractiveness": min_att,
 			"gender_similarity_vector": preferred_gender,

--- a/components/npc/npc_manager.gd
+++ b/components/npc/npc_manager.gd
@@ -798,12 +798,12 @@ func reset() -> void:
 	persistent_by_gender = {}
 	persistent_by_wealth = {}
 
-func query_npc_indices(filters: Dictionary) -> Array[int]:
-        # Ensure the NPC catalogue has a healthy buffer of unencountered
-        # entries before we attempt to query it. This will lazily extend the
-        # catalogue in deterministic batches when we are running low.
-        NPCCatalog.ensure_unencountered()
-        await NPCCatalog.ensure_filtered_unencountered_async(filters)
+func query_npc_indices_async(filters: Dictionary, time_budget_msec: int = 8) -> Array[int]:
+	# Ensure the NPC catalogue has a healthy buffer of unencountered
+	# entries before we attempt to query it. This will lazily extend the
+	# catalogue in deterministic batches when we are running low.
+	NPCCatalog.ensure_unencountered()
+	await NPCCatalog.ensure_filtered_unencountered_async(filters, NPCCatalog.extend_threshold, NPCCatalog.extend_batch_size, time_budget_msec)
 
 	var count: int = int(filters.get("count", 1))
 	var min_attr: float = float(filters.get("min_attractiveness", 0.0))
@@ -811,6 +811,7 @@ func query_npc_indices(filters: Dictionary) -> Array[int]:
 	var min_gender_sim: float = float(filters.get("min_gender_similarity", 0.0))
 	var exclude = (filters.get("exclude", []) as Array[int])
 	var candidates: Array[int] = []
+	var start_time: int = Time.get_ticks_msec()
 	for record in NPCCatalog.npc_catalog:
 		var idx: int = int(record["index"])
 		if encountered_npcs.has(idx) or exclude.has(idx):
@@ -822,6 +823,9 @@ func query_npc_indices(filters: Dictionary) -> Array[int]:
 			if sim < min_gender_sim:
 				continue
 		candidates.append(idx)
+		if Time.get_ticks_msec() - start_time > time_budget_msec:
+			await get_tree().process_frame
+			start_time = Time.get_ticks_msec()
 	RNGManager.npc_manager.shuffle(candidates)
 	var result: Array[int] = candidates.slice(0, count)
 	for idx in result:
@@ -830,3 +834,6 @@ func query_npc_indices(filters: Dictionary) -> Array[int]:
 		if idx >= encounter_count:
 			encounter_count = idx + 1
 	return result
+
+func query_npc_indices(filters: Dictionary, time_budget_msec: int = 8) -> Array[int]:
+	return await query_npc_indices_async(filters, time_budget_msec)


### PR DESCRIPTION
## Summary
- add `query_npc_indices_async` to process catalog queries without blocking, yielding on a time budget
- use the new async NPC query when refilling Fumble profile stacks

## Testing
- `apt-get install -y godot3-server` *(fails: project requires Godot 4)*
- `godot3-server --path . -s tests/test_runner.gd` *(fails: Can't open project ... config_version (5) is from a more recent version)*
- `wget https://downloads.tuxfamily.org/godotengine/4.2.1/Godot_v4.2.1-stable_linux.x86_64_server.zip` *(fails: 503 Service Unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68bf0622c8c08325a5e0ac5677836f7b