### PR TITLE
Persist romantic NPCs after Fumble victory

### DIFF
--- a/components/npc/npc_manager.gd
+++ b/components/npc/npc_manager.gd
@@ -65,15 +65,20 @@ func _flush_save_queue() -> void:
 	_save_queue.clear()
 
 func load_romantic_npc_cache() -> void:
-	romantic_npcs.clear()
-	var ids: Array[int] = DBManager.get_romantic_npc_ids()
-	for id in ids:
-		romantic_npcs.append(int(id))
+       romantic_npcs.clear()
+       var ids: Array[int] = DBManager.get_romantic_npc_ids()
+       for id in ids:
+               var idx: int = int(id)
+               romantic_npcs.append(idx)
+               if not persistent_npcs.has(idx):
+                       promote_to_persistent(idx)
 
 func add_romantic_npc(idx: int) -> void:
-	if not romantic_npcs.has(idx):
-		romantic_npcs.append(idx)
-	set_npc_field(idx, "romantic_relationship", true)
+       if not npcs.has(idx):
+               get_npc_by_index(idx)
+       if not romantic_npcs.has(idx):
+               romantic_npcs.append(idx)
+       set_npc_field(idx, "romantic_relationship", true)
 
 	if persistent_npcs.has(idx):
 		DBManager.save_npc(idx, npcs[idx])

--- a/tests/fumble_victory_persistence_test.gd
+++ b/tests/fumble_victory_persistence_test.gd
@@ -1,0 +1,23 @@
+extends SceneTree
+
+func _ready() -> void:
+    var save_mgr = Engine.get_singleton("SaveManager")
+    var npc_mgr = Engine.get_singleton("NPCManager")
+    var fumble_mgr = Engine.get_singleton("FumbleManager")
+    save_mgr.reset_managers()
+    save_mgr.current_slot_id = 1
+
+    var npc_id := 4343
+    var battle_id := fumble_mgr.start_battle(npc_id)
+    fumble_mgr.save_battle_state(battle_id, [], {}, {}, "victory")
+    save_mgr.save_to_slot(save_mgr.current_slot_id)
+
+    save_mgr.reset_managers()
+    save_mgr.load_from_slot(save_mgr.current_slot_id)
+
+    assert(npc_mgr.persistent_npcs.has(npc_id))
+    var npc = npc_mgr.get_npc_by_index(npc_id)
+    assert(npc.romantic_relationship)
+    assert(npc_mgr.get_romantic_npcs().has(npc_id))
+    print("fumble_victory_persistence_test passed")
+    quit()


### PR DESCRIPTION
## Summary
- Promote romantic NPCs to persistent on load so their data survives saves and reloads
- Ensure add_romantic_npc loads NPCs before flagging romance to avoid missing persistence
- Add regression test for Fumble chat battle victory persistence

## Testing
- `godot3 --headless -s tests/test_runner.gd` *(fails: Project uses newer Godot version)*

------
https://chatgpt.com/codex/tasks/task_e_68c1cdbced248325b9563aecda8a68e6