### PR TITLE
Add smart number formatting for cash and EX

### DIFF
--- a/autoloads/number_formatter.gd
+++ b/autoloads/number_formatter.gd
@@ -93,12 +93,24 @@ static func format_sci(number: float, decimals: int = 2) -> String:
 
 # Mantissa/exponent formatting helpers for FlexNumber
 static func format_mantissa_exponent(mantissa: float, exponent: int, decimals: int = 2) -> String:
-	return "%.*fe%d" % [decimals, mantissa, exponent]
+		return "%.*fe%d" % [decimals, mantissa, exponent]
 
 static func format_flex(number: FlexNumber, decimals: int = 2, style: String = "commas") -> String:
-	if number.is_big():
-		return format_mantissa_exponent(number._mantissa, number._exponent, decimals)
-	return format_number(number.to_float(), style, decimals)
+		if number.is_big():
+				return format_mantissa_exponent(number._mantissa, number._exponent, decimals)
+		return format_number(number.to_float(), style, decimals)
+
+static func smart_format(number: Variant, decimals: int = 2) -> String:
+	if number is FlexNumber:
+		if number.is_big():
+			return format_mantissa_exponent(number._mantissa, number._exponent, decimals)
+		return format_commas(number.to_float(), decimals)
+
+	var n: float = float(number)
+	if abs(n) >= FlexNumber.THRESHOLD:
+		var fn := FlexNumber.new(n)
+		return format_mantissa_exponent(fn._mantissa, fn._exponent, decimals)
+	return format_commas(n, decimals)
 
 # Main interface (now static so it can be called from static helpers)
 static func format_number(number: Variant, style: String = "commas", decimals: int = 2) -> String:

--- a/autoloads/portfolio_manager.gd
+++ b/autoloads/portfolio_manager.gd
@@ -174,7 +174,7 @@ func attempt_spend(amount: float, credit_required_score: int = 0, silent: bool =
 						var total_with_interest := amount * (1.0 + get_credit_interest_rate())
 						set_credit_used(get_credit_used() + total_with_interest)
 						if not silent:
-								StatpopManager.spawn("-$" + str(NumberFormatter.format_number(amount)), get_viewport().get_mouse_position(), "click", Color.ORANGE)
+								StatpopManager.spawn("-$" + str(NumberFormatter.smart_format(amount)), get_viewport().get_mouse_position(), "click", Color.ORANGE)
 						WindowManager.launch_app_by_name("OwerView")
 						return true
 				if not silent:
@@ -185,7 +185,7 @@ func attempt_spend(amount: float, credit_required_score: int = 0, silent: bool =
 		if can_pay_with_cash(amount):
 			spend_cash(amount)
 			if not silent:
-				StatpopManager.spawn("-$" + str(NumberFormatter.format_number(amount)), get_viewport().get_mouse_position(), "click", Color.YELLOW)
+				StatpopManager.spawn("-$" + str(NumberFormatter.smart_format(amount)), get_viewport().get_mouse_position(), "click", Color.YELLOW)
 			return true
 
 		var current_cash := get_cash().to_float()
@@ -202,13 +202,13 @@ func attempt_spend(amount: float, credit_required_score: int = 0, silent: bool =
 			if current_cash > 0.0:
 				spend_cash(current_cash)
 				if not silent:
-					StatpopManager.spawn("-$" + str(NumberFormatter.format_number(remainder)), get_viewport().get_mouse_position(), "click", Color.YELLOW)
+					StatpopManager.spawn("-$" + str(NumberFormatter.smart_format(remainder)), get_viewport().get_mouse_position(), "click", Color.YELLOW)
 
 			if can_pay_with_credit(remainder):
 				var total_with_interest = remainder * (1.0 + get_credit_interest_rate())
 				set_credit_used(get_credit_used() + total_with_interest)
 				if not silent:
-					StatpopManager.spawn("-$" + str(NumberFormatter.format_number(remainder)), get_viewport().get_mouse_position(), "click", Color.ORANGE)
+					StatpopManager.spawn("-$" + str(NumberFormatter.smart_format(remainder)), get_viewport().get_mouse_position(), "click", Color.ORANGE)
 				WindowManager.launch_app_by_name("OwerView")
 				return true
 		# Failed to pay
@@ -424,7 +424,7 @@ func sell_stock(symbol: String, amount: int = 1) -> bool:
 
 	var stock = stock_data.get(symbol)
 	add_cash(stock.price * amount)
-	StatpopManager.spawn("+$" + str(NumberFormatter.format_number(stock.price*amount)), get_viewport().get_mouse_position(), "click", Color.GREEN)
+	StatpopManager.spawn("+$" + str(NumberFormatter.smart_format(stock.price*amount)), get_viewport().get_mouse_position(), "click", Color.GREEN)
 	stocks_owned[symbol] -= amount
 	MarketManager.apply_stock_transaction(symbol, -amount)
 	return true

--- a/autoloads/upgrade_manager.gd
+++ b/autoloads/upgrade_manager.gd
@@ -297,7 +297,7 @@ func _deduct_currency(currency: String, amount: float, credit_only: bool = false
 		ex_stat.subtract(amount)
 		StatManager.set_base_stat("ex", ex_stat)
 		StatpopManager.spawn(
-			"-%s EX" % NumberFormatter.format_number(amount),
+			"-%s EX" % NumberFormatter.smart_format(amount),
 			get_viewport().get_mouse_position(),
 			"click",
 			Color.YELLOW,
@@ -307,7 +307,7 @@ func _deduct_currency(currency: String, amount: float, credit_only: bool = false
 		return false
 	PortfolioManager.add_crypto(currency, -amount)
 	StatpopManager.spawn(
-		"-%s %s" % [NumberFormatter.format_number(amount), currency],
+		"-%s %s" % [NumberFormatter.smart_format(amount), currency],
 		get_viewport().get_mouse_position(),
 		"click",
 		Color.YELLOW

--- a/components/apps/broke_rage/broke_rage_ui.gd
+++ b/components/apps/broke_rage/broke_rage_ui.gd
@@ -75,9 +75,9 @@ func _on_cash_updated(_cash: float) -> void:
 	var cash = PortfolioManager.cash
 	var balance = PortfolioManager.get_balance()
 
-	cash_label.text = "Cash: $" + NumberFormatter.format_number(cash)
-	balance_label.text = "Net Worth: $" + str(NumberFormatter.format_number(balance))
-	charts_cash_label.text = "Cash: $" + NumberFormatter.format_number(cash)
+	cash_label.text = "Cash: $" + NumberFormatter.smart_format(cash)
+	balance_label.text = "Net Worth: $" + str(NumberFormatter.smart_format(balance))
+	charts_cash_label.text = "Cash: $" + NumberFormatter.smart_format(cash)
 
 	HistoryManager.add_sample("cash", TimeManager.get_now_minutes() / 1000.0, cash)
 	_add_net_worth_sample()
@@ -94,9 +94,9 @@ func _on_investments_updated(amount: float):
 	var delta = amount - last_invested
 	last_invested = amount
 
-	invested_label.text = "Invested: $" + str(NumberFormatter.format_number(amount))
-	balance_label.text = "Net Worth: $" + str(NumberFormatter.format_number(PortfolioManager.get_balance()))
-	charts_portfolio_label.text = "Stocks: $" + str(NumberFormatter.format_number(amount))
+	invested_label.text = "Invested: $" + str(NumberFormatter.smart_format(amount))
+	balance_label.text = "Net Worth: $" + str(NumberFormatter.smart_format(PortfolioManager.get_balance()))
+	charts_portfolio_label.text = "Stocks: $" + str(NumberFormatter.smart_format(amount))
 	#TODO: ^Fix: Invalid assignment of property or key 'text' with value of type 'String' on a base object of type 'previously freed'.
 
 	if delta > 0.01:
@@ -120,7 +120,7 @@ func _on_resource_changed(resource: String, _value: float) -> void:
 		_on_debt_updated()
 
 func _on_debt_updated() -> void:
-	debt_label.text = "Debt: $" + NumberFormatter.format_number(PortfolioManager.get_total_debt())
+	debt_label.text = "Debt: $" + NumberFormatter.smart_format(PortfolioManager.get_total_debt())
 	_add_net_worth_sample()
 
 

--- a/components/apps/minerr/crypto_card.gd
+++ b/components/apps/minerr/crypto_card.gd
@@ -162,7 +162,7 @@ func update_display() -> void:
 
 	symbol_label.text = crypto.symbol
 	display_name_label.text = crypto.display_name
-	price_label.text = "$" + NumberFormatter.format_number(crypto.price)
+	price_label.text = "$" + NumberFormatter.smart_format(crypto.price)
 	block_size_label.text = "Block size: %.1f" % crypto.block_size
 
 	var owned: float = PortfolioManager.get_crypto_amount(crypto.symbol)

--- a/components/apps/minerr/minerr_ui.gd
+++ b/components/apps/minerr/minerr_ui.gd
@@ -252,8 +252,8 @@ func _on_cash_updated(_cash: float) -> void:
 	_update_charts_labels()
 
 func _update_charts_labels() -> void:
-	charts_cash_label.text = "Cash: $" + NumberFormatter.format_number(PortfolioManager.cash)
-	charts_crypto_label.text = "Crypto: $" + NumberFormatter.format_number(PortfolioManager.get_crypto_total())
+	charts_cash_label.text = "Cash: $" + NumberFormatter.smart_format(PortfolioManager.cash)
+	charts_crypto_label.text = "Crypto: $" + NumberFormatter.smart_format(PortfolioManager.get_crypto_total())
 
 func _activate_tab(tab_name: StringName) -> void:
 	if tab_name == &"Mine":

--- a/components/apps/wallet/wallet_cards/brag_card.gd
+++ b/components/apps/wallet/wallet_cards/brag_card.gd
@@ -14,8 +14,8 @@ func _build() -> void:
 				cash = PortfolioManager.cash
 				balance = PortfolioManager.get_balance()
 		var rows1: Array = []
-		rows1.append({"label": "Cash", "value": "$" + NumberFormatter.format_number(cash)})
-		rows1.append({"label": "Net Worth", "value": "$" + NumberFormatter.format_number(balance)})
+		rows1.append({"label": "Cash", "value": "$" + NumberFormatter.smart_format(cash)})
+		rows1.append({"label": "Net Worth", "value": "$" + NumberFormatter.smart_format(balance)})
 		add_group("totals", rows1)
 
 		var ex_score: float = _get_ex_factor_score()

--- a/components/apps/wallet/wallet_cards/credit_card.gd
+++ b/components/apps/wallet/wallet_cards/credit_card.gd
@@ -33,8 +33,8 @@ func _build() -> void:
 
 	# Section: account
 	var rows1: Array = []
-	rows1.append({"label": "Balance", "value": "$" + NumberFormatter.format_number(_balance)})
-	rows1.append({"label": "Limit", "value": "$" + NumberFormatter.format_number(_limit)})
+	rows1.append({"label": "Balance", "value": "$" + NumberFormatter.smart_format(_balance)})
+	rows1.append({"label": "Limit", "value": "$" + NumberFormatter.smart_format(_limit)})
 	add_group("account", rows1)
 
 	# Utilization meter

--- a/components/apps/wallet/wallet_cards/student_loan_card.gd
+++ b/components/apps/wallet/wallet_cards/student_loan_card.gd
@@ -21,7 +21,7 @@ func _ready() -> void:
 
 func _build() -> void:
 	var rows1: Array = []
-	rows1.append({"label": "Principal", "value": "$" + NumberFormatter.format_number(_principal)})
+	rows1.append({"label": "Principal", "value": "$" + NumberFormatter.smart_format(_principal)})
 	rows1.append({"label": "Accrued Interest", "value": "$" + String.num(_accrued_interest, 2)})
 	add_group("balance", rows1)
 

--- a/components/popups/ex_factor_view.gd
+++ b/components/popups/ex_factor_view.gd
@@ -399,7 +399,7 @@ func _update_apologize_button() -> void:
 	if not apologize_button.visible:
 			return
 	var cost: int = logic.get_apologize_cost()
-	apologize_button.text = "Apologize (%s EX)" % NumberFormatter.format_number(cost)
+	apologize_button.text = "Apologize (%s EX)" % NumberFormatter.smart_format(cost)
 	apologize_button.disabled = StatManager.get_stat("ex").to_float() < float(cost)
 
 func _update_locked_in_button() -> void:

--- a/components/ticker.gd
+++ b/components/ticker.gd
@@ -95,8 +95,8 @@ func _ready():
 func _process(_delta):
 	if current_template != "":
 		text_label.text = format_ticker_text(current_template)
-	cash_label.text = "$" + str(NumberFormatter.format_number(PortfolioManager.cash))
-	ex_label.text = str(NumberFormatter.format_number(StatManager.get_stat("ex"))) + " EX"
+	cash_label.text = "$" + str(NumberFormatter.smart_format(PortfolioManager.cash))
+	ex_label.text = str(NumberFormatter.smart_format(StatManager.get_stat("ex"))) + " EX"
 
 func _on_timer_timeout():
 	#print("ticker timeout")

--- a/components/upgrade_scenes/deprecated/upgrade_tooltip.gd
+++ b/components/upgrade_scenes/deprecated/upgrade_tooltip.gd
@@ -81,7 +81,7 @@ func format_cost(upgrade: Dictionary) -> String:
 		var cost = UpgradeManager.get_cost_for_next_level(upgrade.get("id"))
 		var parts: Array[String] = []
 		for currency in cost.keys():
-				var amount = NumberFormatter.format_number(cost[currency])
+				var amount = NumberFormatter.smart_format(cost[currency])
 				if currency == "cash":
 						parts.append("💰 $%s" % amount)
 				else:

--- a/tests/number_formatter_smart_format_test.gd
+++ b/tests/number_formatter_smart_format_test.gd
@@ -1,0 +1,12 @@
+extends SceneTree
+
+func _ready() -> void:
+    var small := NumberFormatter.smart_format(999.99)
+    assert(small == "999.99")
+    var big := NumberFormatter.smart_format(1234000000.0)
+    assert(big == "1.23e9")
+    var flex := FlexNumber.new(1234000000.0)
+    var flex_str := NumberFormatter.smart_format(flex)
+    assert(flex_str == "1.23e9")
+    print("number_formatter_smart_format_test passed")
+    quit()


### PR DESCRIPTION
## Summary
- add `smart_format` helper to choose commas or mantissa/exponent formatting
- switch cash/EX displays to use `smart_format`
- add test for smart formatting

## Testing
- `godot4 --headless --path . tests/test_runner.tscn` *(fails: command not found)*
- `apt-get install -y godot4` *(fails: package not found)*
- `wget https://downloads.tuxfamily.org/godotengine/4.2.1/Godot_v4.2.1-stable_linux.x86_64_headless.zip` *(fails: 503 Service Unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68c04217caac83259a9a0eaec0b39fbc