### PR TITLE
Handle non-finite numbers in smart_format

### DIFF
--- a/autoloads/number_formatter.gd
+++ b/autoloads/number_formatter.gd
@@ -100,17 +100,27 @@ static func format_flex(number: FlexNumber, decimals: int = 2, style: String = "
 				return format_mantissa_exponent(number._mantissa, number._exponent, decimals)
 		return format_number(number.to_float(), style, decimals)
 
-static func smart_format(number: Variant, decimals: int = 2) -> String:
-	if number is FlexNumber:
-		if number.is_big():
-			return format_mantissa_exponent(number._mantissa, number._exponent, decimals)
-		return format_commas(number.to_float(), decimals)
+static func smart_format(number: Variant, decimals: int = 2, fallback: String = "∞") -> String:
+        var num_type := typeof(number)
+        if num_type == TYPE_FLOAT or num_type == TYPE_INT:
+                if not is_finite(number):
+                        return fallback
 
-	var n: float = float(number)
-	if abs(n) >= FlexNumber.THRESHOLD:
-		var fn := FlexNumber.new(n)
-		return format_mantissa_exponent(fn._mantissa, fn._exponent, decimals)
-	return format_commas(n, decimals)
+        if number is FlexNumber:
+                if number.is_big():
+                        return format_mantissa_exponent(number._mantissa, number._exponent, decimals)
+                var f := number.to_float()
+                if not is_finite(f):
+                        return fallback
+                return format_commas(f, decimals)
+
+        var n: float = float(number)
+        if not is_finite(n):
+                return fallback
+        if abs(n) >= FlexNumber.THRESHOLD:
+                var fn := FlexNumber.new(n)
+                return format_mantissa_exponent(fn._mantissa, fn._exponent, decimals)
+        return format_commas(n, decimals)
 
 # Main interface (now static so it can be called from static helpers)
 static func format_number(number: Variant, style: String = "commas", decimals: int = 2) -> String:

--- a/tests/number_formatter_smart_format_test.gd
+++ b/tests/number_formatter_smart_format_test.gd
@@ -8,5 +8,8 @@ func _ready() -> void:
     var flex := FlexNumber.new(1234000000.0)
     var flex_str := NumberFormatter.smart_format(flex)
     assert(flex_str == "1.23e9")
+    var inf := INF
+    var inf_str := NumberFormatter.smart_format(inf)
+    assert(inf_str == "∞")
     print("number_formatter_smart_format_test passed")
     quit()


### PR DESCRIPTION
## Summary
- guard `smart_format` against non-finite values and allow a fallback string
- add unit test ensuring `inf` formats to `∞`

## Testing
- `godot4 --headless --path . -s tests/number_formatter_smart_format_test.gd` *(fails: Identifier "FlexNumber" not declared)*


------
https://chatgpt.com/codex/tasks/task_e_68c096eaaec88325aa2c9d9afaf5ab61