### PR TITLE
Embed chat log in AIM and support message creation

### DIFF
--- a/components/apps/alpha_instant_messenger/aim_chat_log.gd
+++ b/components/apps/alpha_instant_messenger/aim_chat_log.gd
@@ -1,11 +1,9 @@
-extends HBoxContainer
+extends VBoxContainer
 class_name AimChatLog
 
-@onready var message_label: Label = %MessageLabel
+const AIM_CHAT_MESSAGE_SCENE: PackedScene = preload("res://components/apps/alpha_instant_messenger/aim_chat_message.tscn")
 
-var is_npc_message: bool = false
-
-func set_message(text: String, from_player: bool) -> void:
-    is_npc_message = not from_player
-    message_label.text = text
-    alignment = BoxContainer.ALIGNMENT_END if from_player else BoxContainer.ALIGNMENT_BEGIN
+func add_message(text: String, from_player: bool) -> void:
+    var message: AimChatMessage = AIM_CHAT_MESSAGE_SCENE.instantiate()
+    add_child(message)
+    message.set_message(text, from_player)

--- a/components/apps/alpha_instant_messenger/aim_chat_log.tscn
+++ b/components/apps/alpha_instant_messenger/aim_chat_log.tscn
@@ -2,9 +2,5 @@
 
 [ext_resource type="Script" path="res://components/apps/alpha_instant_messenger/aim_chat_log.gd" id="1"]
 
-[node name="AimChatLog" type="HBoxContainer"]
+[node name="AimChatLog" type="VBoxContainer"]
 script = ExtResource("1")
-
-[node name="MessageLabel" type="Label" parent="."]
-unique_name_in_owner = true
-autowrap_mode = 3

--- a/components/apps/alpha_instant_messenger/aim_chat_message.gd
+++ b/components/apps/alpha_instant_messenger/aim_chat_message.gd
@@ -1,0 +1,11 @@
+extends HBoxContainer
+class_name AimChatMessage
+
+@onready var message_label: Label = %MessageLabel
+
+var is_npc_message: bool = false
+
+func set_message(text: String, from_player: bool) -> void:
+    is_npc_message = not from_player
+    message_label.text = text
+    alignment = BoxContainer.ALIGNMENT_END if from_player else BoxContainer.ALIGNMENT_BEGIN

--- a/components/apps/alpha_instant_messenger/aim_chat_message.tscn
+++ b/components/apps/alpha_instant_messenger/aim_chat_message.tscn
@@ -1,0 +1,10 @@
+[gd_scene load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://components/apps/alpha_instant_messenger/aim_chat_message.gd" id="1"]
+
+[node name="AimChatMessage" type="HBoxContainer"]
+script = ExtResource("1")
+
+[node name="MessageLabel" type="Label" parent="."]
+unique_name_in_owner = true
+autowrap_mode = 3

--- a/components/apps/alpha_instant_messenger/aim_chat_ui.gd
+++ b/components/apps/alpha_instant_messenger/aim_chat_ui.gd
@@ -2,12 +2,11 @@ extends Pane
 class_name AimChatUI
 
 const EX_FACTOR_VIEW_SCENE: PackedScene = preload("res://components/popups/ex_factor_view.tscn")
-const AIM_CHAT_LOG_SCENE: PackedScene = preload("res://components/apps/alpha_instant_messenger/aim_chat_log.tscn")
 
 @onready var header_container: PanelContainer = %HeaderContainer
 @onready var name_label: Label = %NameLabel
 @onready var portrait_view: PortraitView = %Portrait
-@onready var messages_container: VBoxContainer = %MessagesContainer
+@onready var chat_log: AimChatLog = %AimChatLog
 @onready var line_edit: LineEdit = %PlayerLineEdit
 @onready var greet_button: Button = %GreetButton
 @onready var gift_button: Button = %GiftButton
@@ -77,7 +76,5 @@ func _on_line_edit_submitted(new_text: String) -> void:
         var text = new_text.strip_edges()
         if text == "":
                 return
-        var log: AimChatLog = AIM_CHAT_LOG_SCENE.instantiate()
-        messages_container.add_child(log)
-        log.set_message(text, true)
+        chat_log.add_message(text, true)
         line_edit.clear()

--- a/components/apps/alpha_instant_messenger/aim_chat_ui.tscn
+++ b/components/apps/alpha_instant_messenger/aim_chat_ui.tscn
@@ -1,8 +1,9 @@
-[gd_scene load_steps=5 format=3 uid="uid://c08ykcx6tagdr"]
+[gd_scene load_steps=6 format=3 uid="uid://c08ykcx6tagdr"]
 
 [ext_resource type="Script" uid="uid://bv7alettjmjdi" path="res://components/apps/alpha_instant_messenger/aim_chat_ui.gd" id="1"]
 [ext_resource type="PackedScene" uid="uid://drm1apbdsjj5g" path="res://components/portrait/portrait_view.tscn" id="2"]
 [ext_resource type="Theme" uid="uid://cesgvqexxaqev" path="res://assets/themes/windows_95_theme.tres" id="3"]
+[ext_resource type="PackedScene" path="res://components/apps/alpha_instant_messenger/aim_chat_log.tscn" id="4"]
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_14t81"]
 bg_color = Color(0.964742, 0.964742, 0.964742, 1)
@@ -86,6 +87,9 @@ unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
+
+[node name="AimChatLog" parent="MarginContainer/VBoxContainer/MessagesScroll/MessagesContainer" instance=ExtResource("4")]
+unique_name_in_owner = true
 
 [node name="PlayerLineEdit" type="LineEdit" parent="MarginContainer/VBoxContainer"]
 unique_name_in_owner = true


### PR DESCRIPTION
## Summary
- Embed an AimChatLog node inside the chat UI
- Log creates AimChatMessage entries for player lines
- Connect input box to append messages to the embedded log

## Testing
- `godot3-server --path . tests/test_runner.tscn` *(fails: Can't open project at '/workspace/SigmaSim/project.godot', its `config_version` (5) is from a more recent and incompatible version of the engine)*

------
https://chatgpt.com/codex/tasks/task_e_68c1dd83ef3c8325bcb859cd3d35a1e6