### PR TITLE
Use smart_format for cash and EX buttons

### DIFF
--- a/components/apps/early_bird/early_bird.gd
+++ b/components/apps/early_bird/early_bird.gd
@@ -221,12 +221,12 @@ func _get_autopilot_cost() -> float:
 		return autopilot_cost
 
 func _update_autopilot_button_text() -> void:
-	autopilot_button.button_pressed = autopilot.enabled
-	var cost := _get_autopilot_cost()
-	if not autopilot.enabled and cost > 0.0:
-		autopilot_button.text = "Autopilot: $" + NumberFormatter.format_commas(cost, 2, true)
-	else:
-		autopilot_button.text = "Autopilot"
+        autopilot_button.button_pressed = autopilot.enabled
+        var cost := _get_autopilot_cost()
+        if not autopilot.enabled and cost > 0.0:
+                autopilot_button.text = "Autopilot: $" + NumberFormatter.smart_format(cost)
+        else:
+                autopilot_button.text = "Autopilot"
 
 func _on_upgrade_purchased(id: String, _level: int) -> void:
 	if id == "earlybird_autopilot_free":

--- a/components/popups/ex_factor_view.gd
+++ b/components/popups/ex_factor_view.gd
@@ -258,15 +258,15 @@ func _update_affinity_bar() -> void:
 	affinity_value_label.text = "%s / 100" % NumberFormatter.format_commas(npc.affinity, 0)
 
 func _update_buttons_text() -> void:
-	gift_button.text = "Gift ($%s)" % NumberFormatter.format_commas(npc.gift_cost)
-	date_button.text = "Date ($%s)" % NumberFormatter.format_commas(npc.date_cost)
-	# breakup button label uses preview:
-	breakup_preview = logic.preview_breakup_reward()
-	if npc.relationship_stage >= NPCManager.RelationshipStage.DIVORCED:
-		breakup_button.disabled = true
-	else:
-		breakup_button.disabled = false
-		breakup_button.text = "Breakup & gain " + NumberFormatter.format_commas(breakup_preview) + " EX"
+        gift_button.text = "Gift ($%s)" % NumberFormatter.smart_format(npc.gift_cost)
+        date_button.text = "Date ($%s)" % NumberFormatter.smart_format(npc.date_cost)
+        # breakup button label uses preview:
+        breakup_preview = logic.preview_breakup_reward()
+        if npc.relationship_stage >= NPCManager.RelationshipStage.DIVORCED:
+                breakup_button.disabled = true
+        else:
+                breakup_button.disabled = false
+                breakup_button.text = "Breakup & gain " + NumberFormatter.smart_format(breakup_preview) + " EX"
 
 func _update_love_button() -> void:
 	if npc.relationship_stage < NPCManager.RelationshipStage.DATING:
@@ -492,7 +492,7 @@ func _prepare_next_stage_confirm() -> void:
 		else:
 			next_stage_confirm_primary_button.text = "Get SERIOUS"
 	elif current_stage == NPCManager.RelationshipStage.SERIOUS:
-		next_stage_confirm_primary_button.text = "Propose ($%s)" % NumberFormatter.format_commas(npc.proposal_cost, 0)
+                next_stage_confirm_primary_button.text = "Propose ($%s)" % NumberFormatter.smart_format(npc.proposal_cost, 0)
 	else:
 		next_stage_confirm_primary_button.text = "Progress to %s" % next_name
 


### PR DESCRIPTION
## Summary
- switch autopilot button to `smart_format`
- display EX and cash costs in relationship buttons with `smart_format`

## Testing
- `./Godot_v4.2.1-stable_linux.x86_64 --headless --path /workspace/SigmaSim res://tests/test_runner.tscn` *(fails: Could not find type "FlexNumber"; resources missing)*

------
https://chatgpt.com/codex/tasks/task_e_68c04bb3bae883259cad3023e8c0ea8d