### PR TITLE
Fix FlexNumber UI ops and ensure NumberFormatter autoload loads correctly

### DIFF
--- a/autoloads/number_formatter.gd
+++ b/autoloads/number_formatter.gd
@@ -1,4 +1,6 @@
-extends RefCounted
+# Autoload script with formatting helpers.
+# Must inherit from Node to be used as an autoload singleton.
+extends Node
 # Autoload NumberFormatter
 
 const SHORT_UNITS: Array[String] = ["", "K", "M", "B", "T", "Qa", "Qi", "Sx", "Sp", "Oc", "No", "Dc"]

--- a/autoloads/stat_manager.gd
+++ b/autoloads/stat_manager.gd
@@ -83,7 +83,13 @@ func get_stat(stat_name: String, default: Variant = 0.0) -> Variant:
 		return computed_stats[stat_name]
 
 	# Fallback to player-specific data stored in PlayerManager
-	return PlayerManager.user_data.get(stat_name, default)
+        return PlayerManager.user_data.get(stat_name, default)
+
+func get_cash() -> FlexNumber:
+        return get_stat("cash")
+
+func get_ex() -> FlexNumber:
+        return get_stat("ex")
 
 
 func get_all_stats() -> Dictionary:

--- a/components/apps/broke_rage/stock_market.gd
+++ b/components/apps/broke_rage/stock_market.gd
@@ -31,13 +31,14 @@ func refresh_rows_from_market():
 
 
 func _on_buy_button_pressed(symbol: String, quantity: int) -> void:
-	var stock = PortfolioManager.stock_data.get(symbol)
-	var total_price = stock.price * quantity if stock else 0.0
-	if stock and PortfolioManager.get_cash() < total_price and UpgradeManager.get_level("brokerage_pattern_day_trader") <= 0:
-		print("Credit purchase requires Pattern Day Trader upgrade")
-		return
-	if !PortfolioManager.buy_stock(symbol, quantity):
-		print("Failed to buy stock:", symbol)
+        var stock = PortfolioManager.stock_data.get(symbol)
+        var total_price = stock.price * quantity if stock else 0.0
+        var cash: FlexNumber = PortfolioManager.get_cash()
+        if stock and cash.to_float() < total_price and UpgradeManager.get_level("brokerage_pattern_day_trader") <= 0:
+                print("Credit purchase requires Pattern Day Trader upgrade")
+                return
+        if !PortfolioManager.buy_stock(symbol, quantity):
+                print("Failed to buy stock:", symbol)
 
 func _on_sell_button_pressed(symbol: String, quantity: int) -> void:
 	if !PortfolioManager.sell_stock(symbol, quantity):

--- a/components/apps/broke_rage/stock_row.gd
+++ b/components/apps/broke_rage/stock_row.gd
@@ -16,88 +16,88 @@ var stock: Stock
 var last_price: float = 0.0
 
 func _ready() -> void:
-	for amount in ["1", "10", "100", "MAX"]:
-		quantity_option.add_item(amount)
-	quantity_option.selected = 0
+        for amount in ["1", "10", "100", "MAX"]:
+                quantity_option.add_item(amount)
+        quantity_option.selected = 0
 
 func setup(_stock: Stock) -> void:
-	stock = _stock
-	last_price = stock.price
-	update_display(stock)
+        stock = _stock
+        last_price = stock.price
+        update_display(stock)
 
-	buy_button.pressed.connect(func():
-		var quantity := _get_buy_quantity()
-		if quantity <= 0:
-				return
-		var price := stock.price * quantity
-		if PortfolioManager.get_cash() < price and UpgradeManager.get_level("brokerage_pattern_day_trader") <= 0:
-				print("Credit purchase requires Pattern Day Trader upgrade")
-				return
-		emit_signal("buy_pressed", stock.symbol, quantity)
-		update_display(stock)
-	)
-	sell_button.pressed.connect(func():
-		var quantity := _get_sell_quantity()
-		if quantity <= 0:
-				return
-		emit_signal("sell_pressed", stock.symbol, quantity)
-		update_display(stock)
-	)
+        buy_button.pressed.connect(func():
+                var quantity := _get_buy_quantity()
+                if quantity <= 0:
+                                return
+                var price := stock.price * quantity
+                var cash: FlexNumber = PortfolioManager.get_cash()
+                if cash.to_float() < price and UpgradeManager.get_level("brokerage_pattern_day_trader") <= 0:
+                                print("Credit purchase requires Pattern Day Trader upgrade")
+                                return
+                emit_signal("buy_pressed", stock.symbol, quantity)
+                update_display(stock)
+        )
+        sell_button.pressed.connect(func():
+                var quantity := _get_sell_quantity()
+                if quantity <= 0:
+                                return
+                emit_signal("sell_pressed", stock.symbol, quantity)
+                update_display(stock)
+        )
 
 func _get_buy_quantity() -> int:
-		var text := quantity_option.get_item_text(quantity_option.get_selected_id())
-		if text == "MAX":
-				return int(floor(PortfolioManager.get_cash() / stock.price))
-		return int(text)
+        var text := quantity_option.get_item_text(quantity_option.get_selected_id())
+        if text == "MAX":
+                var cash: FlexNumber = PortfolioManager.get_cash()
+                return int(floor(cash.to_float() / stock.price))
+        return int(text)
 
 func _get_sell_quantity() -> int:
-		var text := quantity_option.get_item_text(quantity_option.get_selected_id())
-		if text == "MAX":
-				return PortfolioManager.stocks_owned.get(stock.symbol, 0)
-		return int(text)
-
+        var text := quantity_option.get_item_text(quantity_option.get_selected_id())
+        if text == "MAX":
+                return PortfolioManager.stocks_owned.get(stock.symbol, 0)
+        return int(text)
 
 func update_display(updated_stock: Stock) -> void:
-	var previous_price = last_price
-	last_price = updated_stock.price
-	stock = updated_stock  # Update reference
-	
-	var owned = PortfolioManager.stocks_owned.get(stock.symbol, 0)
-	var value = stock.price * owned
+        var previous_price = last_price
+        last_price = updated_stock.price
+        stock = updated_stock  # Update reference
 
-	stock_label.text = " %s $%.2f" % [stock.symbol, stock.price]
-	owned_label.text = "%d shares ($%.2f)" % [owned, value]
+        var owned = PortfolioManager.stocks_owned.get(stock.symbol, 0)
+        var value = stock.price * owned
 
-	# Animate price color if changed
-	if stock.price > previous_price:
-		flash_price_color(Color.GREEN)
-	elif stock.price < previous_price:
-		flash_price_color(Color.RED)
+        stock_label.text = " %s $%.2f" % [stock.symbol, stock.price]
+        owned_label.text = "%d shares ($%.2f)" % [owned, value]
 
-	update_sentiment_arrow(stock.sentiment)
+        # Animate price color if changed
+        if stock.price > previous_price:
+                flash_price_color(Color.GREEN)
+        elif stock.price < previous_price:
+                flash_price_color(Color.RED)
+
+        update_sentiment_arrow(stock.sentiment)
 
 func flash_price_color(color: Color) -> void:
-	stock_label.add_theme_color_override("font_color", color)
-	#await get_tree().create_timer(.4).timeout
-	#stock_label.remove_theme_color_override("font_color")
+        stock_label.add_theme_color_override("font_color", color)
+        #await get_tree().create_timer(.4).timeout
+        #stock_label.remove_theme_color_override("font_color")
 
 func update_sentiment_arrow(sentiment: float) -> void:
-	arrow.pivot_offset = arrow.size / 2  # Ensure centered rotation
+        arrow.pivot_offset = arrow.size / 2  # Ensure centered rotation
 
-	sentiment = clamp(sentiment, -1.0, 1.0)
-	var angle_deg = lerp(180.0, 0.0, (sentiment + 1.0) / 2.0)
-	arrow.rotation_degrees = angle_deg
+        sentiment = clamp(sentiment, -1.0, 1.0)
+        var angle_deg = lerp(180.0, 0.0, (sentiment + 1.0) / 2.0)
+        arrow.rotation_degrees = angle_deg
 
-	if sentiment > 0.05:
-		arrow.modulate = Color.GREEN
-	elif sentiment < -0.05:
-		arrow.modulate = Color.RED
-	else:
-		arrow.modulate = Color(0.6, 0.6, 0.6)  # Neutral
-
+        if sentiment > 0.05:
+                arrow.modulate = Color.GREEN
+        elif sentiment < -0.05:
+                arrow.modulate = Color.RED
+        else:
+                arrow.modulate = Color(0.6, 0.6, 0.6)  # Neutral
 
 func _on_stock_label_gui_input(event: InputEvent) -> void:
-	if event is InputEventMouseButton and event.pressed and event.button_index == MOUSE_BUTTON_LEFT:
-			var popup_scene = preload("res://components/popups/stock_popup_ui.tscn")
-			var stock_popup = popup_scene.instantiate() as Pane
-			WindowManager.launch_pane_instance(stock_popup, stock)
+        if event is InputEventMouseButton and event.pressed and event.button_index == MOUSE_BUTTON_LEFT:
+                        var popup_scene = preload("res://components/popups/stock_popup_ui.tscn")
+                        var stock_popup = popup_scene.instantiate() as Pane
+                        WindowManager.launch_pane_instance(stock_popup, stock)

--- a/components/popups/crypto_popup_ui.gd
+++ b/components/popups/crypto_popup_ui.gd
@@ -71,16 +71,17 @@ func _update_ui() -> void:
 	label_owned.text = "%.4f" % PortfolioManager.get_crypto_amount(crypto.symbol)
 
 func _on_buy_pressed() -> void:
-	if crypto:
-		var sel_text := quantity_option.get_item_text(quantity_option.get_selected_id())
-		var amount: float
-		if sel_text == "MAX":
-			amount = PortfolioManager.get_cash() / crypto.price
-		else:
-			amount = float(sel_text)
-		if PortfolioManager.attempt_spend(crypto.price * amount):
-			PortfolioManager.add_crypto(crypto.symbol, amount)
-			_update_ui()
+        if crypto:
+                var sel_text := quantity_option.get_item_text(quantity_option.get_selected_id())
+                var amount: float
+                var cash: FlexNumber = PortfolioManager.get_cash()
+                if sel_text == "MAX":
+                        amount = cash.to_float() / crypto.price
+                else:
+                        amount = float(sel_text)
+                if PortfolioManager.attempt_spend(crypto.price * amount):
+                        PortfolioManager.add_crypto(crypto.symbol, amount)
+                        _update_ui()
 
 func _on_sell_pressed() -> void:
 	if crypto:
@@ -94,17 +95,18 @@ func _on_sell_pressed() -> void:
 			_update_ui()
 
 func _on_buy_button_gui_input(event: InputEvent) -> void:
-	if event is InputEventMouseButton and event.button_index == MOUSE_BUTTON_RIGHT and event.pressed and crypto:
-		var sel_text := quantity_option.get_item_text(quantity_option.get_selected_id())
-		var amount: float
-		if sel_text == "MAX":
-			amount = PortfolioManager.get_cash() / crypto.price
-		else:
-			amount = float(sel_text)
-		if PortfolioManager.attempt_spend(crypto.price * amount, 0, false, true):
-			PortfolioManager.add_crypto(crypto.symbol, amount)
-			_update_ui()
-		buy_button.accept_event()
+        if event is InputEventMouseButton and event.button_index == MOUSE_BUTTON_RIGHT and event.pressed and crypto:
+                var sel_text := quantity_option.get_item_text(quantity_option.get_selected_id())
+                var amount: float
+                var cash: FlexNumber = PortfolioManager.get_cash()
+                if sel_text == "MAX":
+                        amount = cash.to_float() / crypto.price
+                else:
+                        amount = float(sel_text)
+                if PortfolioManager.attempt_spend(crypto.price * amount, 0, false, true):
+                        PortfolioManager.add_crypto(crypto.symbol, amount)
+                        _update_ui()
+                        buy_button.accept_event()
 
 
 func get_custom_save_data() -> Dictionary:

--- a/components/popups/stock_popup_ui.gd
+++ b/components/popups/stock_popup_ui.gd
@@ -72,20 +72,21 @@ func _update_ui() -> void:
 	label_owned.text = str(PortfolioManager.stocks_owned.get(stock.symbol, 0))
 
 func _on_buy_pressed() -> void:
-	if not stock:
-		return
-	var sel_text := quantity_option.get_item_text(quantity_option.get_selected_id())
-	var quantity: int
-	if sel_text == "MAX":
-		quantity = int(floor(PortfolioManager.get_cash() / stock.price))
-	else:
-		quantity = int(sel_text)
-	var price := stock.price * quantity
-	if PortfolioManager.get_cash() < price and UpgradeManager.get_level("brokerage_pattern_day_trader") <= 0:
-		print("Credit purchase requires Pattern Day Trader upgrade")
-		return
-	if PortfolioManager.buy_stock(stock.symbol, quantity):
-		_update_ui()
+        if not stock:
+                return
+        var sel_text := quantity_option.get_item_text(quantity_option.get_selected_id())
+        var quantity: int
+        var cash: FlexNumber = PortfolioManager.get_cash()
+        if sel_text == "MAX":
+                quantity = int(floor(cash.to_float() / stock.price))
+        else:
+                quantity = int(sel_text)
+        var price := stock.price * quantity
+        if cash.to_float() < price and UpgradeManager.get_level("brokerage_pattern_day_trader") <= 0:
+                print("Credit purchase requires Pattern Day Trader upgrade")
+                return
+        if PortfolioManager.buy_stock(stock.symbol, quantity):
+                _update_ui()
 
 func _on_sell_pressed() -> void:
 	if stock:


### PR DESCRIPTION
## Summary
- keep cash and ex accessible as FlexNumbers via new StatManager getters
- store cash as FlexNumber when processing stock/crypto purchases and convert to float only for math
- fix over‑indented lines in trading UI scripts

## Testing
- `godot3-runner --headless --path . tests/test_runner.tscn` *(fails: project.godot config_version 5 requires newer engine)*

------
https://chatgpt.com/codex/tasks/task_e_68c034d138308325a7b34bd23482ebf5