### PR TITLE
Ensure AIM contact buttons open correct chat window

### DIFF
--- a/components/apps/alpha_instant_messenger/alpha_instant_messenger.gd
+++ b/components/apps/alpha_instant_messenger/alpha_instant_messenger.gd
@@ -16,16 +16,17 @@ func _populate_contacts() -> void:
 		if child != contact_button_template:
 			child.queue_free()
 	var entries: Array[int] = NPCManager.get_romantic_npcs()
-	for idx in entries:
-		var npc: NPC = NPCManager.get_npc_by_index(int(idx))
-		var btn: AimContactButton = AIM_CONTACT_BUTTON_SCENE.instantiate()
-		contacts_vbox.add_child(btn)
-		btn.text = "@%s" % npc.username
-		btn.set_npc(npc)
-		btn.pressed.connect(func() -> void:
-				_open_chat_ui(int(idx), npc)
-		)
-	contact_button_template.visible = false
+        for idx in entries:
+                var npc: NPC = NPCManager.get_npc_by_index(int(idx))
+                var btn: AimContactButton = AIM_CONTACT_BUTTON_SCENE.instantiate()
+                contacts_vbox.add_child(btn)
+                btn.text = "@%s" % npc.username
+                btn.set_npc(npc)
+                # Use bind to capture the current NPC and index for each button.
+                # Otherwise, the loop variables would be shared and every button
+                # would open the chat for the last NPC in the list.
+                btn.pressed.connect(_open_chat_ui.bind(int(idx), npc))
+        contact_button_template.visible = false
 
 func _open_chat_ui(idx: int, npc: NPC) -> void:
 		var key: String = "aim_chat_%d" % idx


### PR DESCRIPTION
## Summary
- ensure each AIM contact button opens a chat with its own NPC by binding the NPC and index to the button press handler

## Testing
- `godot --headless --path . -s tests/test_runner.gd` *(fails: script does not inherit from SceneTree or MainLoop and missing resources)*
- `godot --headless --path . tests/test_runner.tscn` *(fails: missing resources and parse errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c1b9bf29c08325ad3fbb169425c6ca