### PR TITLE
chore: ignore static ui assets

### DIFF
--- a/addons/godot_wry/examples/character_creator_ui_demo/ui/static/.gdignore
+++ b/addons/godot_wry/examples/character_creator_ui_demo/ui/static/.gdignore
@@ -1,0 +1,1 @@
+# Ignore UI static asset sources to prevent duplicate UID warnings.


### PR DESCRIPTION
## Summary
- ignore static assets for WRY character creator demo to avoid duplicate UID warnings

## Testing
- `godot3-server --headless --script tests/test_runner.gd` *(fails: project requires newer Godot engine)*

------
https://chatgpt.com/codex/tasks/task_e_68c1da3e6fc883258fe61f9bdf5b2315