### PR TITLE
Toggle DivineFilm visibility based on card ownership

### DIFF
--- a/components/apps/tarot/card_collection_examiner.gd
+++ b/components/apps/tarot/card_collection_examiner.gd
@@ -26,6 +26,7 @@ func show_card(card_id: String) -> void:
 		var count = TarotManager.get_card_rarity_count(card_id, rarity)
 		var view: TarotCardView = CARD_VIEW_SCENE.instantiate()
 		view.show_single_count = true
+		view.hide_divine_film_if_unowned = true
 		view.setup(data, count)
 		card_holder.add_child(view)
 	show()

--- a/components/apps/tarot/tarot_card_view.gd
+++ b/components/apps/tarot/tarot_card_view.gd
@@ -8,6 +8,7 @@ var sell_price: float = 0.0
 var mark_sold_on_sell: bool = false
 var show_single_count: bool = false
 var is_upside_down: bool = false
+var hide_divine_film_if_unowned: bool = false
 
 signal card_pressed(card_id: String)
 
@@ -16,6 +17,7 @@ signal card_pressed(card_id: String)
 @onready var rarity_label: Label = %RarityLabel
 @onready var count_label: Label = %CountLabel
 @onready var sell_button: Button = %SellButton
+@onready var divine_film: ColorRect = %DivineFilm
 
 const RARITY_NAMES := {
 	1: "Paper",
@@ -66,6 +68,7 @@ func update_count(new_count: int) -> void:
 	if count > 0:
 		sell_button.disabled = false
 		sell_button.text = "Sell for $%d" % int(sell_price)
+	update_divine_film()
 
 func update_rarity(new_rarity: int) -> void:
 		rarity = new_rarity
@@ -80,6 +83,10 @@ func update_rarity(new_rarity: int) -> void:
 		if is_upside_down:
 				sell_price *= 2.0
 		sell_button.text = "Sell for $%d" % int(sell_price)
+	update_divine_film()
+
+func update_divine_film() -> void:
+	divine_film.visible = rarity == 5 and (count > 0 or not hide_divine_film_if_unowned)
 
 func set_rarity_label_visible(is_visible: bool) -> void:
 	if not is_node_ready():


### PR DESCRIPTION
## Summary
- show DivineFilm overlay for divine tarot cards
- allow hiding DivineFilm when divine cards are unowned in collection view

## Testing
- `godot4 --headless -s tests/test_runner.gd` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bfaabde51883258f023e65f433b6fc