### PR TITLE
Refactor AIM chat components to use PanelContainers

### DIFF
--- a/components/apps/alpha_instant_messenger/aim_chat_log.gd
+++ b/components/apps/alpha_instant_messenger/aim_chat_log.gd
@@ -1,9 +1,11 @@
-extends VBoxContainer
+extends PanelContainer
 class_name AimChatLog
 
 const AIM_CHAT_MESSAGE_SCENE: PackedScene = preload("res://components/apps/alpha_instant_messenger/aim_chat_message.tscn")
 
+@onready var messages_container: VBoxContainer = $Messages
+
 func add_message(text: String, from_player: bool) -> void:
     var message: AimChatMessage = AIM_CHAT_MESSAGE_SCENE.instantiate()
-    add_child(message)
+    messages_container.add_child(message)
     message.set_message(text, from_player)

--- a/components/apps/alpha_instant_messenger/aim_chat_log.tscn
+++ b/components/apps/alpha_instant_messenger/aim_chat_log.tscn
@@ -2,5 +2,17 @@
 
 [ext_resource type="Script" uid="uid://bsbh3f3fpbov1" path="res://components/apps/alpha_instant_messenger/aim_chat_log.gd" id="1"]
 
-[node name="AimChatLog" type="VBoxContainer"]
+[node name="AimChatLog" type="PanelContainer"]
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
 script = ExtResource("1")
+
+[node name="Messages" type="VBoxContainer" parent="."]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3

--- a/components/apps/alpha_instant_messenger/aim_chat_message.gd
+++ b/components/apps/alpha_instant_messenger/aim_chat_message.gd
@@ -1,6 +1,7 @@
-extends HBoxContainer
+extends PanelContainer
 class_name AimChatMessage
 
+@onready var message_box: HBoxContainer = $MessageBox
 @onready var message_label: Label = %MessageLabel
 
 var is_npc_message: bool = false
@@ -8,4 +9,4 @@ var is_npc_message: bool = false
 func set_message(text: String, from_player: bool) -> void:
     is_npc_message = not from_player
     message_label.text = text
-    alignment = BoxContainer.ALIGNMENT_END if from_player else BoxContainer.ALIGNMENT_BEGIN
+    message_box.alignment = BoxContainer.ALIGNMENT_END if from_player else BoxContainer.ALIGNMENT_BEGIN

--- a/components/apps/alpha_instant_messenger/aim_chat_message.tscn
+++ b/components/apps/alpha_instant_messenger/aim_chat_message.tscn
@@ -2,7 +2,7 @@
 
 [ext_resource type="Script" uid="uid://cpu57qxss27bp" path="res://components/apps/alpha_instant_messenger/aim_chat_message.gd" id="1"]
 
-[node name="AimChatMessage" type="HBoxContainer"]
+[node name="AimChatMessage" type="PanelContainer"]
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
@@ -12,7 +12,12 @@ size_flags_horizontal = 3
 size_flags_vertical = 3
 script = ExtResource("1")
 
-[node name="MessageLabel" type="Label" parent="."]
+[node name="MessageBox" type="HBoxContainer" parent="."]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 1
+
+[node name="MessageLabel" type="Label" parent="MessageBox"]
 unique_name_in_owner = true
 layout_mode = 2
 autowrap_mode = 3


### PR DESCRIPTION
## Summary
- Refactor AimChatMessage to extend PanelContainer and align text via an inner HBoxContainer
- Wrap AimChatLog in a PanelContainer and add an internal VBoxContainer for message entries

## Testing
- `godot3 --headless -s tests/test_runner.gd` *(fails: Can't open project, expected config version 4)*
- `/tmp/godot/Godot_v4.2.1-stable_linux.x86_64 --headless -s tests/test_runner.gd` *(fails: script doesn't inherit from SceneTree or MainLoop)*

------
https://chatgpt.com/codex/tasks/task_e_68c1e033dc508325a6a25ab5e3780f04