### PR TITLE
Handle cash/ex via flex stat registry

### DIFF
--- a/autoloads/portfolio_manager.gd
+++ b/autoloads/portfolio_manager.gd
@@ -147,6 +147,7 @@ func set_passive_income(value: float) -> void:
 	StatManager.set_base_stat("passive_income", value)
 
 func _ready():
+	StatManager.register_flex_stat("cash")
 	StatManager.connect_to_stat("cash", self, "_on_cash_changed")
 	StatManager.connect_to_stat("credit_used", self, "_on_credit_changed")
 	StatManager.connect_to_stat("credit_limit", self, "_on_credit_changed")

--- a/components/popups/ex_factor_view.gd
+++ b/components/popups/ex_factor_view.gd
@@ -645,7 +645,7 @@ func _on_talk_therapy_purchased(_level: int) -> void:
 
 
 func _on_stat_changed(stat: String, _value: Variant) -> void:
-	if stat == "ex":
+	if StatManager.FLEX_STATS.has(stat):
 		_update_apologize_button()
 
 func _on_npc_affinity_changed(idx: int, _value: float) -> void:

--- a/data/upgrades/upgrade_ui.gd
+++ b/data/upgrades/upgrade_ui.gd
@@ -83,7 +83,7 @@ func _refresh_cost() -> void:
 				cost_strs.append("$" + formatted)
 		else:
 			var currency_display: String
-			if currency == "ex":
+			if StatManager.FLEX_STATS.has(currency):
 				currency_display = currency.to_upper()
 			else:
 				currency_display = currency.capitalize()


### PR DESCRIPTION
## Summary
- Introduce a `FLEX_STATS` array and `register_flex_stat` helper, fixing Godot 4 syntax
- Use `FLEX_STATS` membership when rendering upgrade costs and reacting to flex stat changes

## Testing
- `godot4 -s tests/test_runner.gd` *(command not found: godot4)*

------
https://chatgpt.com/codex/tasks/task_e_68c0723d5574832585fea86092364694