### PR TITLE
Add AIM contact button scene with portrait icons

### DIFF
--- a/components/apps/alpha_instant_messenger/aim_contact_button.gd
+++ b/components/apps/alpha_instant_messenger/aim_contact_button.gd
@@ -1,13 +1,21 @@
 extends CustomButton
 class_name AimContactButton
 
+@onready var _icon_viewport: SubViewport = %IconViewport
+@onready var _portrait_view: PortraitView = %Portrait
+
 func _ready() -> void:
-	custom_minimum_size = Vector2(170, 34)
-	margin_left = 4
-	margin_right = 4
-	margin_top = 2
-	margin_bottom = 2
-	icon_texture = preload("res://assets/ui/buttons/redbuttonpressed.png")
-	icon_location = "left"
-	focus_mode = FocusMode.NONE
-	text_overrun_behavior = TextServer.OVERRUN_TRIM_ELLIPSIS
+        custom_minimum_size = Vector2(170, 34)
+        margin_left = 4
+        margin_right = 4
+        margin_top = 2
+        margin_bottom = 2
+        icon_location = "left"
+        focus_mode = FocusMode.NONE
+        text_overrun_behavior = TextServer.OVERRUN_TRIM_ELLIPSIS
+        if _icon_viewport:
+                icon_texture = _icon_viewport.get_texture()
+
+func set_npc(npc: NPC) -> void:
+        if npc.portrait_config != null:
+                _portrait_view.apply_config(npc.portrait_config)

--- a/components/apps/alpha_instant_messenger/aim_contact_button.tscn
+++ b/components/apps/alpha_instant_messenger/aim_contact_button.tscn
@@ -1,0 +1,20 @@
+[gd_scene load_steps=3 format=3 uid="uid://dgq3n6c4cf7ta"]
+
+[ext_resource type="Script" path="res://components/apps/alpha_instant_messenger/aim_contact_button.gd" id="1"]
+[ext_resource type="PackedScene" uid="uid://drm1apbdsjj5g" path="res://components/portrait/portrait_view.tscn" id="2"]
+
+[node name="AimContactButton" type="AimContactButton"]
+script = ExtResource("1")
+
+[node name="IconViewport" type="SubViewport" parent="." unique_name_in_owner="true"]
+size = Vector2i(32, 32)
+disable_3d = true
+render_target_update_mode = 3
+transparent_bg = true
+
+[node name="Portrait" parent="IconViewport" instance=ExtResource("2") unique_name_in_owner="true"]
+custom_minimum_size = Vector2(32, 32)
+size = Vector2(32, 32)
+portrait_scale = 1.0
+portrait_creator_enabled = false
+mouse_filter = 2

--- a/components/apps/alpha_instant_messenger/alpha_instant_messenger.gd
+++ b/components/apps/alpha_instant_messenger/alpha_instant_messenger.gd
@@ -2,6 +2,7 @@ extends Pane
 class_name AlphaInstantMessenger
 
 const AIM_CHAT_UI_SCENE: PackedScene = preload("res://components/apps/alpha_instant_messenger/aim_chat_ui.tscn")
+const AIM_CONTACT_BUTTON_SCENE: PackedScene = preload("res://components/apps/alpha_instant_messenger/aim_contact_button.tscn")
 
 @onready var contacts_vbox: VBoxContainer = %ContactsVBox
 
@@ -13,15 +14,16 @@ func _populate_contacts() -> void:
 	for child in contacts_vbox.get_children():
 
 		child.queue_free()
-	var entries: Array[int] = NPCManager.get_romantic_npcs()
-	for idx in entries:
-		var npc: NPC = NPCManager.get_npc_by_index(int(idx))
-		var btn: AimContactButton = AimContactButton.new()
-		btn.text = "@%s" % npc.username
-		btn.pressed.connect(func() -> void:
-			_open_chat_ui(int(idx), npc)
-		)
-		contacts_vbox.add_child(btn)
+        var entries: Array[int] = NPCManager.get_romantic_npcs()
+        for idx in entries:
+                var npc: NPC = NPCManager.get_npc_by_index(int(idx))
+                var btn: AimContactButton = AIM_CONTACT_BUTTON_SCENE.instantiate()
+                btn.text = "@%s" % npc.username
+                btn.set_npc(npc)
+                btn.pressed.connect(func() -> void:
+                        _open_chat_ui(int(idx), npc)
+                )
+                contacts_vbox.add_child(btn)
 
 
 func _open_chat_ui(idx: int, npc: NPC) -> void:


### PR DESCRIPTION
## Summary
- add AimContactButton scene that renders a 32x32 portrait icon
- wire AlphaInstantMessenger to use the new contact button scene
- generate icon textures from NPC portrait configs

## Testing
- `godot --headless --path . -s tests/test_runner.gd` *(fails: command not found)*
- `apt-get install -y godot4` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68c0a18064e8832594c59dadfed8ff7b