### PR TITLE
Remove manual WebView sizing from NetSerf

### DIFF
--- a/apps/net_serf/net_serf.gd
+++ b/apps/net_serf/net_serf.gd
@@ -58,14 +58,6 @@ func _ready() -> void:
 	# Optional: listen for IPC messages from page JS
 	if web_view.has_signal("ipc_message"):
 		web_view.connect("ipc_message", Callable(self, "_on_webview_ipc_message"))
-	if window_frame:
-		window_frame.resized.connect(_update_webview_rect)
-		if window_frame.has_signal("position_changed"):
-			window_frame.position_changed.connect(_update_webview_rect)
-	var root_viewport: Viewport = get_tree().root
-	root_viewport.size_changed.connect(_update_webview_rect_deferred)
-	_update_webview_rect()
-	_update_webview_rect_deferred()
 
 func open_url(url: String) -> void:
 	_load_url_normalized(url)
@@ -161,17 +153,6 @@ func _on_webview_ipc_message(message: String) -> void:
 	else:
 		print("[NetSerf] IPC:", message)
 
-func _update_webview_rect() -> void:
-	if window_frame == null:
-		return
-	var rect: Rect2 = Rect2(window_frame.global_position, window_frame.size)
-	web_view.set_position(rect.position.round())
-	web_view.set_size(rect.size.round())
-
-func _update_webview_rect_deferred() -> void:
-	await get_tree().process_frame
-	_update_webview_rect()
-
 func _inject_url_hook() -> void:
 	web_view.call("eval", URL_HOOK_JS)
 
@@ -180,8 +161,3 @@ func _on_url_field_gui_input(event: InputEvent) -> void:
 	if event is InputEventMouseButton and event.pressed:
 		url_field.grab_focus()
 		url_field.accept_event()
-
-
-func _notification(what: int) -> void:
-	if what == NOTIFICATION_WM_SIZE_CHANGED:
-		_update_webview_rect_deferred()


### PR DESCRIPTION
## Summary
- remove the window frame hooks used to manually size the NetSerf WebView
- rely on the regular Godot layout to size the embedded browser control

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cafc26d9608325bb5492e285526658