### PR TITLE
Fix romantic NPC persistence

### DIFF
--- a/components/npc/npc_manager.gd
+++ b/components/npc/npc_manager.gd
@@ -71,10 +71,15 @@ func load_romantic_npc_cache() -> void:
 		romantic_npcs.append(int(id))
 
 func add_romantic_npc(idx: int) -> void:
-	if not romantic_npcs.has(idx):
-		romantic_npcs.append(idx)
-	promote_to_persistent(idx)
-	set_npc_field(idx, "romantic_relationship", true)
+        if not romantic_npcs.has(idx):
+                romantic_npcs.append(idx)
+        set_npc_field(idx, "romantic_relationship", true)
+
+        if persistent_npcs.has(idx):
+                DBManager.save_npc(idx, npcs[idx])
+                _save_queue.erase(idx)
+        else:
+                promote_to_persistent(idx)
 
 func get_romantic_npcs() -> Array[int]:
 	return romantic_npcs


### PR DESCRIPTION
## Summary
- ensure romantic status is persisted immediately when an NPC becomes romantic

## Testing
- `godot --headless --script tests/test_runner.gd` *(fails: command not found)*
- `apt-get install -y godot` *(fails: Unable to locate package godot)*

------
https://chatgpt.com/codex/tasks/task_e_68c1c2390a848325a476b0541fb88e25