### PR TITLE
Embed portrait view in AIM contact button

### DIFF
--- a/components/apps/alpha_instant_messenger/aim_contact_button.gd
+++ b/components/apps/alpha_instant_messenger/aim_contact_button.gd
@@ -1,7 +1,7 @@
 extends CustomButton
 class_name AimContactButton
 
-@onready var portrait_viewport: SubViewport = %PortraitViewport
+@onready var portrait_view: PortraitView = %Portrait
 var npc: NPC
 
 @export var npc_path: String = "":
@@ -15,9 +15,10 @@ var npc: NPC
 		return npc_path
 
 func _ready() -> void:
-	super._ready()
-	if npc:
-		_update_portrait()
+        super._ready()
+        _icon_rect.visible = false
+        if npc:
+                _update_portrait()
 
 func set_npc(new_npc: NPC) -> void:
 	npc = new_npc
@@ -25,14 +26,10 @@ func set_npc(new_npc: NPC) -> void:
 		_update_portrait()
 
 func _update_portrait() -> void:
-	if npc == null:
-		return
-	var pv: PortraitView = portrait_viewport.get_node_or_null("PortraitView")
-	if pv == null:
-		var scene: PackedScene = preload("res://components/portrait/portrait_view.tscn")
-		pv = scene.instantiate()
-		pv.portrait_creator_enabled = false
-		portrait_viewport.add_child(pv)
-		pv.size = portrait_viewport.size
-	pv.apply_config(npc.portrait_config)
-	icon_texture = portrait_viewport.get_texture()
+        if npc == null:
+                return
+        portrait_view.portrait_creator_enabled = false
+        portrait_view.custom_minimum_size = Vector2(32, 32)
+        portrait_view.portrait_scale = 1.0
+        if npc.portrait_config and portrait_view.has_method("apply_config"):
+                portrait_view.apply_config(npc.portrait_config)

--- a/components/apps/alpha_instant_messenger/aim_contact_button.tscn
+++ b/components/apps/alpha_instant_messenger/aim_contact_button.tscn
@@ -1,7 +1,8 @@
-[gd_scene load_steps=3 format=3 uid="uid://dejdylbhc8d22"]
+[gd_scene load_steps=4 format=3 uid="uid://dejdylbhc8d22"]
 
 [ext_resource type="PackedScene" path="res://components/ui/custom_button.tscn" id="1"]
 [ext_resource type="Script" uid="uid://bema2a8mtfbin" path="res://components/apps/alpha_instant_messenger/aim_contact_button.gd" id="2"]
+[ext_resource type="PackedScene" path="res://components/portrait/portrait_view.tscn" id="3"]
 
 [node name="AimContactButton" instance=ExtResource("1")]
 custom_minimum_size = Vector2(170, 34)
@@ -21,11 +22,8 @@ layout_mode = 2
 [node name="Icon" parent="ContentMargin/HBox/IconMargin" index="0"]
 layout_mode = 2
 
+[node name="Portrait" parent="ContentMargin/HBox/IconMargin" instance=ExtResource("3") index="1"]
+unique_name_in_owner = true
+
 [node name="Label" parent="ContentMargin/HBox" index="1"]
 layout_mode = 2
-
-[node name="PortraitViewport" type="SubViewport" parent="." index="1"]
-unique_name_in_owner = true
-disable_3d = true
-size = Vector2i(32, 32)
-render_target_update_mode = 3


### PR DESCRIPTION
## Summary
- replace SubViewport icon with inline PortraitView so contact buttons render avatars
- disable portrait creator and shrink portrait view to 32×32 like chat UI

## Testing
- `/tmp/Godot_v4.2.2-stable_linux.x86_64 --headless tests/test_runner.tscn` *(fails: Could not find type "ContextAction" in scope, missing resources)*

------
https://chatgpt.com/codex/tasks/task_e_68c1bf217a9c8325a76e457675a112d9