### PR TITLE
Allow floats in terminal set_stat and add_cash commands

### DIFF
--- a/components/apps/terminal/terminal.gd
+++ b/components/apps/terminal/terminal.gd
@@ -276,12 +276,16 @@ func process_command(command: String) -> bool:
 				return false
 
 			var expected_type := typeof(current_value)
+			var is_flex := current_value is FlexNumber
 
 			# --- parse attempted new value ---
 			var new_value = null
 			var parsed_number = _parse_number(value_str)
 			if parsed_number != null:
-				new_value = parsed_number
+				if is_flex:
+					new_value = FlexNumber.new(parsed_number)
+				else:
+					new_value = parsed_number
 			else:
 				new_value = value_str
 
@@ -289,8 +293,9 @@ func process_command(command: String) -> bool:
 			var new_type := typeof(new_value)
 			var type_ok := false
 
-			# Allow int/float interchange if stat is numeric
-			if (expected_type == TYPE_FLOAT or expected_type == TYPE_INT) and (new_type == TYPE_FLOAT or new_type == TYPE_INT):
+			if is_flex:
+				type_ok = new_value is FlexNumber
+			elif (expected_type == TYPE_FLOAT or expected_type == TYPE_INT) and (new_type == TYPE_FLOAT or new_type == TYPE_INT):
 				type_ok = true
 			elif expected_type == new_type:
 				type_ok = true
@@ -389,7 +394,7 @@ func _purchase_all_upgrades() -> void:
 func _parse_number(s: String) -> Variant:
 	s = s.strip_edges()
 	var regex := RegEx.new()
-	regex.compile("^[-+]?[0-9]+(\\.[0-9]+)?$")
+	regex.compile("^[-+]?(?:\\d+\\.\\d*|\\.\\d+|\\d+)$")
 	if not regex.search(s):
 		return null
 	return s.to_float()

--- a/tests/terminal_command_parser_test.gd
+++ b/tests/terminal_command_parser_test.gd
@@ -18,9 +18,22 @@ func _ready() -> void:
 
 	assert(terminal.process_command("clear_log"))
 	assert(terminal.process_command("clearlog"))
-	assert(terminal.process_command("set_stat foo 1"))
-	assert(terminal.process_command("setstat foo 2"))
-	assert(StatManager.get_stat("foo") == 2)
+	var starting_cash := PortfolioManager.cash
+	assert(terminal.process_command("add_cash 1.5"))
+	assert(is_equal_approx(PortfolioManager.cash, starting_cash + 1.5))
+	assert(terminal.process_command("set_stat cash 2.25"))
+	assert(is_equal_approx(PortfolioManager.cash, 2.25))
+	PortfolioManager.cash = starting_cash
+
+	var starting_ex := StatManager.get_ex().to_float()
+	assert(terminal.process_command("set_stat ex 3.5"))
+	assert(is_equal_approx(StatManager.get_ex().to_float(), 3.5))
+	StatManager.set_base_stat("ex", starting_ex)
+
+	assert(terminal.process_command("set_stat foo 1.5"))
+	assert(is_equal_approx(StatManager.get_stat("foo"), 1.5))
+	assert(terminal.process_command("setstat foo 2.5"))
+	assert(is_equal_approx(StatManager.get_stat("foo"), 2.5))
 
 	print("terminal_command_parser_test passed")
 	quit()


### PR DESCRIPTION
## Summary
- Permit decimal values in Terminal's numeric commands by enhancing number parsing
- Convert FlexNumber-backed stats (cash/ex) from parsed floats so set_stat accepts them
- Test that `add_cash`, `set_stat cash`, `set_stat ex`, and generic stats accept floats
- Normalize indentation in Terminal and tests to match tab-based project style

## Testing
- `godot3-server --path . tests/test_runner.gd` *(fails: project config version too new for Godot 3)*

------
https://chatgpt.com/codex/tasks/task_e_68c07dfad178832596544dfff636b193