### PR TITLE
Rename NetSurfr to NetSerf

### DIFF
--- a/apps/net_serf/net_serf.gd
+++ b/apps/net_serf/net_serf.gd
@@ -1,5 +1,5 @@
 extends Pane
-class_name NetSurfr
+class_name NetSerf
 
 @onready var back_button: Button = %BackButton
 @onready var forward_button: Button = %ForwardButton
@@ -125,4 +125,4 @@ func _is_valid_url(url: String) -> bool:
 
 func _on_webview_ipc_message(message: String) -> void:
 	# For future interop with page JS; keep a simple debug log for now.
-	print("[NetSurfr] IPC:", message)
+        print("[NetSerf] IPC:", message)

--- a/apps/net_serf/net_serf.tscn
+++ b/apps/net_serf/net_serf.tscn
@@ -1,8 +1,9 @@
 [gd_scene load_steps=2 format=3 uid="uid://cx5i71v2lucad"]
 
-[ext_resource type="Script" uid="uid://cro1kjxv0745w" path="res://apps/net_surfr/net_surfr.gd" id="1"]
 
-[node name="NetSurfr" type="PanelContainer"]
+[ext_resource type="Script" uid="uid://cro1kjxv0745w" path="res://apps/net_serf/net_serf.gd" id="1"]
+
+[node name="NetSerf" type="PanelContainer"]
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0

--- a/autoloads/window_manager.gd
+++ b/autoloads/window_manager.gd
@@ -35,7 +35,7 @@ var app_registry := {
 	"NFTarot": preload("res://components/apps/app_scenes/tarot_app.tscn"),
 	"Installer": preload("res://components/apps/app_scenes/installer.tscn"),
 	"ConwaysGame": preload("res://components/apps/conways_game/conways_game_ui.tscn"),
-	"NetSurfr": preload("res://apps/net_surfr/net_surfr.tscn"),
+        "NetSerf": preload("res://apps/net_serf/net_serf.tscn"),
 }
 
 var start_apps := {}


### PR DESCRIPTION
## Summary
- rename NetSurfr app to NetSerf including class, scene, and registry entries

## Testing
- `godot4 --headless tests/test_runner.tscn` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bf7886192c832591582fa38f5267db