### PR TITLE
Use log-based marriage level and test large progress values

### DIFF
--- a/components/npc/npc.gd
+++ b/components/npc/npc.gd
@@ -375,15 +375,17 @@ func describe_gender() -> String:
 	return ", ".join(components) if components.size() > 0 else "ambiguous"
 
 func get_marriage_level() -> int:
-	var n: int = int(floor(relationship_progress.to_float()))
-	if n < 100000:
-		return 0
-	var digits: int = 0
-	var tmp: int = n
-	while tmp > 0:
-		tmp = tmp / 10
-		digits += 1
-	return digits - 5
+        var progress: float = relationship_progress.to_float()
+        if progress < 100000.0:
+                return 0
+
+        var level: int
+        if is_finite(progress):
+                level = int(floor(log(progress) / log(10.0))) - 4
+        else:
+                # When the value overflows to infinity, fall back to FlexNumber's exponent.
+                level = relationship_progress._exponent - 4
+        return max(level, 0)
 
 func is_in_dating() -> bool:
 	return relationship_stage == NPCManager.RelationshipStage.DATING

--- a/tests/npc_marriage_level_large_values_test.gd
+++ b/tests/npc_marriage_level_large_values_test.gd
@@ -1,0 +1,14 @@
+extends SceneTree
+
+func _ready() -> void:
+        load("res://flex_number.gd")
+        load("res://resources/context_action.gd")
+        load("res://resources/portraits/portrait_config.gd")
+        var npc_script = load("res://components/npc/npc.gd")
+        var npc = npc_script.new()
+        npc.relationship_progress.set_value(1e20)
+        assert(npc.get_marriage_level() == 16)
+        npc.relationship_progress.set_value(1e40)
+        assert(npc.get_marriage_level() == 36)
+        print("npc_marriage_level_large_values_test passed")
+        quit()


### PR DESCRIPTION
## Summary
- compute marriage levels using base-10 logarithm with overflow fallback
- preload required scripts and assert correct levels for extreme relationship progress

## Testing
- `/tmp/Godot_v4.2-stable_linux.x86_64 --headless --path . -q --script tests/npc_marriage_level_large_values_test.gd` *(fails: Could not find type 'ContextAction' in the current scope and missing imported resources)*

------
https://chatgpt.com/codex/tasks/task_e_68c0946487508325acd1bb0e398c397e