### PR TITLE
Ensure stats and portfolio emit restored values on load

### DIFF
--- a/autoloads/portfolio_manager.gd
+++ b/autoloads/portfolio_manager.gd
@@ -521,10 +521,9 @@ func load_from_data(data: Dictionary) -> void:
 	stocks_owned = data.get("stocks_owned", {})
 	crypto_owned = data.get("crypto_owned", {})
 	emit_investment_update()
-	_on_cash_changed(get_cash())
+	_on_cash_changed(StatManager.get_cash())
 	_on_credit_changed(get_credit_used())
 	_on_student_loans_changed(get_student_loans())
-
 
 func reset():
 	set_cash(0.0)

--- a/autoloads/stat_manager.gd
+++ b/autoloads/stat_manager.gd
@@ -248,19 +248,22 @@ func get_save_data() -> Dictionary:
 
 
 func load_from_data(data: Dictionary) -> void:
-		temporary_overrides.clear()
-		_load_base_stats()
-		if typeof(data) == TYPE_DICTIONARY:
-				for key in data.keys():
-					var val = data[key]
-					if key == "cash" or key == "ex":
-							base_stats[key] = _flex_from_variant(val)
-					else:
-							base_stats[key] = float(val)
-		_build_upgrade_cache()
-		_build_dependents_map()
-		recalculate_all_stats_once()
-
+	temporary_overrides.clear()
+	_load_base_stats()
+	_build_upgrade_cache()
+	_build_dependents_map()
+	computed_stats.clear()
+	if typeof(data) == TYPE_DICTIONARY:
+		for key in data.keys():
+			var val = data[key]
+			if key == "cash" or key == "ex":
+				base_stats[key] = _flex_from_variant(val)
+			else:
+				base_stats[key] = float(val)
+			_recalculate_stat_and_dependents(key)
+	for key in base_stats.keys():
+		if typeof(data) != TYPE_DICTIONARY or not data.has(key):
+			_recalculate_stat_and_dependents(key)
 
 func connect_to_stat(stat: String, target: Object, method: String) -> void:
 	if !_stat_signal_map.has(stat):


### PR DESCRIPTION
## Summary
- Recalculate and emit callbacks for each stat when loading saved data
- Initialize portfolio cash display from StatManager after load

## Testing
- `/tmp/Godot_v4.2.2-stable_linux.x86_64 --headless --path . -s tests/test_runner.gd` *(fails: Can't load the script "tests/test_runner.gd" as it doesn't inherit from SceneTree or MainLoop)*

------
https://chatgpt.com/codex/tasks/task_e_68c06b53b6548325a9145126b097c1b3