### PR TITLE
Ensure romantic NPCs persist across saves

### DIFF
--- a/autoloads/fumble_manager.gd
+++ b/autoloads/fumble_manager.gd
@@ -88,20 +88,20 @@ func save_battle_state(battle_id: String, chatlog: Array, stats: Dictionary, mov
 		push_warning("save_battle_state received invalid outcome '%s'" % outcome)
 		return
 
-	var data = DBManager.load_fumble_battle(battle_id, SaveManager.current_slot_id)
-	var npc_idx = int(data.npc_id) if data.size() > 0 else -1
-	if npc_idx != -1:
-		print("Saving battle", battle_id, "slot", SaveManager.current_slot_id, "outcome", outcome)
-		DBManager.save_fumble_battle(
-				battle_id,
-				npc_idx,
-				chatlog,
-				stats,
-				move_usage_counts,
-				outcome
-		)
-		if outcome == "victory":
-				NPCManager.add_romantic_npc(npc_idx)
+        var data = DBManager.load_fumble_battle(battle_id, SaveManager.current_slot_id)
+        var npc_idx = int(data.npc_id) if data.size() > 0 else -1
+        if npc_idx != -1:
+                if outcome == "victory":
+                                NPCManager.add_romantic_npc(npc_idx)
+                print("Saving battle", battle_id, "slot", SaveManager.current_slot_id, "outcome", outcome)
+                DBManager.save_fumble_battle(
+                                battle_id,
+                                npc_idx,
+                                chatlog,
+                                stats,
+                                move_usage_counts,
+                                outcome
+                )
 
 func load_battle_state(battle_id: String) -> Dictionary:
 	var data = DBManager.load_fumble_battle(battle_id, SaveManager.current_slot_id)

--- a/components/npc/npc_manager.gd
+++ b/components/npc/npc_manager.gd
@@ -329,12 +329,13 @@ func set_relationship_stage(npc_idx: int, new_stage: int) -> void:
 	var old_equilibrium: float = npc.affinity_equilibrium
 	npc.relationship_stage = new_stage
 	npc.affinity_equilibrium = float(new_stage) * 10.0
-	promote_to_persistent(npc_idx)
-	persistent_npcs[npc_idx]["relationship_stage"] = npc.relationship_stage
-	persistent_npcs[npc_idx]["affinity_equilibrium"] = npc.affinity_equilibrium
-	DBManager.save_npc(npc_idx, npc)
-	if new_stage >= RelationshipStage.DATING:
-			add_romantic_npc(npc_idx)
+        promote_to_persistent(npc_idx)
+        persistent_npcs[npc_idx]["relationship_stage"] = npc.relationship_stage
+        persistent_npcs[npc_idx]["affinity_equilibrium"] = npc.affinity_equilibrium
+        if new_stage >= RelationshipStage.DATING:
+                        add_romantic_npc(npc_idx)
+        else:
+                        DBManager.save_npc(npc_idx, npc)
 	emit_signal("relationship_stage_changed", npc_idx, old_stage, npc.relationship_stage)
 	if old_equilibrium != npc.affinity_equilibrium:
 		emit_signal("affinity_equilibrium_changed", npc_idx, npc.affinity_equilibrium)

--- a/tests/fumble_romantic_persistence_test.gd
+++ b/tests/fumble_romantic_persistence_test.gd
@@ -1,0 +1,24 @@
+extends SceneTree
+
+func _ready() -> void:
+    var save_mgr = Engine.get_singleton("SaveManager")
+    var npc_mgr = Engine.get_singleton("NPCManager")
+    var db_mgr = Engine.get_singleton("DBManager")
+    var fumble_mgr = Engine.get_singleton("FumbleManager")
+
+    save_mgr.reset_managers()
+    save_mgr.current_slot_id = 1
+
+    var npc_id := 6060
+    npc_mgr.get_npc_by_index(npc_id)
+    db_mgr.save_fumble_battle("battle_test", npc_id, [], {}, {}, "active")
+
+    fumble_mgr.save_battle_state("battle_test", [], {}, {}, "victory")
+
+    save_mgr.save_to_slot(save_mgr.current_slot_id)
+    save_mgr.reset_managers()
+    save_mgr.load_from_slot(save_mgr.current_slot_id)
+
+    assert(npc_mgr.has_romantic_relationship(npc_id))
+    print("fumble_romantic_persistence_test passed")
+    quit()

--- a/tests/relationship_stage_romantic_persistence_test.gd
+++ b/tests/relationship_stage_romantic_persistence_test.gd
@@ -1,0 +1,21 @@
+extends SceneTree
+
+func _ready() -> void:
+    var save_mgr = Engine.get_singleton("SaveManager")
+    var npc_mgr = Engine.get_singleton("NPCManager")
+
+    save_mgr.reset_managers()
+    save_mgr.current_slot_id = 1
+
+    var npc_id := 5050
+    npc_mgr.get_npc_by_index(npc_id)
+
+    npc_mgr.set_relationship_stage(npc_id, NPCManager.RelationshipStage.DATING)
+
+    save_mgr.save_to_slot(save_mgr.current_slot_id)
+    save_mgr.reset_managers()
+    save_mgr.load_from_slot(save_mgr.current_slot_id)
+
+    assert(npc_mgr.has_romantic_relationship(npc_id))
+    print("relationship_stage_romantic_persistence_test passed")
+    quit()


### PR DESCRIPTION
## Summary
- Register romantic NPCs before database saves when relationship stages change
- Mark Fumble battle victors as romantic prior to battle state persistence
- Add tests verifying romantic NPC persistence via relationship stage and Fumble victories

## Testing
- `godot3 --headless -s tests/test_runner.gd` *(fails: Can't open project at this config_version with Godot 3)*

------
https://chatgpt.com/codex/tasks/task_e_68c1c8a7ab588325850923214807902b