### PR TITLE
fix webview scaling on hidpi monitors

### DIFF
--- a/apps/net_serf/net_serf.gd
+++ b/apps/net_serf/net_serf.gd
@@ -170,12 +170,10 @@ func _on_webview_ipc_message(message: String) -> void:
 
 func _update_webview_rect() -> void:
 	var root_viewport: Viewport = get_tree().root
-	var visible_rect: Rect2 = root_viewport.get_visible_rect()
+	var window_size: Vector2i = DisplayServer.window_get_size()
+	var scale: Vector2 = Vector2(window_size) / Vector2(root_viewport.size)
 
-	# Convert to Vector2 so both operands match
-	var scale: Vector2 = visible_rect.size / Vector2(root_viewport.size)
-
-	var position: Vector2 = (global_position * scale) + visible_rect.position
+	var position: Vector2 = global_position * scale
 	var scaled_size: Vector2 = size * scale
 
 	web_view.set_position(position)


### PR DESCRIPTION
## Summary
- scale WebView using DisplayServer.window_get_size so native window matches Control on all monitors

## Testing
- `godot --headless --script tests/test_runner.gd` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c5bc1b1918832580974ca8b5bcf02e