### PR TITLE
Add safe stat float accessor

### DIFF
--- a/autoloads/stat_manager.gd
+++ b/autoloads/stat_manager.gd
@@ -89,8 +89,33 @@ func get_cash() -> FlexNumber:
 	return get_stat("cash") as FlexNumber
 
 func get_ex() -> FlexNumber:
-	return get_stat("ex") as FlexNumber
+        return get_stat("ex") as FlexNumber
 
+
+func get_stat_float(stat_name: String, default_value: float = 0.0) -> float:
+        return to_float(get_stat(stat_name, default_value), default_value)
+
+
+static func to_float(value: Variant, default_value: float = 0.0) -> float:
+        var t: int = typeof(value)
+        if t == TYPE_FLOAT:
+                return float(value)
+        if t == TYPE_INT:
+                return float(value)
+        if t == TYPE_OBJECT:
+                if value == null:
+                        return default_value
+                if value is FlexNumber:
+                        var fn: FlexNumber = value
+                        return fn.to_float()
+                var obj: Object = value
+                if obj.has_method("to_float"):
+                        var out_val: Variant = obj.call("to_float")
+                        var ot: int = typeof(out_val)
+                        if ot == TYPE_FLOAT or ot == TYPE_INT:
+                                return float(out_val)
+                return default_value
+        return default_value
 
 
 func get_all_stats() -> Dictionary:

--- a/components/apps/daterbase/daterbase.gd
+++ b/components/apps/daterbase/daterbase.gd
@@ -183,7 +183,7 @@ func _on_upgrade_purchased(id: String, _level: int) -> void:
 func _refresh_hh_open_fumble_button() -> void:
 				var cost: float = PlayerManager.get_var("hh_open_fumble_cost", 10)
 				hh_open_fumble_button.text = "Open in Fumble (%d EX)" % int(cost)
-				hh_open_fumble_button.disabled = hh_current_npc == null or StatManager.get_stat("ex").to_float() < cost
+				hh_open_fumble_button.disabled = hh_current_npc == null or StatManager.get_stat_float("ex") < cost
 
 # =========================================
 # Buttons

--- a/components/apps/fumble/fumble.gd
+++ b/components/apps/fumble/fumble.gd
@@ -107,10 +107,10 @@ func _setup_over_frames() -> void:
 	bio_text_edit.text = PlayerManager.get_var("bio", "")
 	bio_text_edit.text_changed.connect(_on_bio_text_edit_text_changed)
 
-	_update_fugly_filter_ui()
+        _update_fugly_filter_ui()
 
-	confidence_progress_bar.update_value(StatManager.get_stat("confidence"))
-	ex_progress_bar.update_value(StatManager.get_stat("ex").to_float())
+        confidence_progress_bar.update_value(StatManager.get_stat("confidence"))
+        ex_progress_bar.update_value(StatManager.get_stat_float("ex"))
 
 	_on_gender_slider_changed(0)
 	_on_curiosity_h_slider_value_changed(curiosity_slider.value)

--- a/components/popups/ex_factor_view.gd
+++ b/components/popups/ex_factor_view.gd
@@ -398,9 +398,9 @@ func _update_apologize_button() -> void:
 	apologize_button.visible = has_upgrade and in_ex_stage
 	if not apologize_button.visible:
 			return
-	var cost: int = logic.get_apologize_cost()
-	apologize_button.text = "Apologize (%s EX)" % NumberFormatter.smart_format(cost)
-	apologize_button.disabled = StatManager.get_stat("ex").to_float() < float(cost)
+        var cost: int = logic.get_apologize_cost()
+        apologize_button.text = "Apologize (%s EX)" % NumberFormatter.smart_format(cost)
+        apologize_button.disabled = StatManager.get_stat_float("ex") < float(cost)
 
 func _update_locked_in_button() -> void:
 	if not is_instance_valid(locked_in_button):

--- a/tests/tarot_reading_cost_ex_test.gd
+++ b/tests/tarot_reading_cost_ex_test.gd
@@ -13,7 +13,7 @@ func _ready():
 	assert(not majors.is_empty())
 	assert(TarotManager.reading_cost == 2.0)
 	assert(TarotManager.major_reading_cost == 2.0)
-	assert(StatManager.get_stat("ex").to_float() == 99.0)
+        assert(StatManager.get_stat_float("ex") == 99.0)
 	TarotManager._on_hour_passed(0, 0)
 	assert(TarotManager.reading_cost == 1.0)
 	assert(TarotManager.major_reading_cost == 1.0)


### PR DESCRIPTION
## Summary
- add `get_stat_float` and `to_float` helpers in StatManager
- replace unsafe `to_float` calls on stats with safe accessor
- update tarot reading test to use new accessor

## Testing
- `./godot-binary/Godot_v4.2.1-stable_linux.x86_64 --headless tests/test_runner.tscn` *(fails: missing resources)*

------
https://chatgpt.com/codex/tasks/task_e_68c05051159c8325b4c6ab8c7f751542