### PR TITLE
Fix database restoration when switching save slots

### DIFF
--- a/autoloads/db_manager.gd
+++ b/autoloads/db_manager.gd
@@ -220,8 +220,14 @@ func _snapshot_path(slot_id: int) -> String:
 	return SNAPSHOT_DIR + "db_snapshot_slot_%d.db" % slot_id
 
 func snapshot_slot_data(slot_id: int) -> void:
-	var path = _snapshot_path(slot_id)
-	DirAccess.copy_absolute(DB_PATH, path)
+        var path = _snapshot_path(slot_id)
+        if db != null and db.has_method("close_db"):
+                db.close_db()
+        DirAccess.copy_absolute(DB_PATH, path)
+        db = SQLite.new()
+        db.path = DB_PATH
+        db.open_db()
+        _init_schema()
 
 func restore_slot_data(slot_id: int) -> void:
 	var path = _snapshot_path(slot_id)

--- a/tests/db_slot_switch_restore_test.gd
+++ b/tests/db_slot_switch_restore_test.gd
@@ -1,0 +1,40 @@
+extends SceneTree
+
+func _ready() -> void:
+        var save_mgr = Engine.get_singleton("SaveManager")
+        var db_mgr = Engine.get_singleton("DBManager")
+
+        # Setup slot 1 with one NPC
+        save_mgr.reset_managers()
+        save_mgr.current_slot_id = 1
+        db_mgr.db.query("DELETE FROM npc WHERE slot_id = 1")
+        db_mgr.db.query("INSERT OR REPLACE INTO npc (id, slot_id, full_name) VALUES (101, 1, 'Slot1 NPC')")
+        save_mgr.save_to_slot(1)
+
+        # Setup slot 2 with a different NPC
+        save_mgr.reset_managers()
+        save_mgr.current_slot_id = 2
+        db_mgr.db.query("DELETE FROM npc WHERE slot_id = 2")
+        db_mgr.db.query("INSERT OR REPLACE INTO npc (id, slot_id, full_name) VALUES (202, 2, 'Slot2 NPC')")
+        save_mgr.save_to_slot(2)
+
+        # Load slot 1 and verify data
+        save_mgr.load_from_slot(1)
+        var rows = db_mgr.db.select_rows("npc", "slot_id = 1", ["full_name"])
+        assert(rows.size() == 1)
+        assert(rows[0].full_name == "Slot1 NPC")
+
+        # Load slot 2 and verify data
+        save_mgr.load_from_slot(2)
+        rows = db_mgr.db.select_rows("npc", "slot_id = 2", ["full_name"])
+        assert(rows.size() == 1)
+        assert(rows[0].full_name == "Slot2 NPC")
+
+        # Load slot 1 again to ensure it still restores correctly
+        save_mgr.load_from_slot(1)
+        rows = db_mgr.db.select_rows("npc", "slot_id = 1", ["full_name"])
+        assert(rows.size() == 1)
+        assert(rows[0].full_name == "Slot1 NPC")
+
+        print("db_slot_switch_restore_test passed")
+        quit()

--- a/tests/db_slot_switch_restore_test.gd.uid
+++ b/tests/db_slot_switch_restore_test.gd.uid
@@ -1,0 +1,1 @@
+uid://9nccxvtokrao


### PR DESCRIPTION
## Summary
- ensure SaveManager snapshots close and reopen the SQLite DB before copying
- add regression test covering DB snapshot restoration when swapping save slots

## Testing
- `godot --headless -s tests/test_runner.gd` *(fails: Error opening file 'uid://gl0rjxkrh4wh')*

------
https://chatgpt.com/codex/tasks/task_e_68c116285ca083258a2978cdad182b7a