### PR TITLE
Use smart number formatting for cash and EX buttons

### DIFF
--- a/autoloads/number_formatter.gd
+++ b/autoloads/number_formatter.gd
@@ -83,16 +83,27 @@ static func format_flex(number: FlexNumber, decimals: int = 2, style: String = "
 
 # Main interface
 func format_number(number: Variant, style: String = "commas", decimals: int = 2) -> String:
-	if number is FlexNumber:
-		return format_flex(number, decimals, style)
-	match style:
-		"commas":
-			return format_commas(number, decimals)
-		"short":
-			return format_short(number, decimals)
-		"long":
-			return format_long(number, decimals)
-		"sci", "scientific":
-			return format_sci(number, decimals)
-		_:
-			return str(number)
+        if number is FlexNumber:
+                return format_flex(number, decimals, style)
+        match style:
+                "commas":
+                        return format_commas(number, decimals)
+                "short":
+                        return format_short(number, decimals)
+                "long":
+                        return format_long(number, decimals)
+                "sci", "scientific":
+                        return format_sci(number, decimals)
+                _:
+                        return str(number)
+
+# Smart format: commas below 1B, scientific above
+func smart_format(number: Variant, decimals: int = 2, hide_trailing_zeroes: bool = false) -> String:
+        if number is FlexNumber:
+                if number.is_big():
+                        return format_mantissa_exponent(number._mantissa, number._exponent, decimals)
+                number = number.to_float()
+        var n: float = float(number)
+        if abs(n) >= 1_000_000_000.0:
+                return format_sci(n, decimals)
+        return format_commas(n, decimals, hide_trailing_zeroes)

--- a/components/apps/daterbase/daterbase.gd
+++ b/components/apps/daterbase/daterbase.gd
@@ -181,9 +181,9 @@ func _on_upgrade_purchased(id: String, _level: int) -> void:
 								_update_tab_unlocks()
 
 func _refresh_hh_open_fumble_button() -> void:
-				var cost: float = PlayerManager.get_var("hh_open_fumble_cost", 10)
-				hh_open_fumble_button.text = "Open in Fumble (%d EX)" % int(cost)
-				hh_open_fumble_button.disabled = hh_current_npc == null or StatManager.get_stat("ex").to_float() < cost
+        var cost: float = PlayerManager.get_var("hh_open_fumble_cost", 10)
+        hh_open_fumble_button.text = "Open in Fumble (%s EX)" % NumberFormatter.smart_format(cost, 0)
+        hh_open_fumble_button.disabled = hh_current_npc == null or StatManager.get_stat("ex").to_float() < cost
 
 # =========================================
 # Buttons

--- a/components/apps/early_bird/early_bird.gd
+++ b/components/apps/early_bird/early_bird.gd
@@ -221,12 +221,12 @@ func _get_autopilot_cost() -> float:
 		return autopilot_cost
 
 func _update_autopilot_button_text() -> void:
-	autopilot_button.button_pressed = autopilot.enabled
-	var cost := _get_autopilot_cost()
-	if not autopilot.enabled and cost > 0.0:
-		autopilot_button.text = "Autopilot: $" + NumberFormatter.format_commas(cost, 2, true)
-	else:
-		autopilot_button.text = "Autopilot"
+        autopilot_button.button_pressed = autopilot.enabled
+        var cost := _get_autopilot_cost()
+        if not autopilot.enabled and cost > 0.0:
+                autopilot_button.text = "Autopilot: $" + NumberFormatter.smart_format(cost, 2, true)
+        else:
+                autopilot_button.text = "Autopilot"
 
 func _on_upgrade_purchased(id: String, _level: int) -> void:
 	if id == "earlybird_autopilot_free":

--- a/components/apps/soft_wares/soft_ware_item.gd
+++ b/components/apps/soft_wares/soft_ware_item.gd
@@ -38,10 +38,10 @@ func _prepare_icon(source: Texture2D) -> Texture2D:
 	return ImageTexture.create_from_image(img)
 
 func _update_action_button() -> void:
-	if WindowManager.is_app_unlocked(app_id):
-		action_button.text = "Launch"
-	else:
-		action_button.text = "Buy App for $" + str(app_cost)
+        if WindowManager.is_app_unlocked(app_id):
+                action_button.text = "Launch"
+        else:
+                action_button.text = "Buy App for $" + NumberFormatter.smart_format(app_cost, 0)
 
 func _on_action_button_pressed() -> void:
 	feedback_label.text = ""

--- a/components/apps/tarot/tarot_card_view.gd
+++ b/components/apps/tarot/tarot_card_view.gd
@@ -56,7 +56,7 @@ func setup(data: Dictionary, owned: int) -> void:
 	if tex:
 		texture_rect.texture = tex
 	update_count(owned)
-	sell_button.text = "Sell for $%d" % int(sell_price)
+       sell_button.text = "Sell for $%s" % NumberFormatter.smart_format(sell_price, 0)
 	sell_button.pressed.connect(_on_sell_pressed)
 
 func update_count(new_count: int) -> void:
@@ -67,7 +67,7 @@ func update_count(new_count: int) -> void:
 	texture_rect.modulate = Color(1,1,1,1) if count > 0 else Color(0.5,0.5,0.5,1)
 	if count > 0:
 		sell_button.disabled = false
-		sell_button.text = "Sell for $%d" % int(sell_price)
+               sell_button.text = "Sell for $%s" % NumberFormatter.smart_format(sell_price, 0)
 	update_divine_film()
 
 func update_rarity(new_rarity: int) -> void:
@@ -82,7 +82,7 @@ func update_rarity(new_rarity: int) -> void:
 	sell_price = TarotManager.get_sell_price(rarity)
 	if is_upside_down:
 			sell_price *= 2.0
-	sell_button.text = "Sell for $%d" % int(sell_price)
+       sell_button.text = "Sell for $%s" % NumberFormatter.smart_format(sell_price, 0)
 	update_divine_film()
 
 func update_divine_film() -> void:
@@ -124,4 +124,4 @@ func set_upside_down(flag: bool) -> void:
 		sell_price = TarotManager.get_sell_price(rarity)
 		if is_upside_down:
 				sell_price *= 2.0
-		sell_button.text = "Sell for $%d" % int(sell_price)
+               sell_button.text = "Sell for $%s" % NumberFormatter.smart_format(sell_price, 0)

--- a/components/popups/ex_factor_view.gd
+++ b/components/popups/ex_factor_view.gd
@@ -258,15 +258,15 @@ func _update_affinity_bar() -> void:
 	affinity_value_label.text = "%s / 100" % NumberFormatter.format_commas(npc.affinity, 0)
 
 func _update_buttons_text() -> void:
-	gift_button.text = "Gift ($%s)" % NumberFormatter.format_commas(npc.gift_cost)
-	date_button.text = "Date ($%s)" % NumberFormatter.format_commas(npc.date_cost)
-	# breakup button label uses preview:
-	breakup_preview = logic.preview_breakup_reward()
-	if npc.relationship_stage >= NPCManager.RelationshipStage.DIVORCED:
-		breakup_button.disabled = true
-	else:
-		breakup_button.disabled = false
-		breakup_button.text = "Breakup & gain " + NumberFormatter.format_commas(breakup_preview) + " EX"
+       gift_button.text = "Gift ($%s)" % NumberFormatter.smart_format(npc.gift_cost)
+       date_button.text = "Date ($%s)" % NumberFormatter.smart_format(npc.date_cost)
+       # breakup button label uses preview:
+       breakup_preview = logic.preview_breakup_reward()
+       if npc.relationship_stage >= NPCManager.RelationshipStage.DIVORCED:
+               breakup_button.disabled = true
+       else:
+               breakup_button.disabled = false
+               breakup_button.text = "Breakup & gain " + NumberFormatter.smart_format(breakup_preview) + " EX"
 
 func _update_love_button() -> void:
 	if npc.relationship_stage < NPCManager.RelationshipStage.DATING:
@@ -398,9 +398,9 @@ func _update_apologize_button() -> void:
 	apologize_button.visible = has_upgrade and in_ex_stage
 	if not apologize_button.visible:
 			return
-	var cost: int = logic.get_apologize_cost()
-	apologize_button.text = "Apologize (%s EX)" % NumberFormatter.format_number(cost)
-	apologize_button.disabled = StatManager.get_stat("ex").to_float() < float(cost)
+       var cost: int = logic.get_apologize_cost()
+       apologize_button.text = "Apologize (%s EX)" % NumberFormatter.smart_format(cost)
+       apologize_button.disabled = StatManager.get_stat("ex").to_float() < float(cost)
 
 func _update_locked_in_button() -> void:
 	if not is_instance_valid(locked_in_button):
@@ -491,10 +491,10 @@ func _prepare_next_stage_confirm() -> void:
 			next_stage_confirm_alt_button.visible = true
 		else:
 			next_stage_confirm_primary_button.text = "Get SERIOUS"
-	elif current_stage == NPCManager.RelationshipStage.SERIOUS:
-		next_stage_confirm_primary_button.text = "Propose ($%s)" % NumberFormatter.format_commas(npc.proposal_cost, 0)
-	else:
-		next_stage_confirm_primary_button.text = "Progress to %s" % next_name
+       elif current_stage == NPCManager.RelationshipStage.SERIOUS:
+               next_stage_confirm_primary_button.text = "Propose ($%s)" % NumberFormatter.smart_format(npc.proposal_cost, 0)
+       else:
+               next_stage_confirm_primary_button.text = "Progress to %s" % next_name
 
 func _on_next_stage_confirm_primary_pressed() -> void:
 	next_stage_confirm.visible = false

--- a/tests/number_formatter_smart_format_test.gd
+++ b/tests/number_formatter_smart_format_test.gd
@@ -1,0 +1,9 @@
+extends SceneTree
+
+func _ready() -> void:
+    var below := NumberFormatter.smart_format(500_000_000)
+    assert(below == "500,000,000")
+    var above := NumberFormatter.smart_format(1_234_567_890)
+    assert(above == "1.23e9")
+    print("number_formatter_smart_format_test passed")
+    quit()


### PR DESCRIPTION
## Summary
- add `smart_format` helper to switch from commas to scientific notation above 1B
- use `smart_format` for button text displaying cash or EX values
- cover smart formatting with a unit test

## Testing
- `godot3 --headless -s tests/test_runner.gd` *(fails: project requires newer Godot)*

------
https://chatgpt.com/codex/tasks/task_e_68c049802a9c83259b80d2a7490f0b7d