### PR TITLE
Handle FlexNumber persistence in PlayerManager

### DIFF
--- a/autoloads/player_manager.gd
+++ b/autoloads/player_manager.gd
@@ -231,14 +231,26 @@ func mark_seen(id: String) -> void:
 ## -- SAVE LOAD
 
 func get_save_data() -> Dictionary:
-	user_data["global_rng_seed"] = RNGManager.seed
-	return user_data.duplicate(true)
+        user_data["global_rng_seed"] = RNGManager.seed
+        var data := user_data.duplicate(true)
+        for key in data.keys():
+                var val = data[key]
+                if typeof(val) == TYPE_OBJECT and val.get_class() == "FlexNumber":
+                        if val._is_big:
+                                data[key] = {"mantissa": val._mantissa, "exponent": val._exponent}
+                        else:
+                                data[key] = {"mantissa": val.to_float(), "exponent": 0}
+        return data
 
 func load_from_data(data: Dictionary) -> void:
-	user_data = data.duplicate(true)
-	ensure_default_stats()
-	if user_data.has("confidence"):
-		user_data["confidence"] = clamp(user_data["confidence"], 0.0, 100.0)
+        user_data = data.duplicate(true)
+        for key in user_data.keys():
+                var val = user_data[key]
+                if typeof(val) == TYPE_DICTIONARY and val.has("mantissa") and val.has("exponent"):
+                        user_data[key] = StatManager._flex_from_variant(val)
+        ensure_default_stats()
+        if user_data.has("confidence"):
+                user_data["confidence"] = clamp(user_data["confidence"], 0.0, 100.0)
 
 
 

--- a/tests/player_manager_flexnumber_roundtrip_test.gd
+++ b/tests/player_manager_flexnumber_roundtrip_test.gd
@@ -1,0 +1,18 @@
+extends SceneTree
+
+const FlexNumber = preload("res://flex_number.gd")
+
+func _ready() -> void:
+    var fn = FlexNumber.new(1.23e45)
+    var pm = Engine.get_singleton("PlayerManager")
+    pm.set_var("ex", fn)
+    var saved = pm.get_save_data()
+    assert(typeof(saved["ex"]) == TYPE_DICTIONARY)
+    pm.set_var("ex", 0)
+    pm.load_from_data(saved)
+    var loaded = pm.get_var("ex")
+    assert(typeof(loaded) == TYPE_OBJECT and loaded.get_class() == "FlexNumber")
+    assert(is_equal_approx(loaded._mantissa, fn._mantissa))
+    assert(loaded._exponent == fn._exponent)
+    print("player_manager_flexnumber_roundtrip_test passed")
+    quit()


### PR DESCRIPTION
## Summary
- serialize FlexNumber fields in PlayerManager as `{mantissa, exponent}` dictionaries
- rebuild FlexNumber instances when loading saved data
- add regression test for PlayerManager FlexNumber round-trip

## Testing
- `godot --headless --path . -s tests/player_manager_flexnumber_roundtrip_test.gd` *(fails: Failed loading resource: res://.godot/imported/GALSB.ttf-00248b54f1c3b8ccfcd8f7d3c03f4c36.fontdata)*

------
https://chatgpt.com/codex/tasks/task_e_68c06ad2ff248325bc076e2bbaabad2e