### PR TITLE
Refactor relationship progress to FlexNumber

### DIFF
--- a/autoloads/db_manager.gd
+++ b/autoloads/db_manager.gd
@@ -20,7 +20,7 @@ const SCHEMA: Dictionary = {
 		"relationship_status": {"data_type": "text"},
 		"locked_in_connection": {"data_type": "int"},
 		"relationship_stage": {"data_type": "int"},
-		"relationship_progress": {"data_type": "real"},
+		"relationship_progress": {"data_type": "text"},
 		"exclusivity_core": {"data_type": "int"},
 		"romantic_relationship": {"data_type": "int"},
 		"personal_relationship": {"data_type": "int"},
@@ -154,6 +154,7 @@ func save_npc(idx: int, npc: NPC, slot_id: int = SaveManager.current_slot_id):
 	dict["dislikes"] = to_json(dict.get("dislikes", []))
 	dict["preferred_pet_names"] = to_json(dict.get("preferred_pet_names", []))
 	dict["player_pet_names"] = to_json(dict.get("player_pet_names", []))
+	dict["relationship_progress"] = to_json(dict.get("relationship_progress", {"mantissa":0.0,"exponent":0}))
 	dict["ocean"] = to_json(dict.get("ocean", {}))
 	dict["wall_posts"] = to_json(dict.get("wall_posts", []))
 	var pc = dict.get("portrait_config", null)
@@ -176,6 +177,7 @@ func load_npc(idx: int, slot_id: int = SaveManager.current_slot_id) -> NPC:
 		return null
 	var row = result[0]
 	# Deserialize JSON fields safely
+	row["relationship_progress"] = _safe_from_json(row.get("relationship_progress", null), '{"mantissa":0,"exponent":0}')
 	row["gender_vector"] = _safe_from_json(row.get("gender_vector", null), '{"x":0,"y":0,"z":1}')
 	row["tags"] = _safe_from_json(row.get("tags", null), "[]")
 	row["likes"] = _safe_from_json(row.get("likes", null), "[]")
@@ -191,6 +193,7 @@ func get_all_npcs_for_slot(slot_id: int = SaveManager.current_slot_id) -> Array:
 	var raw_rows = db.select_rows("npc", "slot_id = %d" % slot_id, ["*"])
 	var out: Array = []
 	for row in raw_rows:
+		row["relationship_progress"] = _safe_from_json(row.get("relationship_progress", null), '{"mantissa":0,"exponent":0}')
 		row["gender_vector"] = _safe_from_json(row.get("gender_vector", null), '{"x":0,"y":0,"z":1}')
 		row["tags"] = _safe_from_json(row.get("tags", null), "[]")
 		row["likes"] = _safe_from_json(row.get("likes", null), "[]")

--- a/components/npc/npc.gd
+++ b/components/npc/npc.gd
@@ -173,7 +173,7 @@ func to_dict() -> Dictionary:
 		"relationship_status": relationship_status,
 		"locked_in_connection": locked_in_connection,
 		"relationship_stage": relationship_stage,
-		"relationship_progress": relationship_progress.to_float(),
+		"relationship_progress": StatManager._flex_to_dict(relationship_progress),
 		"exclusivity_core": exclusivity_core,
 		"romantic_relationship": romantic_relationship,
 		"personal_relationship": personal_relationship,
@@ -243,7 +243,7 @@ static func from_dict(data: Dictionary) -> NPC:
 	npc.relationship_status = _safe_string(data.get("relationship_status"), "Single")
 	npc.locked_in_connection = _safe_int(data.get("locked_in_connection"), 0) != 0
 	npc.relationship_stage = _safe_int(data.get("relationship_stage"), NPCManager.RelationshipStage.STRANGER)
-	npc.relationship_progress = FlexNumber.new(_safe_float(data.get("relationship_progress")))
+	npc.relationship_progress = StatManager._flex_from_variant(data.get("relationship_progress"))
 	npc.exclusivity_core = _safe_int(data.get("exclusivity_core"), NPCManager.ExclusivityCore.POLY)
 	if not data.has("exclusivity_core"):
 		var legacy_ex: Variant = data.get("exclusivity")

--- a/components/popups/ex_factor_logic.gd
+++ b/components/popups/ex_factor_logic.gd
@@ -103,7 +103,7 @@ func process(delta: float) -> void:
 		state.update(delta)
 		if npc.relationship_progress.to_float() != before:
 			emit_signal("progress_changed", npc.relationship_progress.to_float())
-			emit_signal("request_persist", {"relationship_progress": npc.relationship_progress.to_float()})
+			emit_signal("request_persist", {"relationship_progress": npc.relationship_progress})
 
 # ---------------------------- User actions ----------------------------
 
@@ -147,7 +147,7 @@ func try_date(credit_only: bool = false) -> bool:
 	emit_signal("costs_changed", npc.gift_cost, npc.date_cost)
 	emit_signal("progress_changed", npc.relationship_progress.to_float())
 	emit_signal("request_persist", {
-		"relationship_progress": npc.relationship_progress.to_float(),
+		"relationship_progress": npc.relationship_progress,
 		"date_count": npc.date_count
 	})
 
@@ -219,7 +219,7 @@ func confirm_breakup() -> void:
 	emit_signal("affinity_changed", npc.affinity)
 	emit_signal("progress_changed", npc.relationship_progress.to_float())
 	emit_signal("request_persist", {
-		"relationship_progress": npc.relationship_progress.to_float(),
+		"relationship_progress": npc.relationship_progress,
 		"affinity": npc.affinity
 	})
 
@@ -251,7 +251,7 @@ func apologize_try() -> bool:
 	emit_signal("affinity_changed", npc.affinity)
 	emit_signal("progress_changed", npc.relationship_progress.to_float())
 	emit_signal("request_persist", {
-			"relationship_progress": npc.relationship_progress.to_float(),
+			"relationship_progress": npc.relationship_progress,
 			"affinity": npc.affinity,
 			"gift_count": npc.gift_count,
 			"date_count": npc.date_count

--- a/components/popups/ex_factor_view.gd
+++ b/components/popups/ex_factor_view.gd
@@ -132,7 +132,7 @@ func _process(delta: float) -> void:
 	if npc_idx != -1 and npc.relationship_progress.to_float() != last_saved_progress:
 		progress_save_elapsed += delta
 		if progress_save_elapsed >= PROGRESS_SAVE_INTERVAL and abs(npc.relationship_progress.to_float() - last_saved_progress) >= PROGRESS_MIN_DELTA:
-			_persist_fields({"relationship_progress": npc.relationship_progress.to_float()})
+			_persist_fields({"relationship_progress": npc.relationship_progress})
 			last_saved_progress = npc.relationship_progress.to_float()
 			progress_save_elapsed = 0.0
 
@@ -154,7 +154,7 @@ func _exit_tree() -> void:
 			NPCManager.cheating_detected.disconnect(_on_cheating_detected)
 
 	if npc.relationship_progress.to_float() != last_saved_progress:
-		_persist_fields({"relationship_progress": npc.relationship_progress.to_float()})
+		_persist_fields({"relationship_progress": npc.relationship_progress})
 
 
 

--- a/tests/npc_relationship_progress_flexnumber_roundtrip_test.gd
+++ b/tests/npc_relationship_progress_flexnumber_roundtrip_test.gd
@@ -1,0 +1,15 @@
+extends SceneTree
+
+const NPC = preload("res://components/npc/npc.gd")
+
+func _ready() -> void:
+	var npc := NPC.new()
+	npc.relationship_progress.set_value(1.23e45)
+	var saved = npc.to_dict()
+	assert(typeof(saved["relationship_progress"]) == TYPE_DICTIONARY)
+	var loaded := NPC.from_dict(saved)
+	assert(typeof(loaded.relationship_progress) == TYPE_OBJECT and loaded.relationship_progress.get_class() == "FlexNumber")
+	assert(is_equal_approx(loaded.relationship_progress._mantissa, npc.relationship_progress._mantissa))
+	assert(loaded.relationship_progress._exponent == npc.relationship_progress._exponent)
+	print("npc_relationship_progress_flexnumber_roundtrip_test passed")
+	quit()


### PR DESCRIPTION
## Summary
- store NPC relationship_progress as FlexNumber dictionary
- persist relationship_progress JSON in database and adjust schema
- adjust Ex Factor UI persistence and add FlexNumber round-trip test
- normalize tab indentation for new FlexNumber code

## Testing
- ❌ `/tmp/godot/Godot_v4.2.1-stable_linux.x86_64 --headless --path . -s tests/npc_relationship_progress_flexnumber_roundtrip_test.gd` *(failed: parse errors and missing project resources)*

------
https://chatgpt.com/codex/tasks/task_e_68c084ce103083258da679c7b1e4c924