### PR TITLE
fix: remove invalid UID from fumble chat box scene

### DIFF
--- a/components/apps/fumble/fumble_battle/fumble_chat_box.tscn
+++ b/components/apps/fumble/fumble_battle/fumble_chat_box.tscn
@@ -1,6 +1,6 @@
 [gd_scene load_steps=4 format=3 uid="uid://dyv7bmgfriqht"]
 
-[ext_resource type="Script" uid="uid://bem114rcr3lcc" path="res://components/apps/fumble/fumble_battle/fumble_chat_box.gd" id="1_i1vjr"]
+[ext_resource type="Script" path="res://components/apps/fumble/fumble_battle/fumble_chat_box.gd" id="1_i1vjr"]
 [ext_resource type="Texture2D" uid="uid://b8piqndlfnolp" path="res://assets/early_bird/wojak_bird_1.png" id="2_ugbyc"]
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_i1vjr"]


### PR DESCRIPTION
## Summary
- remove invalid UID from fumble chat box scene resource

## Testing
- `godot --headless --path . -s res://tests/test_runner.gd` *(fails: command not found)*
- `wget https://downloads.tuxfamily.org/godotengine/4.2.1/Godot_v4.2.1-stable_linux.x86_64.zip -O /tmp/godot.zip` *(fails: 503 Service Unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68c1ee6279848325bdd082724496599d