### PR TITLE
Ensure romantic NPC persistence after app closure

### DIFF
--- a/components/npc/npc_manager.gd
+++ b/components/npc/npc_manager.gd
@@ -73,13 +73,19 @@ func load_romantic_npc_cache() -> void:
 func add_romantic_npc(idx: int) -> void:
 	if not romantic_npcs.has(idx):
 		romantic_npcs.append(idx)
-	set_npc_field(idx, "romantic_relationship", true)
 
-	if persistent_npcs.has(idx):
-		DBManager.save_npc(idx, npcs[idx])
-		_save_queue.erase(idx)
+	var npc: NPC = get_npc_by_index(idx)
+	if npcs.has(idx):
+		set_npc_field(idx, "romantic_relationship", true)
+
+		if persistent_npcs.has(idx):
+			DBManager.save_npc(idx, npcs[idx])
+			_save_queue.erase(idx)
+		else:
+			promote_to_persistent(idx)
 	else:
-		promote_to_persistent(idx)
+		npc.romantic_relationship = true
+		DBManager.save_npc(idx, npc)
 
 func get_romantic_npcs() -> Array[int]:
 	return romantic_npcs

--- a/tests/fumble_romantic_relationship_persistence_test.gd
+++ b/tests/fumble_romantic_relationship_persistence_test.gd
@@ -1,0 +1,23 @@
+extends SceneTree
+
+func _ready() -> void:
+    var save_mgr = Engine.get_singleton("SaveManager")
+    var npc_mgr = Engine.get_singleton("NPCManager")
+    var fumble_mgr = Engine.get_singleton("FumbleManager")
+
+    save_mgr.reset_managers()
+    save_mgr.current_slot_id = 1
+
+    var npc_id := 4343
+    var battle_id := fumble_mgr.start_battle(npc_id)
+    npc_mgr.npcs = {}
+
+    fumble_mgr.save_battle_state(battle_id, [], {}, {}, "victory")
+
+    save_mgr.save_to_slot(save_mgr.current_slot_id)
+    save_mgr.reset_managers()
+    save_mgr.load_from_slot(save_mgr.current_slot_id)
+
+    assert(npc_mgr.get_romantic_npcs().has(npc_id))
+    print("fumble_romantic_relationship_persistence_test passed")
+    quit()


### PR DESCRIPTION
## Summary
- Ensure `add_romantic_npc` loads NPC before setting fields and saves directly if NPC cache still missing
- Add regression test verifying romantic relationships persist when added via Fumble after closing romance apps

## Testing
- ⚠️ `godot -q --headless -s tests/test_runner.gd` *(Godot not installed)*
- ⚠️ `apt-get install -y godot4` *(package not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c1c7b2a2688325a2b6693c2448cfb6