### PR TITLE
Compute NetSerf window size from viewport

### DIFF
--- a/apps/net_serf/net_serf.gd
+++ b/apps/net_serf/net_serf.gd
@@ -37,6 +37,11 @@ const URL_HOOK_JS: String = """
 """
 
 func _ready() -> void:
+	var visible_rect: Rect2 = get_viewport().get_visible_rect()
+	default_window_size = visible_rect.size * 0.8
+	if window_frame:
+		window_frame.default_size = default_window_size
+		window_frame.size = default_window_size
 	# Toolbar wiring
 	back_button.pressed.connect(_on_back_pressed)
 	forward_button.pressed.connect(_on_forward_pressed)


### PR DESCRIPTION
## Summary
- derive NetSerf default window size from the current viewport
- update WindowFrame to apply this calculated size when loading the pane

## Testing
- `/tmp/godot4/Godot_v4.2.1-stable_linux.x86_64 --headless --path . tests/test_runner.tscn` *(fails: missing resources and parse errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c5bc36ff048325a73fad61f0107652