### PR TITLE
Ensure NetSerf resizes WebView with window

### DIFF
--- a/apps/net_serf/net_serf.gd
+++ b/apps/net_serf/net_serf.gd
@@ -62,9 +62,11 @@ func _ready() -> void:
 		window_frame.resized.connect(_update_webview_rect)
 		if window_frame.has_signal("position_changed"):
 			window_frame.position_changed.connect(_update_webview_rect)
-	var root_viewport: Viewport = get_tree().root
-	root_viewport.size_changed.connect(_update_webview_rect)
+	var root_window: Window = get_window()
+	root_window.size_changed.connect(_update_webview_rect_deferred)
+	root_window.position_changed.connect(_update_webview_rect_deferred)
 	_update_webview_rect()
+	_update_webview_rect_deferred()
 
 func open_url(url: String) -> void:
 	_load_url_normalized(url)
@@ -177,6 +179,9 @@ func _update_webview_rect() -> void:
 	web_view.set_position(rect.position)
 	web_view.set_size(rect.size)
 
+func _update_webview_rect_deferred() -> void:
+	await get_tree().process_frame
+	_update_webview_rect()
 
 func _inject_url_hook() -> void:
 	web_view.call("eval", URL_HOOK_JS)
@@ -185,3 +190,7 @@ func _on_url_field_gui_input(event: InputEvent) -> void:
 	if event is InputEventMouseButton and event.pressed:
 		url_field.grab_focus()
 		url_field.accept_event()
+
+func _notification(what: int) -> void:
+	if what == NOTIFICATION_WM_SIZE_CHANGED:
+		_update_webview_rect_deferred()


### PR DESCRIPTION
## Summary
- refresh NetSerf WebView rectangle after OS window resize
- call a deferred update to catch initial and runtime window scaling
- connect to window size and position signals for accurate placement across resolutions

## Testing
- `godot --headless --path . tests/test_runner.tscn` *(fails: command not found)*
- `apt-get update`
- `apt-cache search godot4` *(no relevant packages)*

------
https://chatgpt.com/codex/tasks/task_e_68c583bcb15c8325a73a3e79f02f10ee